### PR TITLE
Remove sys-info and sys-info pretty

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -156,10 +156,6 @@ get_health_1: |-
 update_health_1: |-
 get_version_1: |-
   client.version()
-get_pretty_sys_info_1: |-
-  client.systemInformationPretty()
-get_sys_info_1: |-
-  client.systemInformation()
 distinct_attribute_guide_1: |-
   client.getIndex('jackets').settings({ distinctAttribute: 'product_id' })
 field_properties_guide_searchable_1: |-

--- a/README.md
+++ b/README.md
@@ -498,16 +498,6 @@ If you want to know more about the development workflow or want to contribute, p
 
 `client.version(): Promise<Version>`
 
-### System <!-- omit in toc -->
-
-- Get system information
-
-`client.systemInformation(): Promise<SysInfo>`
-
-- Get system information (pretty mode)
-
-`client.systemInformationPretty(): Promise<SysInfoPretty>`
-
 <hr>
 
 **MeiliSearch** provides and maintains many **SDKs and Integration tools** like this one. We want to provide everyone with an **amazing search experience for any kind of project**. If you want to contribute, make suggestions, or just know what's going on right now, visit us in the [integration-guides](https://github.com/meilisearch/integration-guides) repository.

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -168,28 +168,6 @@ class MeiliSearch extends MeiliAxiosWrapper
 
     return await this.get(url)
   }
-
-  /**
-   * Get the server consuption, RAM / CPU / Network
-   * @memberof MeiliSearch
-   * @method sysInfo
-   */
-  async sysInfo(): Promise<Types.SysInfo> {
-    const url = '/sys-info'
-
-    return await this.get(url)
-  }
-
-  /**
-   * Get the server consuption, RAM / CPU / Network. All information as human readable
-   * @memberof MeiliSearch
-   * @method prettySysInfo
-   */
-  async prettySysInfo(): Promise<Types.SysInfoPretty> {
-    const url = '/sys-info/pretty'
-
-    return await this.get(url)
-  }
 }
 
 export default MeiliSearch

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,43 +222,6 @@ export interface Version {
 }
 
 /*
- ** SYS-INFO
- */
-export interface SysInfo {
-  memoryUsage: number
-  processorUsage: number[]
-  global: {
-    totalMemory: number
-    usedMemory: number
-    totalSwap: number
-    usedSwap: number
-    inputData: number
-    outputData: number
-  }
-  process: {
-    memory: number
-    cpu: number
-  }
-}
-
-export interface SysInfoPretty {
-  memoryUsage: string
-  processorUsage: string[]
-  global: {
-    totalMemory: string
-    usedMemory: string
-    totalSwap: string
-    usedSwap: string
-    inputData: string
-    outputData: string
-  }
-  process: {
-    memory: string
-    cpu: string
-  }
-}
-
-/*
  ** MeiliSearch Class Interfaces
  */
 
@@ -278,8 +241,6 @@ export interface MeiliSearchInterface extends MeiliAxiosWrapper {
   changeHealthTo: (health: boolean) => Promise<void>
   stats: () => Promise<Stats>
   version: () => Promise<Version>
-  sysInfo: () => Promise<SysInfo>
-  prettySysInfo: () => Promise<SysInfoPretty>
 }
 
 export interface IndexInterface<T = any> extends MeiliAxiosWrapperInterface {

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -165,39 +165,6 @@ describe.each([
         expect(response).toHaveProperty('pkgVersion', expect.any(String))
       })
     })
-    test(`${permission} key: get system info`, async () => {
-      await client.sysInfo().then((response: Types.SysInfo) => {
-        expect(response).toHaveProperty('memoryUsage', expect.any(Number))
-        expect(response).toHaveProperty('processorUsage', expect.any(Array))
-        expect(response.global).toHaveProperty(
-          'totalMemory',
-          expect.any(Number)
-        )
-        expect(response.global).toHaveProperty('usedMemory', expect.any(Number))
-        expect(response.global).toHaveProperty('totalSwap', expect.any(Number))
-        expect(response.global).toHaveProperty('usedSwap', expect.any(Number))
-        expect(response.global).toHaveProperty('inputData', expect.any(Number))
-        expect(response.global).toHaveProperty('outputData', expect.any(Number))
-        expect(response.process).toHaveProperty('memory', expect.any(Number))
-      })
-    })
-    test(`${permission} key: get pretty system info`, async () => {
-      await client.prettySysInfo().then((response: Types.SysInfoPretty) => {
-        expect(response).toHaveProperty('memoryUsage', expect.any(String))
-        expect(response).toHaveProperty('processorUsage', expect.any(Array))
-        expect(response.global).toHaveProperty(
-          'totalMemory',
-          expect.any(String)
-        )
-        expect(response.global).toHaveProperty('usedMemory', expect.any(String))
-        expect(response.global).toHaveProperty('totalSwap', expect.any(String))
-        expect(response.global).toHaveProperty('usedSwap', expect.any(String))
-        expect(response.global).toHaveProperty('inputData', expect.any(String))
-        expect(response.global).toHaveProperty('outputData', expect.any(String))
-        expect(response.process).toHaveProperty('memory', expect.any(String))
-        expect(response.process).toHaveProperty('cpu', expect.any(String))
-      })
-    })
     test(`${permission} key: get /stats information`, async () => {
       await client.stats().then((response: Types.Stats) => {
         expect(response).toHaveProperty('databaseSize', expect.any(Number))
@@ -253,16 +220,6 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
           `Invalid API key: ${PUBLIC_KEY}`
         )
       })
-      test(`${permission} key: try to get system info and be denied`, async () => {
-        await expect(client.sysInfo()).rejects.toThrowError(
-          `Invalid API key: ${PUBLIC_KEY}`
-        )
-      })
-      test(`${permission} key: try to get pretty system info and be denied`, async () => {
-        await expect(client.prettySysInfo()).rejects.toThrowError(
-          `Invalid API key: ${PUBLIC_KEY}`
-        )
-      })
       test(`${permission} key: try to get /stats information and be denied`, async () => {
         await expect(client.stats()).rejects.toThrowError(
           `Invalid API key: ${PUBLIC_KEY}`
@@ -314,16 +271,6 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     describe('Test on base routes', () => {
       test(`${permission} key: try to get version and be denied`, async () => {
         await expect(client.version()).rejects.toThrowError(
-          `You must have an authorization token`
-        )
-      })
-      test(`${permission} key: try to get system info and be denied`, async () => {
-        await expect(client.sysInfo()).rejects.toThrowError(
-          `You must have an authorization token`
-        )
-      })
-      test(`${permission} key: try to get pretty system info and be denied`, async () => {
-        await expect(client.prettySysInfo()).rejects.toThrowError(
           `You must have an authorization token`
         )
       })


### PR DESCRIPTION
fixes: #504 

The tests in the CI will fail until MeiliSearch `v0.13.0` is out.

Currently, tested with the `v0.13.0rc0`, tests are failing because of:
- the error message changed #531 
- `genre: 'fantasy'` missing in search tests, fixed in: #529 
-  <s>Settings tests fixed in #530</s> -> merged