### PR TITLE
allow for additional header and set correct content type for requests

### DIFF
--- a/src/meili-axios-wrapper.ts
+++ b/src/meili-axios-wrapper.ts
@@ -21,18 +21,21 @@ class MeiliAxiosWrapper implements Types.MeiliAxiosWrapperInterface {
   cancelTokenSource: CancelTokenSource
 
   constructor(config: Types.Config) {
+    let headers = {
+      ...(config.headers || {}),
+      'Content-Type': 'application/json',
+    }
     if (config.apiKey !== undefined) {
-      this.instance = instance.create({
-        baseURL: config.host,
-        headers: {
-          'X-Meili-API-Key': config.apiKey,
-        },
-      })
-    } else {
-      this.instance = instance.create({
-        baseURL: config.host,
+      headers = Object.defineProperty(headers, 'X-Meili-API-Key', {
+        enumerable: true,
+        configurable: true,
+        value: config.apiKey,
       })
     }
+    this.instance = instance.create({
+      baseURL: config.host,
+      headers: headers,
+    })
     this.cancelTokenSource = instance.CancelToken.source()
     this.instance.interceptors.response.use((response) => response.data)
     this.instance.interceptors.request.use((request) => {

--- a/src/meili-axios-wrapper.ts
+++ b/src/meili-axios-wrapper.ts
@@ -21,16 +21,12 @@ class MeiliAxiosWrapper implements Types.MeiliAxiosWrapperInterface {
   cancelTokenSource: CancelTokenSource
 
   constructor(config: Types.Config) {
-    let headers = {
+    const headers: { [index: string]: any } = {
       ...(config.headers || {}),
       'Content-Type': 'application/json',
     }
     if (config.apiKey !== undefined) {
-      headers = Object.defineProperty(headers, 'X-Meili-API-Key', {
-        enumerable: true,
-        configurable: true,
-        value: config.apiKey,
-      })
+      headers['X-Meili-API-Key'] = config.apiKey
     }
     this.instance = instance.create({
       baseURL: config.host,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export { MeiliSearchTimeOutError }
 export interface Config {
   host: string
   apiKey?: string
+  headers?: object
 }
 
 ///


### PR DESCRIPTION
This PR adds an additional parameter `headers` to the Config and changes the way the AxiosInstance is created. 
This way the user can supply additional headers that are required by the local infrastructure (e.g. an API Gateway).

Additionally, i added the correct `Content-Type` Header. At the moment requests use the `x-www-form-urlencoded` ContentType.
