### PR TITLE
Resolve path removal of host url

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -7,8 +7,7 @@ import {
 
 class HttpRequests {
   headers: {}
-  baseUrl: string
-  url: URL
+  url: string
 
   constructor(config: Types.Config) {
     this.headers = {
@@ -16,8 +15,7 @@ class HttpRequests {
       'Content-Type': 'application/json',
       ...(config.apiKey ? { 'X-Meili-API-Key': config.apiKey } : {}),
     }
-    this.baseUrl = config.host
-    this.url = new URL(this.baseUrl)
+    this.url = config.host
   }
 
   async request({
@@ -34,7 +32,9 @@ class HttpRequests {
     config?: Request
   }) {
     try {
-      const constructURL = new URL(url, this.url)
+      const constructURL = new URL(this.url)
+      constructURL.pathname = constructURL.pathname + url
+
       if (params) {
         const queryParams = new URLSearchParams()
         Object.keys(params)
@@ -42,6 +42,7 @@ class HttpRequests {
           .map((x: string) => queryParams.set(x, params[x]))
         constructURL.search = queryParams.toString()
       }
+
       const response: Response = await fetch(constructURL.toString(), {
         ...config,
         method,

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -37,6 +37,31 @@ describe.each([
     const health = await client.isHealthy()
     expect(health).toBe(true)
   })
+
+  test(`${permission} key: Client handles host URL with domain and path`, () => {
+    const customHost = `${config.host}/api`
+    const client = new MeiliSearch({
+      host: customHost,
+      apiKey: key,
+    })
+    expect(client.config.host).toBe(customHost)
+    expect(client.httpRequest.url).toBe(customHost)
+  })
+
+  test(`${permission} key: Client uses complete URL with domain and additionnal path in MeiliSearch call`, async () => {
+    try {
+      const customHost = `${config.host}/api`
+      const client = new MeiliSearch({
+        host: customHost,
+        apiKey: key,
+      })
+      const health = await client.isHealthy()
+      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+    } catch (e) {
+      expect(e.type).toBe('MeiliSearchCommunicationError')
+      expect(e.message).toBe('Not Found') // Expect 404 because host does not exist
+    }
+  })
 })
 
 describe.each([


### PR DESCRIPTION
In this PR we resolve a problem that has been explained on slack where if the host URL had a path ( domain + slash something ) the package would ignore the path and just keep the domain.

Tests have been added to ensure this will not happen again