### PR TITLE
Documents route done and tested

### DIFF
--- a/src/__tests__/indexes.ts
+++ b/src/__tests__/indexes.ts
@@ -198,7 +198,7 @@ test('delete-documents', async () => {
     .deleteDocuments([firstDocumentId, offsetDocumentId]))
     .resolves
     .toHaveProperty('updateId');
-
+    await sleep(3000);
     await expect(meili.Index(index.uid).getDocument(firstDocumentId)).rejects.toThrow();
     await expect(meili.Index(index.uid).getDocument(offsetDocumentId)).rejects.toThrow();
 })
@@ -207,7 +207,7 @@ test('delete-all-documents', async () => {
   await expect(meili.Index(index.uid).deleteAllDocuments())
     .resolves
     .toHaveProperty('updateId');
-  await sleep(5000);
+  await sleep(3000);
   await expect(meili.Index(index.uid).getDocuments())
     .resolves
     .toHaveLength(0);

--- a/src/__tests__/indexes.ts
+++ b/src/__tests__/indexes.ts
@@ -188,6 +188,7 @@ test('delete-document', async () => {
   await expect(meili.Index(index.uid).deleteDocument(randomDocument))
     .resolves
     .toHaveProperty('updateId');
+  await sleep(3000);
   await expect(meili.Index(index.uid).getDocument(randomDocument))
     .rejects
     .toThrow();

--- a/src/__tests__/indexes.ts
+++ b/src/__tests__/indexes.ts
@@ -207,6 +207,7 @@ test('delete-all-documents', async () => {
   await expect(meili.Index(index.uid).deleteAllDocuments())
     .resolves
     .toHaveProperty('updateId');
+  await sleep(5000);
   await expect(meili.Index(index.uid).getDocuments())
     .resolves
     .toHaveLength(0);

--- a/src/__tests__/indexes.ts
+++ b/src/__tests__/indexes.ts
@@ -12,75 +12,43 @@ const index = {
   uid: 'movies',
 }
 
-const schema = {
-  identifier: 'id',
-  attributes: {
-    id: {
-      displayed: true,
-      indexed: true,
-      ranked: false,
-    },
-    title: {
-      displayed: true,
-      indexed: true,
-      ranked: false,
-    },
-    poster: {
-      displayed: true,
-      indexed: true,
-      ranked: false,
-    },
-    overview: {
-      displayed: true,
-      indexed: true,
-      ranked: false,
-    },
-    release_date: {
-      displayed: true,
-      indexed: true,
-      ranked: false,
-    },
-  },
-}
+const randomDocument = '287947';
+const offsetDocumentId = '157433';
+const firstDocumentId = '299537';
+const defaultNumberOfDocuments = 20;
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 const clearAllIndexes = async () => {
-  let indexes = await meili
+  const indexes = await meili
     .listIndexes()
     .then((response: any) => {
       return response.map((elem: any) => elem.uid)
     })
     .catch((err) => {
       expect(err).toBe(null)
-    })
+    });
 
-  for (let indexUid of indexes) {
+  for (const indexUid of indexes) {
     await meili
       .Index(indexUid)
       .deleteIndex()
       .catch((err) => {
         expect(err).toBe(null)
-      })
+      });
   }
 
-  await meili
-    .listIndexes()
-    .then((response: any) => {
-      expect(response.length).toBe(0)
-    })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
+  await expect(meili.listIndexes())
+    .resolves
+    .toHaveLength(0);
 }
 
 
 test('reset-start', async () => {
-  await clearAllIndexes()
+  await clearAllIndexes();
 })
-// jest.setTimeout(15 * 1000)
 
 ///
 /// INDEXES
@@ -95,7 +63,7 @@ test('create-index', async () => {
     })
     .catch((err) => {
       expect(err).toBe(null)
-    })
+    });
 })
 
 test('get-index', async () => {
@@ -110,28 +78,22 @@ test('get-index', async () => {
       expect(err).toBe(null)
     })
 
-  await meili
-    .listIndexes()
-    .then((response: any) => {
-      expect(response.length).toBe(1)
-    })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
+    await expect(meili.listIndexes())
+    .resolves
+    .toHaveLength(1);
 })
