### PR TITLE
Main to UMD instead of CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "qdequele <quentin@meilisearch.com>"
   ],
   "license": "MIT",
-  "main": "./dist/bundles/meilisearch.cjs.js",
+  "main": "./dist/bundles/meilisearch.umd.js",
   "module": "./dist/bundles/meilisearch.esm.js",
   "browser": "./dist/bundles/meilisearch.umd.js",
   "typings": "./dist/types/types.d.ts",


### PR DESCRIPTION
Because we want our library to be usable on browser and in node we should use umd format and not cjs as the "main" in package.json