### PR TITLE
fix: allow to type the search response when using index search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ A GitHub Action will be triggered and push the package on [npm](https://www.npmj
 
 - Make a search request:
 
-`client.getIndex('xxx').search(query: string, options?: SearchParams): Promise<SearchResponse>`
+`client.getIndex('xxx').search<T = any>(query: string, options?: SearchParams): Promise<SearchResponse<T>>`
 
 ### Indexes <!-- omit in toc -->
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class Index extends MeiliAxiosWrapper implements Types.IndexInterface {
    * @memberof Index
    * @method search
    */
-  async search<T>(
+  async search<T = any>(
     query: string,
     options?: Types.SearchParams
   ): Promise<Types.SearchResponse<T>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,10 +72,10 @@ class Index extends MeiliAxiosWrapper implements Types.IndexInterface {
    * @memberof Index
    * @method search
    */
-  async search(
+  async search<T>(
     query: string,
     options?: Types.SearchParams
-  ): Promise<Types.SearchResponse> {
+  ): Promise<Types.SearchResponse<T>> {
     const url = `/indexes/${this.uid}/search`
 
     const params: Types.SearchRequest = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,7 @@ export interface IndexInterface extends MeiliAxiosWrapperInterface {
   uid: string
   getUpdateStatus: (updateId: number) => Promise<Update>
   getAllUpdateStatus: () => Promise<Update[]>
-  search: <T>(
+  search: <T = any>(
     query: string,
     options?: SearchParams
   ) => Promise<SearchResponse<T>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,7 +233,10 @@ export interface IndexInterface extends MeiliAxiosWrapperInterface {
   uid: string
   getUpdateStatus: (updateId: number) => Promise<Update>
   getAllUpdateStatus: () => Promise<Update[]>
-  search: (query: string, options?: SearchParams) => Promise<SearchResponse>
+  search: <T>(
+    query: string,
+    options?: SearchParams
+  ) => Promise<SearchResponse<T>>
   show: () => Promise<IndexResponse>
   updateIndex: (data: UpdateIndexRequest) => Promise<IndexResponse>
   deleteIndex: () => Promise<string>
@@ -296,11 +299,11 @@ export interface MeiliAxiosWrapperInterface {
     data: IndexRequest,
     config?: AxiosRequestConfig
   ) => Promise<IndexResponse>) &
-  (<T = any, R = AxiosResponse<EnqueuedUpdate>>(
-    url: string,
-    data?: T,
-    config?: AxiosRequestConfig
-  ) => Promise<R>)
+    (<T = any, R = AxiosResponse<EnqueuedUpdate>>(
+      url: string,
+      data?: T,
+      config?: AxiosRequestConfig
+    ) => Promise<R>)
   put: <T = any, R = AxiosResponse<T>>(
     url: string,
     data?: any,


### PR DESCRIPTION
This PR allows to specify the type of the `hits` property when using the index search query. It's now possible to do:
```typescript
type Tweet = {
  id: string
  text: string
}
const index = client.getIndex('tweets')
const search = await index.search<Tweet>('some text')
search.hits[0].text // <== type safe
```
It fallbacks on `any` if no type is provided. I also amended the documentation with this change, but feel free to revert it :) 

**On a side note**, this is pretty basic and straightforward but I think we could go further in another PR by making the `Index` class generic, and tailor the searchResponse type using the `attributesToRetrieve`. If this attribute is provided we can then infer the return type from the generic (because we know the fields asked by the user), and also provides auto-completion on the `attributesToRetrieve` property because we have the generic. Let me know if you're interested in that!