### PR TITLE
Replace sleep with wait for update

### DIFF
--- a/tests/accept_new_fields_tests.ts
+++ b/tests/accept_new_fields_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -19,7 +18,6 @@ jest.setTimeout(100 * 1000)
 beforeAll(async () => {
   await clearAllIndexes(config)
   await masterClient.createIndex(index)
-  await sleep(500)
 })
 
 afterAll(() => {
@@ -43,14 +41,14 @@ describe.each([
       })
   })
   test(`${permission} key: Update accept new fields to false`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .updateAcceptNewFields(false)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getAcceptNewFields()

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -53,23 +52,26 @@ describe.each([
     await masterClient.createIndex(uidAndPrimaryKey)
   })
   test(`${permission} key: Add documents to uid with NO primary key`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Add documents to uid with primary key`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get documents from index that has no primary key`, async () => {
-    await sleep(500)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocuments()
@@ -78,7 +80,6 @@ describe.each([
       })
   })
   test(`${permission} key: Get documents from index that has a primary key`, async () => {
-    await sleep(500)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocuments()
@@ -89,13 +90,14 @@ describe.each([
   test(`${permission} key: Replace documents from index that has NO primary key`, async () => {
     const id = 2
     const title = 'The Red And The Black'
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .addDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocument(id)
@@ -107,13 +109,14 @@ describe.each([
   test(`${permission} key: Replace documents from index that has a primary key`, async () => {
     const id = 2
     const title = 'The Red And The Black'
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .addDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocument(id)
@@ -126,13 +129,14 @@ describe.each([
   test(`${permission} key: Update document from index that has NO primary key`, async () => {
     const id = 456
     const title = 'The Little Prince'
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocument(id)
@@ -144,13 +148,14 @@ describe.each([
   test(`${permission} key: Update document from index that has a primary key`, async () => {
     const id = 456
     const title = 'The Little Prince'
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocument(id)
@@ -163,13 +168,14 @@ describe.each([
   test(`${permission} key: Add document with update documents function from index that has NO primary key`, async () => {
     const id = 9
     const title = '1984'
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocument(id)
@@ -187,13 +193,14 @@ describe.each([
   test(`${permission} key: Add document with update documents function from index that has a primary key`, async () => {
     const id = 9
     const title = '1984'
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocument(id)
@@ -210,13 +217,14 @@ describe.each([
   })
   test(`${permission} key: Delete a document from index that has NO primary key`, async () => {
     const id = 9
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .deleteDocument(id)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocuments()
@@ -226,13 +234,14 @@ describe.each([
   })
   test(`${permission} key: Delete a document from index that has a primary key`, async () => {
     const id = 9
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .deleteDocument(id)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocuments()
@@ -243,13 +252,14 @@ describe.each([
 
   test(`${permission} key: Delete some documents from index that has NO primary key`, async () => {
     const ids = [1, 2]
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .deleteDocuments(ids)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocuments()
@@ -262,13 +272,14 @@ describe.each([
   })
   test(`${permission} key: Delete some documents from index that has a primary key`, async () => {
     const ids = [1, 2]
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .deleteDocuments(ids)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocuments()
@@ -280,13 +291,14 @@ describe.each([
       })
   })
   test(`${permission} key: Delete all document from index that has NO primary key`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .deleteAllDocuments()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getDocuments()
@@ -295,13 +307,14 @@ describe.each([
       })
   })
   test(`${permission} key: Delete all document from index that has a primary key`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(uidAndPrimaryKey.uid)
       .deleteAllDocuments()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidAndPrimaryKey.uid)
       .getDocuments()
@@ -333,13 +346,14 @@ describe.each([
       .then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', 'updateUid')
       })
-    await client
+    const { updateId } = await client
       .getIndex('updateUid')
       .addDocuments(docs, { primaryKey: 'unique' })
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(500)
+    await client.getIndex('updateUid').waitForPendingUpdate(updateId)
     await client
       .getIndex('updateUid')
       .show()
@@ -355,13 +369,14 @@ describe.each([
         title: 'Le Rouge et le Noir',
       },
     ]
-    await client
+    const { updateId } = await client
       .getIndex(uidNoPrimaryKey.uid)
       .addDocuments(docs)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
+        return response
       })
-    await sleep(100)
+    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(uidNoPrimaryKey.uid)
       .getAllUpdateStatus()

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -23,10 +23,6 @@ const anonymousClient = new MeiliSearch({
   host,
 })
 
-const sleep = function (ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 const clearAllIndexes = async (config) => {
   const client = new MeiliSearch(config)
   const indexes = await client
@@ -49,7 +45,6 @@ const clearAllIndexes = async (config) => {
 
 export {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,

--- a/tests/searchable_attributes_tests.ts
+++ b/tests/searchable_attributes_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -45,8 +44,10 @@ describe.each([
   beforeAll(async () => {
     await clearAllIndexes(config)
     await masterClient.createIndex(index)
-    await masterClient.getIndex(index.uid).addDocuments(dataset)
-    await sleep(500)
+    const { updateId } = await masterClient
+      .getIndex(index.uid)
+      .addDocuments(dataset)
+    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default searchable attributes`, async () => {
     await client
@@ -58,14 +59,14 @@ describe.each([
   })
   test(`${permission} key: Update searchable attributes`, async () => {
     const new_da = ['title']
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .updateSearchableAttributes(new_da)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getSearchableAttributes()
@@ -74,14 +75,14 @@ describe.each([
       })
   })
   test(`${permission} key: Reset searchable attributes`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .resetSearchableAttributes()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getSearchableAttributes()

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -79,9 +78,10 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index)
     await masterClient.createIndex(indexAndPK)
-    await masterClient.getIndex(index.uid).addDocuments(dataset)
-    await masterClient.getIndex(index.uid).addDocuments(dataset)
-    await sleep(500)
+    const { updateId } = await masterClient
+      .getIndex(index.uid)
+      .addDocuments(dataset)
+    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default settings of an index`, async () => {
     await client
@@ -129,14 +129,14 @@ describe.each([
       rankingRules: ['asc(title)', 'typo'],
       stopWords: ['the'],
     }
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getSettings()
@@ -169,14 +169,14 @@ describe.each([
       rankingRules: ['asc(title)', 'typo'],
       stopWords: ['the'],
     }
-    await client
+    const { updateId } = await client
       .getIndex(indexAndPK.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(indexAndPK.uid)
       .getSettings()
@@ -201,14 +201,14 @@ describe.each([
   })
 
   test(`${permission} key: Reset settings`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .resetSettings()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getSettings()
@@ -236,14 +236,14 @@ describe.each([
   })
 
   test(`${permission} key: Reset settings of empty index`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(indexAndPK.uid)
       .resetSettings()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(indexAndPK.uid)
       .getSettings()
@@ -274,14 +274,14 @@ describe.each([
     const newSettings = {
       searchableAttributes: ['title'],
     }
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getSettings()
@@ -309,14 +309,14 @@ describe.each([
     const newSettings = {
       searchableAttributes: ['title'],
     }
-    await client
+    const { updateId } = await client
       .getIndex(indexAndPK.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(indexAndPK.uid)
       .getSettings()

--- a/tests/stop_words_tests.ts
+++ b/tests/stop_words_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -45,8 +44,10 @@ describe.each([
   beforeAll(async () => {
     await clearAllIndexes(config)
     await masterClient.createIndex(index)
-    await masterClient.getIndex(index.uid).addDocuments(dataset)
-    await sleep(500)
+    const { updateId } = await masterClient
+      .getIndex(index.uid)
+      .addDocuments(dataset)
+    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default stop words`, async () => {
     await client
@@ -58,14 +59,14 @@ describe.each([
   })
   test(`${permission} key: Update stop words`, async () => {
     const new_sw = ['the']
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .updateStopWords(new_sw)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getStopWords()
@@ -74,14 +75,14 @@ describe.each([
       })
   })
   test(`${permission} key: Reset stop words`, async () => {
-    await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .resetStopWords()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
-        return response.updateId
+        return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
       .getStopWords()

--- a/tests/update_tests.ts
+++ b/tests/update_tests.ts
@@ -1,7 +1,6 @@
 import * as Types from '../src/types'
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
   privateClient,
@@ -48,17 +47,17 @@ describe.each([
     await masterClient.createIndex(index)
   })
   test(`${permission} key: Get one update`, async () => {
-    let updateObj = await client
+    const { updateId } = await client
       .getIndex(index.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await sleep(500)
+    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
     await client
       .getIndex(index.uid)
-      .getUpdateStatus(updateObj.updateId)
+      .getUpdateStatus(updateId)
       .then((response: Types.Update) => {
         expect(response).toHaveProperty('status', 'processed')
         expect(response).toHaveProperty('updateId', expect.any(Number))

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -1,9 +1,8 @@
 import {
   clearAllIndexes,
-  sleep,
   config,
   masterClient,
-  privateClient
+  privateClient,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -29,7 +28,6 @@ jest.setTimeout(100 * 1000)
 beforeAll(async () => {
   await clearAllIndexes(config)
   await masterClient.createIndex(index)
-  await sleep(500)
 })
 
 afterAll(() => {


### PR DESCRIPTION
I have removed all the sleeps in all the javascript tests and replaced them with 
```javascruot
await client.getIndex(index.uid).waitForPendingUpdate(updateId)
```

 And **bonus**: It is so much faster!
<img width="415" alt="Screenshot 2020-04-23 at 19 16 12" src="https://user-images.githubusercontent.com/33010418/80129150-f75edf80-8596-11ea-8ad5-acfb3a742f2e.png">

<img width="507" alt="Screenshot 2020-04-23 at 19 10 05" src="https://user-images.githubusercontent.com/33010418/80129358-39882100-8597-11ea-87f3-5b29cba5a589.png">

