### PR TITLE
Fixing documentation example issue, related to attribute `attributesToHighlight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ const search = await index.search('prince')
 All the supported options are described in [this documentation section](https://docs.meilisearch.com/references/search.html#search-in-an-index).
 
 ```javascript
-await index.search('prince', { limit: 1, attributesToHighlight: '*' })
+await index.search('prince', { limit: 1, attributesToHighlight: ['*'] })
 ```
 
 ```json


### PR DESCRIPTION
According to MeiliSearch Documentation v0.15, the value of the attribute `attributesToHighlight` should take an array of string.

However, current example inside the Readme.md file use value `'*'` instead of `['*']` and may be causing some misconfiguration  related to the search functionality. 