### PR TITLE
Fix `isHealthy` return value in maintenance mode

### DIFF
--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -103,7 +103,15 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   async isHealthy(): Promise<boolean> {
     const url = '/health'
 
-    return await this.httpRequest.get(url).then(() => true)
+    try {
+      await this.httpRequest.get(url)
+      return true
+    } catch (error) {
+      if (error.errorCode !== 'maintenance') {
+        throw error
+      }
+      return false
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fix the return value of the `isHealthy` method if the server is in maintenance mode ( unhealthy ).

I think the purpose of calling the `isHealthy` method should be to return `true`/`false` based on the state of the server.