### PR TITLE
replaced Object.fromEntries() to support node < v12.0

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,12 @@
-function removeUndefinedFromObject(obj: object): object {
-  // remove undefined
-  const cleaned = Object.entries(obj).filter((x) => x[1] !== undefined)
-  return Object.fromEntries(cleaned)
+/**
+ * Removes undefined entries from object
+ */
+function removeUndefinedFromObject(obj: Record<string, any>): object {
+  return Object.entries(obj).reduce((acc, curEntry) => {
+    const [key, val] = curEntry
+    if (val !== undefined) acc[key] = val
+    return acc
+  }, {} as Record<string, any>)
 }
 
 async function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
Hey, this is a pr for issue #581 
I used one reducer to get the job done instead of using the delete operator (which warns Injection sink) or piping from a filter.
I also changed the type of the `obj` from `object` to `Record`.