### PR TITLE
Add dependencies label to exclude-labels in the release drafter

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -2,6 +2,7 @@ name-template: 'v$RESOLVED_VERSION 🌻'
 tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'skip-changelog'
+  - 'dependencies'
 version-resolver:
   minor:
     labels:


### PR DESCRIPTION
If you agree with this @bidoubiwa, I add the label `dependencies` as a label to skip the changelogs in the release drafter.

So, you don't have to add the `skip-changelog` label every time that Dependabot does a PR (since it's many times a day.....) as I did this morning for each new PR (cf the picture below):

<img width="1441" alt="Capture d’écran 2020-06-18 à 09 58 17" src="https://user-images.githubusercontent.com/20380692/84994013-5a5d9480-b14a-11ea-8a96-d909ec8cffff.png">

Dependabot adds automatically the `dependencies` label, and with this PR you will not have to add the `skip-changelog` label for the Dependabot PR anymore.
