### PR TITLE
Change search route parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const meili = new Meili(config)
 
 meili
   .Index('movies')
-  .search({ q: 'batman' })
+  .search('batman')
   .then((response) => {
     console.log(response.hits)
   })
@@ -69,9 +69,7 @@ Go checkout [examples](./examples)!
 ```js
 meili
   .Index('movies')
-  .search({
-    q: 'batman',
-  })
+  .search('batman')
   .then((response) => {
     console.log(response.hits)
   })
@@ -196,14 +194,14 @@ The method `add_documents` is **[asynchronous](https://docs.meilisearch.com/adva
 
 ### Get some documents
 
-Browse is a method to get defaults documents without search. This method is usually used to display results when you have no input in the search bar.
+getDocuments is a method to get defaults documents without search. This method is usually used to display results when you have no input in the search bar.
 
 **Example:**
 
 ```js
 meili
   .Index('movies')
-  .browse({
+  .getDocuments({
     limit: 3,
   })
   .then((response) => {
@@ -245,7 +243,7 @@ meili
 
 - Make a search request:
 
-`meili.Index('xxx').search(options: Types.SearchParams): Promise<Types.SearchResponse>`
+`meili.Index('xxx').search(query: string, options?: Types.SearchParams): Promise<Types.SearchResponse>`
 
 ### Indexes
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,6 +1,3 @@
-/**
- * @type {Partial<jest.InitialOptions>}
- */
 const config = {
   preset: 'ts-jest',
   rootDir: '..',

--- a/examples/search_example.js
+++ b/examples/search_example.js
@@ -33,8 +33,6 @@ const addDataset = async () => {
 ;(async () => {
   await addDataset()
   let resp
-  resp = await meili.Index('movies').search({
-    q: 'Avengers',
-  })
+  resp = await meili.Index('movies').search('Avengers')
   console.log({ resp })
 })()

--- a/src/__tests__/indexes.ts
+++ b/src/__tests__/indexes.ts
@@ -228,17 +228,14 @@ test('get-documents', async () => {
 test('search', async () => {
   await meili
     .Index(index.uid)
-    .search({
-      q: 'Escape',
-    })
+    .search('Escape')
     .then((response: any) => {
       expect(response.hits).toHaveLength(2)
       expect(response.hits[0]).toHaveProperty('id', '522681')
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'Escape',
+    .search('Escape', {
       offset: 1,
     })
     .then((response: any) => {
@@ -247,8 +244,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'The',
+    .search('The', {
       offset: 1,
       limit: 5,
     })
@@ -258,8 +254,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'The',
+    .search('The', {
       offset: 1,
       limit: 5,
       attributesToRetrieve: ['title', 'id'],
@@ -271,8 +266,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'The',
+    .search('The', {
       offset: 1,
       limit: 5,
       attributesToRetrieve: ['title', 'id'],
@@ -285,8 +279,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'scientist',
+    .search('scientist', {
       offset: 0,
       limit: 5,
       attributesToRetrieve: ['overview', 'id'],
@@ -302,8 +295,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'scientist',
+    .search('scientist', {
       offset: 0,
       limit: 5,
       attributesToRetrieve: ['overview', 'id'],
@@ -319,8 +311,7 @@ test('search', async () => {
 
   await meili
     .Index(index.uid)
-    .search({
-      q: 'scientist',
+    .search('scientist', {
       offset: 0,
       limit: 5,
       attributesToRetrieve: ['overview', 'id'],
@@ -337,8 +328,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'The',
+    .search('The', {
       offset: 0,
       limit: 5,
       filters: 'title:The Mule',
@@ -351,8 +341,7 @@ test('search', async () => {
     })
   await meili
     .Index(index.uid)
-    .search({
-      q: 'woman',
+    .search('woman', {
       filters: 'title:After',
       matches: true,
     })

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -57,42 +57,46 @@ class Indexes {
    * @memberof Meili
    * @method search
    */
-  search(options: Types.SearchParams): Promise<Types.SearchResponse> {
+  search(
+    query: string,
+    options?: Types.SearchParams
+  ): Promise<Types.SearchResponse> {
     const url = `/indexes/${this.indexUid}/search`
 
     const params: Types.SearchRequest = {
-      q: options.q,
+      q: query,
     }
-
-    if (options.offset) {
-      params.offset = options.offset
-    }
-    if (options.limit) {
-      params.limit = options.limit
-    }
-    if (options.attributesToRetrieve) {
-      params.attributesToRetrieve = options.attributesToRetrieve.join()
-    }
-    if (options.attributesToSearchIn) {
-      params.attributesToSearchIn = options.attributesToSearchIn.join()
-    }
-    if (options.attributesToCrop) {
-      params.attributesToCrop = options.attributesToCrop.join()
-    }
-    if (options.cropLength) {
-      params.cropLength = options.cropLength
-    }
-    if (options.attributesToHighlight) {
-      params.attributesToHighlight = options.attributesToHighlight.join()
-    }
-    if (options.filters) {
-      params.filters = options.filters
-    }
-    if (options.timeoutMs) {
-      params.timeoutMs = options.timeoutMs
-    }
-    if (options.matches) {
-      params.matches = options.matches
+    if (options) {
+      if (options.offset) {
+        params.offset = options.offset
+      }
+      if (options.limit) {
+        params.limit = options.limit
+      }
+      if (options.attributesToRetrieve) {
+        params.attributesToRetrieve = options.attributesToRetrieve.join()
+      }
+      if (options.attributesToSearchIn) {
+        params.attributesToSearchIn = options.attributesToSearchIn.join()
+      }
+      if (options.attributesToCrop) {
+        params.attributesToCrop = options.attributesToCrop.join()
+      }
+      if (options.cropLength) {
+        params.cropLength = options.cropLength
+      }
+      if (options.attributesToHighlight) {
+        params.attributesToHighlight = options.attributesToHighlight.join()
+      }
+      if (options.filters) {
+        params.filters = options.filters
+      }
+      if (options.timeoutMs) {
+        params.timeoutMs = options.timeoutMs
+      }
+      if (options.matches) {
+        params.matches = options.matches
+      }
     }
 
     return this.instance.get(url, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,6 @@ export interface GetDocumentsParams {
 }
 
 export interface SearchParams {
-  q: string
   offset?: number
   limit?: number
   attributesToRetrieve?: string[]


### PR DESCRIPTION
Change search route from 

`meili.Index('xxx').search(options: Types.SearchParams): Promise<Types.SearchResponse>`

in which `q` was a key in SearchParams.

to 

`meili.Index('xxx').search(query: string, options?: Types.SearchParams): Promise<Types.SearchResponse>`