-
 
 test('update-index', async () => {
   await meili
-  .Index(index.uid)
-  .updateIndex({ name: 'new name' })
-  .then((response: any) => {
-    expect(response.name).toBe('new name')
-    expect(response.uid).toBe(index.uid)
-  })
-  .catch((err) => {
-    expect(err).toBe(null)
-  })
+    .Index(index.uid)
+    .updateIndex({ name: 'new name' })
+    .then((response: any) => {
+      expect(response.name).toBe('new name')
+      expect(response.uid).toBe(index.uid)
+    })
+    .catch((err) => {
+      expect(err).toBe(null)
+    });
   await meili
     .Index(index.uid)
     .getIndex()
@@ -141,7 +103,7 @@ test('update-index', async () => {
     })
     .catch((err) => {
       expect(err).toBe(null)
-    })
+    });
   await meili
     .Index(index.uid)
     .updateIndex({ name: index.name })
@@ -151,119 +113,118 @@ test('update-index', async () => {
     })
     .catch((err) => {
       expect(err).toBe(null)
-    })
+    });
 })
-
-
 
 ///
 /// SCHEMA
 ///
 test('update-schema', async () => {
-    await meili
-      .Index(index.uid)
+  await expect(meili.Index(index.uid)
       .updateSchema({
         'id': ['indexed','displayed','identifier'],
         'title':['displayed','indexed'],
         'poster':['displayed','indexed'],
         'overview':['indexed','displayed'],
         'release_date':['indexed','displayed']
-      }).then((response: any) => {
-        expect(response).toHaveProperty('updateId')
-      })
-      .catch((err) => {
-        expect(err).toBe(null)
-      })
-
+      }))
+      .resolves
+      .toHaveProperty('updateId');
 })
 
 test('get-schema', async () => {
-  await meili
-    .Index(index.uid)
-    .getSchema()
-    .then((response: any) => {
-      expect(response)
-      .toBeDefined()
-    })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
+  await expect(meili.Index(index.uid).getSchema())
+  .resolves
+  .toBeDefined();
 })
 
 
-// test('add-documents', async () => {
-//   await meili
-//     .Index(index.uid)
-//     .addDocuments(dataset)
-//     .then((response: any) => {
-//       expect(response.updateId).toBeDefined()
-//     })
-//     .catch((err) => {
-//       expect(err).toBe(null)
-//     })
-// })
+test('add-documents', async () => {
+  await expect(meili.Index(index.uid).addDocuments(dataset))
+    .resolves
+    .toHaveProperty('updateId');
+})
+jest.setTimeout(20 * 1000)
 
-// test('get-document', async () => {
-//   await sleep(3 * 1000)
-//   await meili
-//     .Index(index.uid)
-//     .getDocument('287947')
-//     .then((response: any) => {
-//       expect(response).toEqual(dataset[0])
-//     })
-//     .catch((err) => {
-//       expect(err).toBe(null)
-//     })
-// })
+test('get-document', async () => {
+  await sleep(15 * 1000)
+  await expect(meili.Index(index.uid).getDocument(randomDocument))
+  .resolves
+  .toEqual(dataset[0]);
+})
 
-test('delete-index', async () => {
+test('get-documents', async () => {
   await meili
     .Index(index.uid)
-    .deleteIndex()
+    .getDocuments()
     .then((response: any) => {
-      expect(response)
-      .toBeDefined()
+      expect(response.length).toBe(defaultNumberOfDocuments);
+      expect(response[0].id).toEqual(firstDocumentId);
+    });
+
+  await meili
+    .Index(index.uid)
+    .getDocuments({
+        offset: 1
     })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
-    await meili
-    .listIndexes()
     .then((response: any) => {
-      expect(response.length).toBe(0)
+      expect(response.length).toBe(defaultNumberOfDocuments);
+      expect(response[0].id).toEqual(offsetDocumentId);
+    });
+
+  await meili
+    .Index(index.uid)
+    .getDocuments({
+        offset: 1,
+        limit: 1
     })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
+    .then((response: any) => {
+      expect(response.length).toBe(1);
+      expect(response[0].id).toEqual(offsetDocumentId);
+    });
+})
+
+test('delete-document', async () => {
+  await expect(meili.Index(index.uid).deleteDocument(randomDocument))
+    .resolves
+    .toHaveProperty('updateId');
+  await expect(meili.Index(index.uid).getDocument(randomDocument))
+    .rejects
+    .toThrow();
+})
+
+test('delete-documents', async () => {
+    await expect(meili.Index(index.uid)
+    .deleteDocuments([firstDocumentId, offsetDocumentId]))
+    .resolves
+    .toHaveProperty('updateId');
+
+    await expect(meili.Index(index.uid).getDocument(firstDocumentId)).rejects.toThrow();
+    await expect(meili.Index(index.uid).getDocument(offsetDocumentId)).rejects.toThrow();
+})
+
+test('delete-all-documents', async () => {
+  await expect(meili.Index(index.uid).deleteAllDocuments())
+    .resolves
+    .toHaveProperty('updateId');
+  await expect(meili.Index(index.uid).getDocuments())
+    .resolves
+    .toHaveLength(0);
+})
+
+
+
+test('delete-index', async () => {
+  await expect(meili.Index(index.uid).deleteIndex())
+    .resolves
+    .toBeDefined();
+  await expect(meili.listIndexes())
+    .resolves
+    .toHaveLength(0);
 })
 
 
 
 test('reset-stop', async () => {
-  let indexes = await meili
-    .listIndexes()
-    .then((response: any) => {
-      return response.map((elem: any) => elem.uid)
-    })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
-
-  for (let indexUid of indexes) {
-    await meili
-      .Index(indexUid)
-      .deleteIndex()
-      .catch((err) => {
-        expect(err).toBe(null)
-      })
-  }
-
-  await meili
-    .listIndexes()
-    .then((response: any) => {
-      expect(response.length).toBe(0)
-    })
-    .catch((err) => {
-      expect(err).toBe(null)
-    })
+  await clearAllIndexes();
 })

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -101,18 +101,7 @@ class Indexes {
     })
   }
 
