### PR TITLE
Update tests for MeiliSearch v0.15.0

### DIFF
--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -144,7 +144,7 @@ describe.each([
         client.createIndex(uidAndPrimaryKey.uid, {
           primaryKey: uidAndPrimaryKey.primaryKey,
         })
-      ).rejects.toThrowError(`index already exists`)
+      ).rejects.toThrowError(`Index ${uidAndPrimaryKey.uid} already exists`)
     })
 
     test(`${permission} key: delete index with uid that does not exist should fail`, async () => {

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -402,7 +402,7 @@ describe.each([
         })
     })
 
-    test(`${permission} key: ${method} search with multiple facetFilters and placeholder search`, async () => {
+    test(`${permission} key: ${method} search with multiple facetFilters and undefined query (placeholder)`, async () => {
       await client
         .getIndex(index.uid)
         .search(
@@ -421,11 +421,30 @@ describe.each([
         })
     })
 
-    test(`${permission} key: ${method} search with multiple facetFilters and placeholder search`, async () => {
+    test(`${permission} key: ${method} search with multiple facetFilters and null query (placeholder)`, async () => {
       await client
         .getIndex(index.uid)
         .search(
           null,
+          {
+            facetFilters: ['genre:fantasy'],
+            facetsDistribution: ['genre'],
+          },
+          method
+        )
+        .then((response) => {
+          expect(response).toHaveProperty('facetsDistribution', {
+            genre: { adventure: 0, fantasy: 2, romance: 0, 'sci fi': 0 },
+          })
+          expect(response.hits.length).toEqual(2)
+        })
+    })
+
+    test(`${permission} key: ${method} search with multiple facetFilters and empty query (placeholder)`, async () => {
+      await client
+        .getIndex(index.uid)
+        .search(
+          '',
           {
             facetFilters: ['genre:fantasy'],
             facetsDistribution: ['genre'],

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -440,7 +440,7 @@ describe.each([
         })
     })
 
-    test(`${permission} key: ${method} search with multiple facetFilters and empty query (placeholder)`, async () => {
+    test(`${permission} key: ${method} search with multiple facetFilters and empty string query (placeholder)`, async () => {
       await client
         .getIndex(index.uid)
         .search(


### PR DESCRIPTION
Update tests and add a test for the placeholder when the query is empty.

This PR:
- fails in this CI because the MeiliSearch's release v0.15.0 is not out
- should work locally with the [prerelease v0.15.0rc2](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0rc2)