### PR TITLE
Add export mode to rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -90,6 +90,7 @@ module.exports = [
           resolve(ROOT, pkg.main),
           env === 'production'
         ),
+        exports: 'default',
         format: 'cjs',
         sourcemap: env === 'production', // create sourcemap for error reporting in production mode
       },
@@ -98,6 +99,7 @@ module.exports = [
           resolve(ROOT, pkg.module),
           env === 'production'
         ),
+        exports: 'default',
         format: 'es',
         sourcemap: env === 'production', // create sourcemap for error reporting in production mode
       },


### PR DESCRIPTION
With the rollup updates, a new warning was raised during build:

```bash
(!) Entry module "src/meilisearch.ts" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "src/meilisearch.ts" to use named exports only.
```

To avoid this confusion I have added the export mode we use in the rollup config.