### PR TITLE
Fix: Updated settings type to fix misnamed acceptNewFields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface Settings {
   synonyms?: {
     [field: string]: string[]
   }
-  indexNewFields?: boolean
+  acceptNewFields?: boolean
 }
 
 /*


### PR DESCRIPTION
The API is expecting acceptNewFields but the typescript type here was using indexNewFields.

This is a redo of #492 