### PR TITLE
MeiliSearch Bump to v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Output:
 
 This package is compatible with the following MeiliSearch versions:
 
+- `v0.14.X`
 - `v0.13.X`
 
 ## 🎬 Examples

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -113,8 +113,8 @@ describe.each([
       await expect(
         index.updateIndex({ primaryKey: 'newPrimaryKey' })
       ).rejects.toThrowError(
-        `The schema already have an primary key. It's impossible to update it`
-      ) // see issue in meilisearch/meilisearch
+        `A primary key is already present. It's impossible to update it`
+      )
     })
 
     test(`${permission} key: delete index`, async () => {


### PR DESCRIPTION
- Update compatibility in README.md
- Fixed error message failing test.
- Tested against [v0.14.0rc0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.14.0rc0)