### PR TITLE
Fix settings examples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -157,9 +157,9 @@ update_health_1: |-
 get_version_1: |-
   client.version()
 distinct_attribute_guide_1: |-
-  client.getIndex('jackets').settings({ distinctAttribute: 'product_id' })
+  client.getIndex('jackets').updateSettings({ distinctAttribute: 'product_id' })
 field_properties_guide_searchable_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
         searchableAttributes: [
             'uid',
             'movie_id',
@@ -171,7 +171,7 @@ field_properties_guide_searchable_1: |-
         ]
     })
 field_properties_guide_displayed_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
       displayedAttributes: [
           'title',
           'description',
@@ -234,13 +234,13 @@ search_parameter_guide_matches_1: |-
     matches: true
   })
 settings_guide_synonyms_1: |-
-  client.getIndex('tops').settings({
+  client.getIndex('tops').updateSettings({
     synonyms: {
       sweater: ['jumper'],
       jumper: ['sweater']
   })
 settings_guide_stop_words_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
     stopWords: [
       'the',
       'a',
@@ -248,7 +248,7 @@ settings_guide_stop_words_1: |-
     ]
   })
 settings_guide_ranking_rules_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
     rankingRules: [
         'typo',
         'words',
@@ -261,11 +261,11 @@ settings_guide_ranking_rules_1: |-
     ]
   })
 settings_guide_distinct_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
     distinctAttribute: 'product_id'
   })
 settings_guide_searchable_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
     searchableAttributes: [
       'uid',
       'movie_id',
@@ -277,7 +277,7 @@ settings_guide_searchable_1: |-
     ]
   })
 settings_guide_displayed_1: |-
-  client.getIndex('movies').settings({
+  client.getIndex('movies').updateSettings({
     displayedAttributes: [
       'title',
       'description',


### PR DESCRIPTION
Question @bidoubiwa:

Why are we using the global settings route to update one specific setting in most examples? It's a louder way to write it. 

Instead of only:
```js
client.getIndex('movies').updateDistinctAttribute('bla')
```
we have currently:
```js
client.getIndex('movies').updateSettings({ distinctAttribute: 'bla' })
```