### PR TITLE
Change list order in params for faceted_search_update_settings_1

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -346,8 +346,8 @@ reset_attributes_for_faceting_1: |-
 faceted_search_update_settings_1: |-
   client.getIndex('movies')
     .updateAttributesForFaceting([
-      'genres',
-      'director'
+      'director',
+      'genres'
     ])
 faceted_search_facet_filters_1: |-
   client.getIndex('movies')


### PR DESCRIPTION
Just to keep documentation tidy, the list of parameters should have the same order in the different SDKs examples (using cURL as reference). :)

https://docs.meilisearch.com/guides/advanced_guides/settings.html#example-3