### PR TITLE
Fix the non-standard (V8) `captureStackTrace` method call in the custom error instance

### DIFF
--- a/src/errors/meilisearch-api-error.ts
+++ b/src/errors/meilisearch-api-error.ts
@@ -21,7 +21,10 @@ const MeiliSearchApiError: Types.MSApiErrorConstructor = class
     this.errorLink = error.errorLink
     this.message = error.message
     this.httpStatus = status
-    Error.captureStackTrace(this, MeiliSearchApiError)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MeiliSearchApiError)
+    }
   }
 }
 export default MeiliSearchApiError

--- a/src/errors/meilisearch-communication-error.ts
+++ b/src/errors/meilisearch-communication-error.ts
@@ -20,7 +20,9 @@ class MeiliSearchCommunicationError extends Error {
       this.code = body.code
     }
 
-    Error.captureStackTrace(this, MeiliSearchCommunicationError)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MeiliSearchCommunicationError)
+    }
   }
 }
 

--- a/src/errors/meilisearch-error.ts
+++ b/src/errors/meilisearch-error.ts
@@ -4,7 +4,10 @@ class MeiliSearchError extends Error {
     super(message)
     this.name = 'MeiliSearchError'
     this.type = 'MeiliSearchError'
-    Error.captureStackTrace(this, MeiliSearchError)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MeiliSearchError)
+    }
   }
 }
 

--- a/src/errors/meilisearch-timeout-error.ts
+++ b/src/errors/meilisearch-timeout-error.ts
@@ -4,7 +4,10 @@ class MeiliSearchTimeOutError extends Error {
     super(message)
     this.name = 'MeiliSearchTimeOutError'
     this.type = this.constructor.name
-    Error.captureStackTrace(this, MeiliSearchTimeOutError)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MeiliSearchTimeOutError)
+    }
   }
 }
 


### PR DESCRIPTION
This PR fix the non-standard (V8) `captureStackTrace` method call in the custom error instance.

Since the method `captureStackTrace` is non-standard, non V8 browsers (e.g., Safari) throws another error like: `Error.captureStackTrace is not a function. (In 'Error.captureStackTrace(_this, MeiliSearchCommunicationError)', 'Error.captureStackTrace' is undefined)`

_Links:_
[MDN | Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
