### PR TITLE
Wait for pending update and error naming

### DIFF
--- a/src/errors/meilisearch-error.ts
+++ b/src/errors/meilisearch-error.ts
@@ -1,15 +1,17 @@
 import { AxiosError } from 'axios'
-import * as Types from './types'
+import * as Types from '../types'
 
-const MeiliAxiosError: Types.MeiliAxiosErrorConstructor = class extends Error
-  implements Types.MeiliAxiosErrorInterface {
-  response?: Types.MeiliAxiosErrorResponse
-  request?: Types.MeiliAxiosErrorRequest
+const MeiliSearchApiError: Types.MeiliSearchApiErrorConstructor = class
+  extends Error
+  implements Types.MeiliSearchApiErrorInterface {
+  response?: Types.MeiliSearchApiErrorResponse
+  request?: Types.MeiliSearchApiErrorRequest
+  type: string
 
   constructor(error: AxiosError, cachedStack?: string) {
     super(error.message)
-
-    this.name = 'MeiliSearch Error'
+    this.type = this.constructor.name
+    this.name = 'MeiliSearchApiError'
 
     // Fetch the native error message but add our application name in front of it.
     // This means slicing the "Error" string at the start of the message.
@@ -40,8 +42,11 @@ const MeiliAxiosError: Types.MeiliAxiosErrorConstructor = class extends Error
     }
     // use cached Stack on error object to keep the call stack
     if (cachedStack && error.stack) {
-      this.stack = cachedStack
+      this.stack = `${this.name}: ${this.message}\n${cachedStack
+        .split('\n')
+        .slice(1)
+        .join('\n')}`
     }
   }
 }
-export default MeiliAxiosError
+export default MeiliSearchApiError

--- a/src/errors/meilisearch-timeout-error.ts
+++ b/src/errors/meilisearch-timeout-error.ts
@@ -1,0 +1,11 @@
+class MeiliSearchTimeOutError extends Error {
+  type: string
+  constructor(message: string) {
+    super(message)
+    this.name = 'MeiliSearchTimeOutError'
+    this.type = this.constructor.name
+    Error.captureStackTrace(this, MeiliSearchTimeOutError)
+  }
+}
+
+export { MeiliSearchTimeOutError }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -12,8 +12,6 @@ import MeiliAxiosWrapper from './meili-axios-wrapper'
 import * as Types from './types'
 import { sleep } from './utils'
 
