### PR TITLE
Rename Meilisearch class into MeiliSearch in Typescript files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 /*
- * Bundle: Meilisearch / Indexes
- * Project: Meilisearch - Javascript API
+ * Bundle: MeiliSearch / Indexes
+ * Project: MeiliSearch - Javascript API
  * Author: Quentin de Quelen <quentin@meilisearch.com>
- * Copyright: 2019, Meilisearch
+ * Copyright: 2019, MeiliSearch
  */
 
 'use strict'

--- a/src/meili-axios-wrapper.ts
+++ b/src/meili-axios-wrapper.ts
@@ -1,8 +1,8 @@
 /*
- * Bundle: Meilisearch
- * Project: Meilisearch - Javascript API
+ * Bundle: MeiliSearch
+ * Project: MeiliSearch - Javascript API
  * Author: Quentin de Quelen <quentin@meilisearch.com>
- * Copyright: 2019, Meilisearch
+ * Copyright: 2019, MeiliSearch
  */
 
 'use strict'

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -1,8 +1,8 @@
 /*
- * Bundle: Meilisearch
- * Project: Meilisearch - Javascript API
+ * Bundle: MeiliSearch
+ * Project: MeiliSearch - Javascript API
  * Author: Quentin de Quelen <quentin@meilisearch.com>
- * Copyright: 2019, Meilisearch
+ * Copyright: 2019, MeiliSearch
  */
 
 'use strict'
@@ -11,7 +11,7 @@ import { Index } from './index'
 import MeiliAxiosWrapper from './meili-axios-wrapper'
 import * as Types from './types'
 
-class Meilisearch extends MeiliAxiosWrapper
+class MeiliSearch extends MeiliAxiosWrapper
   implements Types.MeiliSearchInterface {
   config: Types.Config
   constructor(config: Types.Config) {
@@ -21,7 +21,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Return an Index instance
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method getIndex
    */
   getIndex<T = any>(indexUid: string): Index<T> {
@@ -30,7 +30,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get an index or create it if it does not exist
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method getOrCreateIndex
    */
   async getOrCreateIndex<T = any>(
@@ -50,7 +50,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * List all indexes in the database
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method listIndexes
    */
   async listIndexes(): Promise<Types.IndexResponse[]> {
@@ -61,7 +61,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Create a new index
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method createIndex
    */
   async createIndex<T = any>(
@@ -80,7 +80,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get private and public key
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method getKey
    */
   async getKeys(): Promise<Types.Keys> {
@@ -95,7 +95,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Check if the server is healhty
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method isHealthy
    */
   async isHealthy(): Promise<boolean> {
@@ -106,7 +106,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Change the healthyness to healthy
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method setHealthy
    */
   async setHealthy(): Promise<void> {
@@ -119,7 +119,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Change the healthyness to unhealthy
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method setUnhealthy
    */
   async setUnhealthy(): Promise<void> {
@@ -132,7 +132,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Set the healthyness to health value
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method changeHealthTo
    */
   async changeHealthTo(health: boolean): Promise<void> {
@@ -149,7 +149,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get the stats of all the database
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method stats
    */
   async stats(): Promise<Types.Stats> {
@@ -160,7 +160,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get the version of MeiliSearch
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method version
    */
   async version(): Promise<Types.Version> {
@@ -171,7 +171,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get the server consuption, RAM / CPU / Network
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method sysInfo
    */
   async sysInfo(): Promise<Types.SysInfo> {
@@ -182,7 +182,7 @@ class Meilisearch extends MeiliAxiosWrapper
 
   /**
    * Get the server consuption, RAM / CPU / Network. All information as human readable
-   * @memberof Meilisearch
+   * @memberof MeiliSearch
    * @method prettySysInfo
    */
   async prettySysInfo(): Promise<Types.SysInfoPretty> {
@@ -192,4 +192,4 @@ class Meilisearch extends MeiliAxiosWrapper
   }
 }
 
-export default Meilisearch
+export default MeiliSearch

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-// Type definitions for meilisearch 0.10.0
+// Type definitions for meilisearch
 // Project: https://github.com/meilisearch/meilisearch-js
 // Definitions by: qdequele <quentin@meilisearch.com> <https://github.com/meilisearch>
 // Definitions: https://github.com/meilisearch/meilisearch-js


### PR DESCRIPTION
Make the code consistent with `MeiliSearch` name.