### PR TITLE
Documents tests

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -186,7 +186,7 @@ class Indexes extends MeiliAxiosWrapper {
    * @memberof Indexes
    * @method getDocument
    */
-  getDocument(documentId: string): Promise<object> {
+  getDocument(documentId: string | number): Promise<object> {
     const url = `/indexes/${this.indexUid}/documents/${documentId}`
 
     return this.get(url)

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,20 +14,6 @@ export interface AsyncUpdateId {
   updateId: number
 }
 
-export interface Settings {
-  distinctAttribute?: string
-  searchableAttributes?: string[]
-  displayedAttributes?: string[]
-  rankingRules?: {
-    [field: string]: string
-  }
-  stopWords?: string[]
-  synonyms?: {
-    [field: string]: string[]
-  }
-  indexNewFields?: boolean
-}
-
 ///
 /// Request specific interfaces
 ///
@@ -46,12 +32,6 @@ export interface IndexResponse {
 
 export interface UpdateIndexRequest {
   primaryKey?: string
-}
-
-export interface GetDocumentsParams {
-  offset?: number
-  limit?: number
-  attributesToRetrieve?: string[]
 }
 
 export interface AddDocumentParams {
@@ -105,6 +85,56 @@ export interface FieldFrequency {
 }
 
 /*
+ ** Documents
+ */
+export interface GetDocumentsParams {
+  offset?: number
+  limit?: number
+  attributesToRetrieve?: string[]
+}
+
+export interface Document<T = any> {
+  [attribute: string]: T
+}
+
+/*
+ ** Settings
+ */
+export interface Settings {
+  distinctAttribute?: string
+  searchableAttributes?: string[]
+  displayedAttributes?: string[]
+  rankingRules?: {
+    [field: string]: string
+  }
+  stopWords?: string[]
+  synonyms?: {
+    [field: string]: string[]
+  }
+  indexNewFields?: boolean
+}
+
+/*
+ ** UPDATE
+ */
+
+export interface EnqueuedUpdate {
+  updateId: number
+}
+
+export interface Update {
+  status: string
+  updateId: number
+  type: {
+    name: string
+    number: number
+  }
+  duration: number
+  enqueuedAt: string
+  processedAt: string
+}
+
+/*
  *** STATS
  */
 
@@ -138,10 +168,6 @@ export interface Version {
   commitSha: string
   buildDate: string
   pkgVersion: string
-}
-
-export interface Update {
-  updateId: number
 }
 
 /*

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -145,7 +145,7 @@ describe.each([
     const title = 'The Little Prince'
     await client
       .getIndex(uidNoPrimaryKey.uid)
-      .addDocuments([{ id, title }])
+      .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
       })
@@ -163,7 +163,7 @@ describe.each([
     const title = 'The Little Prince'
     await client
       .getIndex(uidAndPrimaryKey.uid)
-      .addDocuments([{ id, title }])
+      .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
       })
@@ -177,12 +177,12 @@ describe.each([
       })
   })
 
-  test(`${permission} key: Add document with Update documents fct from index that has NO primary key`, async () => {
+  test(`${permission} key: Add document with update documents function from index that has NO primary key`, async () => {
     const id = 9
     const title = '1984'
     await client
       .getIndex(uidNoPrimaryKey.uid)
-      .addDocuments([{ id, title }])
+      .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
       })
@@ -201,12 +201,12 @@ describe.each([
         expect(response.length).toEqual(dataset.length + 1)
       })
   })
-  test(`${permission} key: Add document with Update documents fct from index that has a primary key`, async () => {
+  test(`${permission} key: Add document with update documents function from index that has a primary key`, async () => {
     const id = 9
     const title = '1984'
     await client
       .getIndex(uidAndPrimaryKey.uid)
-      .addDocuments([{ id, title }])
+      .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
       })

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -1,0 +1,440 @@
+import MeiliSearch from '../src'
+import * as Types from '../src/types'
+import { clearAllIndexes } from './utils'
+
+const { HOST: host, MASTER_KEY, PRIVATE_KEY, PUBLIC_KEY } = process.env
+const config = {
+  host,
+  apiKey: MASTER_KEY,
+}
+const masterClient = new MeiliSearch({
+  host,
+  apiKey: MASTER_KEY,
+})
+const privateClient = new MeiliSearch({
+  host,
+  apiKey: PRIVATE_KEY,
+})
+const publicClient = new MeiliSearch({
+  host,
+  apiKey: PUBLIC_KEY,
+})
+const anonymousClient = new MeiliSearch({
+  host,
+})
+
+const uidNoPrimaryKey = {
+  uid: 'movies_test',
+}
+const uidAndPrimaryKey = {
+  uid: 'movies_test2',
+  primaryKey: 'id',
+}
+
+const dataset = [
+  { id: 123, title: 'Pride and Prejudice', comment: 'A great book' },
+  { id: 456, title: 'Le Petit Prince', comment: 'A french book' },
+  { id: 2, title: 'Le Rouge et le Noir', comment: 'Another french book' },
+  { id: 1, title: 'Alice In Wonderland', comment: 'A weird book' },
+  { id: 1344, title: 'The Hobbit', comment: 'An awesome book' },
+  {
+    id: 4,
+    title: 'Harry Potter and the Half-Blood Prince',
+    comment: 'The best book',
+  },
+  { id: 42, title: "The Hitchhiker's Guide to the Galaxy" },
+]
+jest.setTimeout(100 * 1000)
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+beforeAll(async () => {
+  await clearAllIndexes(config)
+  await masterClient.createIndex(uidNoPrimaryKey)
+  await masterClient.createIndex(uidAndPrimaryKey)
+})
+
+afterAll(() => {
+  return clearAllIndexes(config)
+})
+
+describe.each([
+  { client: masterClient, permission: 'Master' },
+  { client: privateClient, permission: 'Private' },
+])('Test on documents', ({ client, permission }) => {
+  beforeAll(async () => {
+    await clearAllIndexes(config)
+    await masterClient.createIndex(uidNoPrimaryKey)
+    await masterClient.createIndex(uidAndPrimaryKey)
+  })
+  test(`${permission} key: Add documents to uid with NO primary key`, async () => {
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .addDocuments(dataset)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+  })
+  test(`${permission} key: Add documents to uid with primary key`, async () => {
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .addDocuments(dataset)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+  })
+  test(`${permission} key: Get documents from index that has no primary key`, async () => {
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.Document[]) => {
+        expect(response.length).toEqual(dataset.length)
+      })
+  })
+  test(`${permission} key: Get documents from index that has a primary key`, async () => {
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.Document[]) => {
+        expect(response.length).toEqual(dataset.length)
+      })
+  })
+  test(`${permission} key: Replace documents from index that has NO primary key`, async () => {
+    const id = 2
+    const title = 'The Red And The Black'
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+  })
+  test(`${permission} key: Replace documents from index that has a primary key`, async () => {
+    const id = 2
+    const title = 'The Red And The Black'
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+  })
+
+  test(`${permission} key: Update document from index that has NO primary key`, async () => {
+    const id = 456
+    const title = 'The Little Prince'
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+  })
+  test(`${permission} key: Update document from index that has a primary key`, async () => {
+    const id = 456
+    const title = 'The Little Prince'
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+  })
+
+  test(`${permission} key: Add document with Update documents fct from index that has NO primary key`, async () => {
+    const id = 9
+    const title = '1984'
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length + 1)
+      })
+  })
+  test(`${permission} key: Add document with Update documents fct from index that has a primary key`, async () => {
+    const id = 9
+    const title = '1984'
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .addDocuments([{ id, title }])
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocument(id)
+      .then((response: Types.Document) => {
+        expect(response).toHaveProperty('id', id)
+        expect(response).toHaveProperty('title', title)
+      })
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length + 1)
+      })
+  })
+  test(`${permission} key: Delete a document from index that has NO primary key`, async () => {
+    const id = 9
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .deleteDocument(id)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length)
+      })
+  })
+  test(`${permission} key: Delete a document from index that has a primary key`, async () => {
+    const id = 9
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .deleteDocument(id)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length)
+      })
+  })
+
+  test(`${permission} key: Delete some document from index that has NO primary key`, async () => {
+    const ids = [1, 2]
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .deleteDocuments(ids)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length - 2)
+        const returnedIds = response.map((x: Types.Document) => x.id)
+        expect(returnedIds).not.toContain(ids[0])
+        expect(returnedIds).not.toContain(ids[1])
+      })
+  })
+  test(`${permission} key: Delete some document from index that has a primary key`, async () => {
+    const ids = [1, 2]
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .deleteDocuments(ids)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(dataset.length - 2)
+        const returnedIds = response.map((x: Types.Document) => x.id)
+        expect(returnedIds).not.toContain(ids[0])
+        expect(returnedIds).not.toContain(ids[1])
+      })
+  })
+  test(`${permission} key: Delete all document from index that has NO primary key`, async () => {
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .deleteAllDocuments()
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(0)
+      })
+  })
+  test(`${permission} key: Delete all document from index that has a primary key`, async () => {
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .deleteAllDocuments()
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex(uidAndPrimaryKey.uid)
+      .getDocuments()
+      .then((response: Types.IndexResponse[]) => {
+        expect(response.length).toEqual(0)
+      })
+  })
+  test(`${permission} key: Try to get deleted document from index that has NO primary key`, async () => {
+    await expect(
+      client.getIndex(uidNoPrimaryKey.uid).getDocument(1)
+    ).rejects.toThrowError('Document with id 1 not found')
+  })
+  test(`${permission} key: Try to get deleted document from index that has a primary key`, async () => {
+    await expect(
+      client.getIndex(uidAndPrimaryKey.uid).getDocument(1)
+    ).rejects.toThrowError('Document with id 1 not found')
+  })
+  test(`${permission} key: Add documents from index with no primary key by giving a primary key as parameter`, async () => {
+    const docs = [
+      {
+        id: 1,
+        unique: 2,
+        title: 'Le Rouge et le Noir',
+      },
+    ]
+
+    await client
+      .createIndex({ uid: 'updateUid' })
+      .then((response: Types.IndexResponse) => {
+        expect(response).toHaveProperty('uid', 'updateUid')
+      })
+    await client
+      .getIndex('updateUid')
+      .addDocuments(docs, { primaryKey: 'unique' })
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(500)
+    await client
+      .getIndex('updateUid')
+      .show()
+      .then((response: Types.IndexResponse) => {
+        expect(response).toHaveProperty('uid', 'updateUid')
+        expect(response).toHaveProperty('primaryKey', 'unique')
+      })
+  })
+})
+
+describe.each([{ client: publicClient, permission: 'Public' }])(
+  'Test on documents',
+  ({ client, permission }) => {
+    test(`${permission} key: Try to add documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+    test(`${permission} key: Try to update documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+    test(`${permission} key: Try to get documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+    test(`${permission} key: Try to delete one document and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+    test(`${permission} key: Try to delete some documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+    test(`${permission} key: Try to delete all documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: ${PUBLIC_KEY}`
+      )
+    })
+  }
+)
+
+describe.each([{ client: anonymousClient, permission: 'No' }])(
+  'Test on documents',
+  ({ client, permission }) => {
+    test(`${permission} key: Try to add documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+    test(`${permission} key: Try to update documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+    test(`${permission} key: Try to get documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+    test(`${permission} key: Try to delete one document and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+    test(`${permission} key: Try to delete some documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+    test(`${permission} key: Try to delete all documents and be denied`, async () => {
+      await expect(client.listIndexes()).rejects.toThrowError(
+        `Invalid API key: Need a token`
+      )
+    })
+  }
+)

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -365,6 +365,29 @@ describe.each([
         expect(response).toHaveProperty('primaryKey', 'unique')
       })
   })
+  test(`${permission} key: Try to Add documents from index with no primary key with NO valid primary key and fail`, async () => {
+    const docs = [
+      {
+        unique: 2,
+        title: 'Le Rouge et le Noir',
+      },
+    ]
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .addDocuments(docs)
+      .then((response: Types.EnqueuedUpdate) => {
+        expect(response).toHaveProperty('updateId', expect.any(Number))
+      })
+    await sleep(100)
+    await client
+      .getIndex(uidNoPrimaryKey.uid)
+      .getAllUpdateStatus()
+      .then((response: Types.Update[]) => {
+        const lastUpdate = response[response.length - 1]
+        expect(lastUpdate).toHaveProperty('error', 'document id is missing')
+        expect(lastUpdate).toHaveProperty('status', 'failed')
+      })
+  })
 })
 
 describe.each([{ client: publicClient, permission: 'Public' }])(


### PR DESCRIPTION
Added tests for documents. 
All tests are done on every API key and on both an index containing a primary key from the start and on an index containing no primary key.

<img width="905" alt="Screenshot 2020-04-08 at 16 10 00" src="https://user-images.githubusercontent.com/33010418/78794037-807cf080-79b3-11ea-8a30-d052ff799911.png">