-
-
 class Indexes extends MeiliAxiosWrapper implements Types.Indexes {
   indexUid: string
   constructor(config: Types.Config, indexUid: string) {

--- a/src/meili-axios-wrapper.ts
+++ b/src/meili-axios-wrapper.ts
@@ -13,7 +13,7 @@ import instance, {
   AxiosResponse,
   CancelTokenSource,
 } from 'axios'
-import MeiliAxiosError from './meili-axios-error'
+import MeiliSearchApiError from './errors/meilisearch-error'
 import * as Types from './types'
 
 class MeiliAxiosWrapper {
@@ -57,7 +57,7 @@ class MeiliAxiosWrapper {
       .get(url, config)
       .then((response: any) => response)
       .catch((e) => {
-        const meiliError = new MeiliAxiosError(e, cachedStack)
+        const meiliError = new MeiliSearchApiError(e, cachedStack)
         throw meiliError
       })
   }
@@ -73,7 +73,7 @@ class MeiliAxiosWrapper {
       .post(url, data, config)
       .then((response: any) => response)
       .catch((e) => {
-        throw new MeiliAxiosError(e, cachedStack)
+        throw new MeiliSearchApiError(e, cachedStack)
       })
   }
 
@@ -88,7 +88,7 @@ class MeiliAxiosWrapper {
       .put(url, data, config)
       .then((response: any) => response)
       .catch((e) => {
-        const meiliError = new MeiliAxiosError(e, cachedStack)
+        const meiliError = new MeiliSearchApiError(e, cachedStack)
         throw meiliError
       })
   }
@@ -103,7 +103,7 @@ class MeiliAxiosWrapper {
       .patch(url, data, config)
       .then((response: any) => response)
       .catch((e) => {
-        const meiliError = new MeiliAxiosError(e, cachedStack)
+        const meiliError = new MeiliSearchApiError(e, cachedStack)
         throw meiliError
       })
   }
@@ -117,7 +117,7 @@ class MeiliAxiosWrapper {
       .delete(url, config)
       .then((response: any) => response)
       .catch((e) => {
-        const meiliError = new MeiliAxiosError(e, cachedStack)
+        const meiliError = new MeiliSearchApiError(e, cachedStack)
         throw meiliError
       })
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,10 @@
-import { AxiosError, AxiosInstance, CancelTokenSource, AxiosRequestConfig, AxiosResponse } from 'axios'
+import {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  CancelTokenSource,
+} from 'axios'
 
 ///
 /// Global interfaces
@@ -203,127 +209,126 @@ export interface SysInfoPretty {
  ** MeiliSearch Class
  */
 
-
-export interface Indexes extends MeiliAxiosWrapper{
-  indexUid: string;
-  getUpdateStatus(updateId: number): Promise<Update>;
-  getAllUpdateStatus(): Promise<Update[]>;
-  search(query: string, options?: SearchParams): Promise<SearchResponse>;
-  show(): Promise<Index>;
-  updateIndex(data: UpdateIndexRequest): Promise<Index>;
-  deleteIndex(): Promise<string>;
-  getStats(): Promise<IndexStats>;
-  getDocuments(options?: GetDocumentsParams): Promise<Document[]>;
-  getDocument(documentId: string | number): Promise<Document>;
+export interface Indexes extends MeiliAxiosWrapper {
+  indexUid: string
+  getUpdateStatus(updateId: number): Promise<Update>
+  getAllUpdateStatus(): Promise<Update[]>
+  search(query: string, options?: SearchParams): Promise<SearchResponse>
+  show(): Promise<Index>
+  updateIndex(data: UpdateIndexRequest): Promise<Index>
+  deleteIndex(): Promise<string>
+  getStats(): Promise<IndexStats>
+  getDocuments(options?: GetDocumentsParams): Promise<Document[]>
+  getDocument(documentId: string | number): Promise<Document>
   addDocuments(
     documents: Document[],
     options?: AddDocumentParams
-  ): Promise<EnqueuedUpdate>;
+  ): Promise<EnqueuedUpdate>
   updateDocuments(
     documents: Document[],
     options?: AddDocumentParams
-  ): Promise<EnqueuedUpdate>;
-  deleteDocument(documentId: string | number): Promise<EnqueuedUpdate>;
-  deleteDocuments(documentsIds: string[] | number[]): Promise<EnqueuedUpdate>;
-  deleteAllDocuments(): Promise<EnqueuedUpdate>;
-  getSettings(): Promise<Settings>;
-  updateSettings(settings: Settings): Promise<EnqueuedUpdate>;
-  resetSettings(): Promise<EnqueuedUpdate>;
-  getSynonyms(): Promise<object>;
-  updateSynonyms(synonyms: object): Promise<object>;
-  resetSynonyms(): Promise<object>;
-  getStopWords(): Promise<string[]>;
-  updateStopWords(stopWords: string[]): Promise<EnqueuedUpdate>;
-  resetStopWords(): Promise<EnqueuedUpdate>;
-  getRankingRules(): Promise<string[]>;
-  updateRankingRules(rankingRules: string[]): Promise<EnqueuedUpdate>;
-  resetRankingRules(): Promise<EnqueuedUpdate>;
-  getDistinctAttribute(): Promise<string | void>;
-  updateDistinctAttribute(distinctAttribute: string): Promise<EnqueuedUpdate>;
-  resetDistinctAttribute(): Promise<EnqueuedUpdate>;
-  getSearchableAttributes(): Promise<string[]>;
+  ): Promise<EnqueuedUpdate>
+  deleteDocument(documentId: string | number): Promise<EnqueuedUpdate>
+  deleteDocuments(documentsIds: string[] | number[]): Promise<EnqueuedUpdate>
+  deleteAllDocuments(): Promise<EnqueuedUpdate>
+  getSettings(): Promise<Settings>
+  updateSettings(settings: Settings): Promise<EnqueuedUpdate>
+  resetSettings(): Promise<EnqueuedUpdate>
+  getSynonyms(): Promise<object>
+  updateSynonyms(synonyms: object): Promise<object>
+  resetSynonyms(): Promise<object>
+  getStopWords(): Promise<string[]>
+  updateStopWords(stopWords: string[]): Promise<EnqueuedUpdate>
+  resetStopWords(): Promise<EnqueuedUpdate>
+  getRankingRules(): Promise<string[]>
+  updateRankingRules(rankingRules: string[]): Promise<EnqueuedUpdate>
+  resetRankingRules(): Promise<EnqueuedUpdate>
+  getDistinctAttribute(): Promise<string | void>
+  updateDistinctAttribute(distinctAttribute: string): Promise<EnqueuedUpdate>
+  resetDistinctAttribute(): Promise<EnqueuedUpdate>
+  getSearchableAttributes(): Promise<string[]>
   updateSearchableAttributes(
     searchableAttributes: string[]
-  ): Promise<EnqueuedUpdate>;
-  resetSearchableAttributes(): Promise<EnqueuedUpdate>;
-  getDisplayedAttributes(): Promise<string[]>;
+  ): Promise<EnqueuedUpdate>
+  resetSearchableAttributes(): Promise<EnqueuedUpdate>
+  getDisplayedAttributes(): Promise<string[]>
   updateDisplayedAttributes(
     displayedAttributes: string[]
-  ): Promise<EnqueuedUpdate>;
-  resetDisplayedAttributes(): Promise<EnqueuedUpdate>;
-  getAcceptNewFields(): Promise<boolean>;
-  updateAcceptNewFields(acceptNewFields: boolean): Promise<EnqueuedUpdate>;
+  ): Promise<EnqueuedUpdate>
+  resetDisplayedAttributes(): Promise<EnqueuedUpdate>
+  getAcceptNewFields(): Promise<boolean>
+  updateAcceptNewFields(acceptNewFields: boolean): Promise<EnqueuedUpdate>
 }
 
-export interface Meilisearch extends MeiliAxiosErrorInterface {
-  config: Config;
-  getIndex(indexUid: string): Indexes;
-  listIndexes(): Promise<IndexResponse[]>;
-  createIndex(data: IndexRequest): Promise<IndexResponse>;
-  getKeys(): Promise<Keys>;
-  isHealthy(): Promise<boolean>;
-  setHealthy(): Promise<void>;
-  setUnhealthy(): Promise<void>;
-  changeHealthTo(health: boolean): Promise<void>;
-  stats(): Promise<Stats>;
-  version(): Promise<Version>;
-  sysInfo(): Promise<SysInfo>;
-  prettySysInfo(): Promise<SysInfoPretty>;
+export interface Meilisearch extends MeiliSearchApiErrorInterface {
+  config: Config
+  getIndex(indexUid: string): Indexes
+  listIndexes(): Promise<IndexResponse[]>
+  createIndex(data: IndexRequest): Promise<IndexResponse>
+  getKeys(): Promise<Keys>
+  isHealthy(): Promise<boolean>
+  setHealthy(): Promise<void>
+  setUnhealthy(): Promise<void>
+  changeHealthTo(health: boolean): Promise<void>
+  stats(): Promise<Stats>
+  version(): Promise<Version>
+  sysInfo(): Promise<SysInfo>
+  prettySysInfo(): Promise<SysInfoPretty>
 }
 
 export interface MeiliAxiosWrapper {
-  instance: AxiosInstance;
-  cancelTokenSource: CancelTokenSource;
+  instance: AxiosInstance
+  cancelTokenSource: CancelTokenSource
   get<T = any, R = AxiosResponse<T>>(
     url: string,
     config?: AxiosRequestConfig
-  ): Promise<R>;
+  ): Promise<R>
   post<T = any, R = AxiosResponse<T>>(
     url: string,
     data?: any,
     config?: AxiosRequestConfig
-  ): Promise<R>;
+  ): Promise<R>
   put<T = any, R = AxiosResponse<T>>(
     url: string,
     data?: any,
     config?: AxiosRequestConfig
-  ): Promise<R>;
+  ): Promise<R>
   patch<T = any, R = AxiosResponse<T>>(
     url: string,
     data?: any,
     config?: AxiosRequestConfig
-  ): Promise<R>;
+  ): Promise<R>
   delete<T = any, R = AxiosResponse<T>>(
     url: string,
     config?: AxiosRequestConfig
-  ): Promise<R>;
+  ): Promise<R>
 }
 
 /*
  ** ERROR HANDLER
  */
 
