### PR TITLE
Fixes types for facetfilter

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,7 @@ export interface Document<T = any> {
  */
 
 export interface Settings {
-  attributesForFacetting?: string[]
+  attributesForFaceting?: string[]
   distinctAttribute?: string
   searchableAttributes?: string[]
   displayedAttributes?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,8 @@ export interface AddDocumentParams {
   primaryKey?: string
 }
 
+export type FacetFilter = string | FacetFilter[];
+
 export interface SearchParams {
   offset?: number
   limit?: number
@@ -59,7 +61,7 @@ export interface SearchParams {
   cropLength?: number
   attributesToHighlight?: string[] | string
   filters?: string
-  facetFilters?: string[]
+  facetFilters?: FacetFilter[]
   facetsDistribution?: string[]
   matches?: boolean
 }
@@ -110,7 +112,9 @@ export interface Document<T = any> {
 /*
  ** Settings
  */
+
 export interface Settings {
+  attributesForFacetting?: string[]
   distinctAttribute?: string
   searchableAttributes?: string[]
   displayedAttributes?: string[]

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -307,6 +307,23 @@ describe.each([
       })
   })
 
+  test(`${permission} key: Search with multiple facetFilters`, async () => {
+    await client
+      .getIndex(index.uid)
+      .search('a', {
+        facetFilters: ['genre:romance', ['genre:romance', 'genre:romance']],
+        facetsDistribution: ['genre'],
+      })
+      .then((response: Types.SearchResponse) => {
+        expect(response).toHaveProperty('facetsDistribution', {
+          genre: { adventure: 0, fantasy: 0, romance: 2 },
+        })
+        expect(response).toHaveProperty('exhaustiveFacetsCount', true)
+        expect(response).toHaveProperty('hits', expect.any(Array))
+        expect(response.hits.length).toEqual(2)
+      })
+  })
+
   test(`${permission} key: Search on index with no documents and no primary key`, async () => {
     await client
       .getIndex(emptyIndex.uid)

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -125,6 +125,7 @@ describe.each([
       distinctAttribute: 'title',
       rankingRules: ['asc(title)', 'typo'],
       stopWords: ['the'],
+      attributesForFaceting: []
     }
     const { updateId } = await client
       .getIndex(index.uid)


### PR DESCRIPTION
Facetfilter were typed as follow: 

```javascript
facetFilters? : string[]
```
This is in contradiction with how facetFilters expect as input: 

```
facetFilters: ['genre:romance', ['genre:thriller', 'genre:comedy']],
```

now it is declared the following way: 

```
export type FacetFilter = string | FacetFilter[];
​
export interface SearchParams {
  // ... 
  facetFilters?: FacetFilter[]
}

```

I also added `attributesForFaceting` which was not present in the settings object!