-  /**
-   * Browse for documents into an index
-   * @memberof Indexes
-   * @method browse
-   */
-  browse(params: Types.BrowseParams): Promise<object[]> {
-    const url = `/indexes/${this.indexUid}/documents`
 
-    return this.instance.get(url, {
-      params,
-    })
-  }
 
   ///
   /// INDEX
@@ -173,6 +162,19 @@ class Indexes {
   ///
 
   /**
+   * Browse for documents into an index
+   * @memberof Indexes
+   * @method browse
+   */
+  getDocuments(params?: Types.GetDocumentsParams): Promise<object[]> {
+    const url = `/indexes/${this.indexUid}/documents`
+
+    return this.instance.get(url, {
+      params,
+    })
+  }
+
+  /**
    * Get one document
    * @memberof Documents
    * @method getDocument
@@ -200,7 +202,7 @@ class Indexes {
    * @method deleteDocument
    */
   deleteDocument(documentId: string): Promise<Types.AsyncUpdateId> {
-    const url = `/indexes/${this.indexUid}/documents/ + ${documentId}`
+    const url = `/indexes/${this.indexUid}/documents/${documentId}`
 
     return this.instance.delete(url)
   }
@@ -216,24 +218,8 @@ class Indexes {
     return this.instance.post(url, documentsIds)
   }
 
-  /**
-   * Add, update or delete multiples document in one time
-   * @memberof Documents
-   * @method batchWrite
-   */
-  batchWriteDocuments(
-    documentsToInsert: object[],
-    documentsToDelete: object[]
-  ): Promise<Types.AsyncUpdateId> {
-    const url = `/indexes/${this.indexUid}/documents/batch`
 
-    return this.instance.post(url, {
-      insert: documentsToInsert,
-      delete: documentsToDelete,
-    })
-  }
-
-  clearAllDocuments(): Promise<Types.AsyncUpdateId> {
+  deleteAllDocuments(): Promise<Types.AsyncUpdateId> {
     const url = `/indexes/${this.indexUid}/documents`
 
     return this.instance.delete(url)

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,17 @@ export interface UpdateIndexRequest {
   name: string
 }
 
+export interface GetDocumentsParams{
+  offset?: number
+  limit?: number
+  attributesToRetrieve?: string[]
+}
+
+
+export interface PostDocumentParams{
+
+}
+
 export interface SearchParams {
   q: string
   offset?: number
@@ -95,8 +106,3 @@ export interface SearchResponse {
   query: string
 }
 
-export interface BrowseParams {
-  offset?: number
-  limit?: number
-  attributesToRetrieve?: string[]
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,11 +65,6 @@ export interface GetDocumentsParams{
   attributesToRetrieve?: string[]
 }
 
-
-export interface PostDocumentParams{
-
-}
-
 export interface SearchParams {
   q: string
   offset?: number


### PR DESCRIPTION
**CHANGES:**
Src/Indexes.ts 
- Renamed `browse` function with `getDocuments`
- Moved `getDocuments` to be closer to other document methods
- FIX: fixed a bug on the document delete URL that was badly formatted
- Removed batchWriteDocument which doesn’t exist anymore
- Renamed `clearAllDocuments` with `deleteAllDocuments`

Src/test/
- Changed format of tests with async jest functions
- Added semi-colon at the end of every command
- Added testing on schema
- Added testing on documents delete
- Changed the dataset to a smaller one for testing purpose

Src/types
- Renamed `BrowseParams` with `GetDocumentsParams`
