### PR TITLE
doc/fix-typo-docker-run: fix typo in readme part 'Run MeiliSearch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are many easy ways to [download and run a MeiliSearch instance](https://do
 For example, if you use Docker:
 
 ```bash
-$ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest --master-key=masterKey
+$ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey
 ```
 
 NB: you can also download MeiliSearch from **Homebrew** or **APT**.


### PR DESCRIPTION
Hi there, I found a typo in the readme :)