-export interface MeiliAxiosErrorInterface extends Error {
+export interface MeiliSearchApiErrorInterface extends Error {
   name: string
   message: string
   stack?: string
 }
-export interface MeiliAxiosErrorResponse {
+export interface MeiliSearchApiErrorResponse {
   status?: number
   statusText?: string
   path?: string
   method?: string
   body?: object
 }
-export interface MeiliAxiosErrorRequest {
+export interface MeiliSearchApiErrorRequest {
   url?: string
   path?: string
   method?: string
 }
 
-export type MeiliAxiosErrorConstructor = new (
+export type MeiliSearchApiErrorConstructor = new (
   error: AxiosError,
   cachedStack?: string
 ) => void
 
-export default Indexes;
+export default Indexes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,5 @@
-
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export {
-  sleep
-}
+export { sleep }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export {
+  sleep
+}

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -38,7 +38,7 @@ afterAll(() => {
 
 describe.each([
   { client: masterClient, permission: 'Master' },
-  // { client: privateClient, permission: 'Private' },
+  { client: privateClient, permission: 'Private' },
 ])('Test on wait-for-pending-update', ({ client, permission }) => {
   beforeEach(async () => {
     await clearAllIndexes(config)

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -1,0 +1,85 @@
+import * as Types from '../src/types'
+import {
+  clearAllIndexes,
+  sleep,
+  config,
+  masterClient,
+} from './meilisearch-test-utils'
+
+const index = {
+  uid: 'movies_test',
+}
+
+const dataset = [
+  { id: 123, title: 'Pride and Prejudice', comment: 'A great book' },
+  { id: 456, title: 'Le Petit Prince', comment: 'A french book' },
+  { id: 2, title: 'Le Rouge et le Noir', comment: 'Another french book' },
+  { id: 1, title: 'Alice In Wonderland', comment: 'A weird book' },
+  { id: 1344, title: 'The Hobbit', comment: 'An awesome book' },
+  {
+    id: 4,
+    title: 'Harry Potter and the Half-Blood Prince',
+    comment: 'The best book',
+  },
+  { id: 42, title: "The Hitchhiker's Guide to the Galaxy" },
+]
+
+jest.setTimeout(100 * 1000)
+
+beforeAll(async () => {
+  await clearAllIndexes(config)
+  await masterClient.createIndex(index)
+  await sleep(500)
+})
+
+afterAll(() => {
+  return clearAllIndexes(config)
+})
+
+describe.each([
+  { client: masterClient, permission: 'Master' },
+  // { client: privateClient, permission: 'Private' },
+])('Test on wait-for-pending-update', ({ client, permission }) => {
+  beforeEach(async () => {
+    await clearAllIndexes(config)
+    await masterClient.createIndex(index)
+  })
+  test(`${permission} key: Get WaitForPendingStatus until done and resolved`, async () => {
+    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const update = await client
+      .getIndex(index.uid)
+      .waitForPendingUpdate(updateId)
+    expect(update).toHaveProperty('status', 'processed')
+  })
+  test(`${permission} key: Get WaitForPendingStatus with custom interval and timeout until done and resolved`, async () => {
+    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const update = await client
+      .getIndex(index.uid)
+      .waitForPendingUpdate(updateId, {
+        timeOutMs: 6000,
+        intervalMs: 100,
+      })
+    expect(update).toHaveProperty('status', 'processed')
+  })
+  test(`${permission} key: Get WaitForPendingStatus with custom timeout and interval at 0 done and resolved`, async () => {
+    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const update = await client
+      .getIndex(index.uid)
+      .waitForPendingUpdate(updateId, {
+        timeOutMs: 6000,
+        intervalMs: 0,
+      })
+    expect(update).toHaveProperty('status', 'processed')
+  })
+
+  test(`${permission} key: Try to WaitForPendingStatus with small timeout and raise an error`, async () => {
+    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    await expect(
+      client
+        .getIndex(index.uid)
+        .waitForPendingUpdate(updateId, { timeOutMs: 0 })
+    ).rejects.toThrowError(
+      `timeout of 0ms has exceeded on process 0 when waiting for pending update to resolve.`
+    )
+  })
+})


### PR DESCRIPTION
In this PR 

* Some styling fixes

### Wait For Pending Update
 **WaitForPendingUpdate** function, based on this issue: meilisearch/integrations-guides#1
With its associated tests.

### New Error naming
- The base MeiliSearch error is now called `MeiliSearchApiError`. 
- The timeout error in wait for Pending update is called `MeiliSearchTimeOutError`

