### PR TITLE
Remove circular reference in type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface AddDocumentParams {
   primaryKey?: string
 }
 
-export type FacetFilter = string | FacetFilter[]
+export type FacetFilter = (string | string[])[]
 
 export interface SearchParams {
   offset?: number
@@ -61,7 +61,7 @@ export interface SearchParams {
   cropLength?: number
   attributesToHighlight?: string[] | string
   filters?: string
-  facetFilters?: FacetFilter[]
+  facetFilters?: string | FacetFilter | FacetFilter[]
   facetsDistribution?: string[]
   matches?: boolean
 }


### PR DESCRIPTION
fixes: #482 

Because facetFilter only has a max deepness of `2` the following is still possible with this new type: 

Valid:
```javascript
facetFilters: ['genre:thriller', [['genre:comedy'], 'genre:romance']],
```

Not valid:
```javascript
facetFilters: ['genre:thriller', [[['genre:comedy'], 'genre:romance']]],
```

