### PR TITLE
Change tests error messages

### DIFF
--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -112,7 +112,9 @@ describe.each([
       const index = client.getIndex(uidAndPrimaryKey.uid)
       await expect(
         index.updateIndex({ primaryKey: 'newPrimaryKey' })
-      ).rejects.toThrowError(`The primary key cannot be updated`)
+      ).rejects.toThrowError(
+        `The schema already have an primary key. It's impossible to update it`
+      ) // see issue in meilisearch/meilisearch
     })
 
     test(`${permission} key: delete index`, async () => {

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -376,10 +376,7 @@ describe.each([
       .getAllUpdateStatus()
       .then((response: Types.Update[]) => {
         const lastUpdate = response[response.length - 1]
-        expect(lastUpdate).toHaveProperty(
-          'error',
-          'serializer error; Primary key is missing.'
-        )
+        expect(lastUpdate).toHaveProperty('error', 'document id is missing')
         expect(lastUpdate).toHaveProperty('status', 'failed')
       })
   })


### PR DESCRIPTION
The tests in the CI will fail until MeiliSearch v0.13.0 is out.

Currently, tested with the v0.13.0rc0, tests are failing because of:
- genre: 'fantasy' missing in search tests, fixed in: #529
- <s>404 on get system info tests: fixed in #528</s> -> merged