### PR TITLE
Add ability to abort search request

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,27 @@ await index.search(null, {
 }
 ```
 
+#### Abortable Search
+
+You can abort a pending search request by providing an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to the request.
+
+```js
+const controller = new AbortController()
+
+index
+  .search('prince', {}, 'POST', {
+    signal: controller.signal,
+  })
+  .then((response) => {
+    /** ... */
+  })
+  .catch((e) => {
+    /** Catch AbortError here. */
+  })
+
+controller.abort()
+```
+
 ## ⚙️ Development Workflow and Contributing
 
 Any new contribution is more than welcome in this project!
@@ -348,7 +369,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Make a search request:
 
-`client.getIndex<T>('xxx').search(query: string, options: SearchParams = {}, method: 'POST' | 'GET' = 'POST'): Promise<SearchResponse<T>>`
+`client.getIndex<T>('xxx').search(query: string, options: SearchParams = {}, method: 'POST' | 'GET' = 'POST', config?: Partial<Request>): Promise<SearchResponse<T>>`
 
 ### Indexes <!-- omit in toc -->
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/prettier": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
+    "abort-controller": "^3.0.0",
     "brotli-size": "^4.0.0",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -29,7 +29,7 @@ class HttpRequests {
     url: string
     params?: { [key: string]: any }
     body?: any
-    config?: Request
+    config?: Partial<Request>
   }) {
     try {
       const constructURL = new URL(this.url)
@@ -64,19 +64,19 @@ class HttpRequests {
   async get(
     url: string,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<void>
 
   async get<T = any>(
     url: string,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<T>
 
   async get(
     url: string,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<any> {
     return await this.request({
       method: 'GET',
@@ -90,21 +90,21 @@ class HttpRequests {
     url: string,
     data: Types.IndexRequest,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<Types.IndexResponse>
 
   async post<T = any, R = Types.EnqueuedUpdate>(
     url: string,
     data?: T,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<R>
 
   async post(
     url: string,
     data?: any,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<any> {
     return await this.request({
       method: 'POST',
@@ -119,21 +119,21 @@ class HttpRequests {
     url: string,
     data: Types.IndexOptions | Types.IndexRequest,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<Types.IndexResponse>
 
   async put<T = any, R = Types.EnqueuedUpdate>(
     url: string,
     data?: T,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<R>
 
   async put(
     url: string,
     data?: any,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<any> {
     return await this.request({
       method: 'PUT',
@@ -148,19 +148,19 @@ class HttpRequests {
     url: string,
     data?: any,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<void>
   async delete<T>(
     url: string,
     data?: any,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<T>
   async delete(
     url: string,
     data?: any,
     params?: { [key: string]: any },
-    config?: Request
+    config?: Partial<Request>
   ): Promise<any> {
     return await this.request({
       method: 'DELETE',

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,8 @@ class Index<T> implements Types.IndexInterface<T> {
   async search<P extends Types.SearchParams<T>>(
     query?: string | null,
     options?: P,
-    method: Types.Methods = 'POST'
+    method: Types.Methods = 'POST',
+    config?: Partial<Request>
   ): Promise<Types.SearchResponse<T, P>> {
     const url = `/indexes/${this.uid}/search`
     const params: Types.SearchRequest = {
@@ -95,7 +96,12 @@ class Index<T> implements Types.IndexInterface<T> {
       attributesToHighlight: options?.attributesToHighlight,
     }
     if (method.toUpperCase() === 'POST') {
-      return await this.httpRequest.post(url, removeUndefinedFromObject(params))
+      return await this.httpRequest.post(
+        url,
+        removeUndefinedFromObject(params),
+        undefined,
+        config
+      )
     } else if (method.toUpperCase() === 'GET') {
       const getParams: Types.GetSearchRequest = {
         ...params,
@@ -119,7 +125,8 @@ class Index<T> implements Types.IndexInterface<T> {
 
       return await this.httpRequest.get<Types.SearchResponse<T, P>>(
         url,
-        removeUndefinedFromObject(getParams)
+        removeUndefinedFromObject(getParams),
+        config
       )
     } else {
       throw new MeiliSearchError(

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,7 +260,8 @@ export interface IndexInterface<T = any> {
   search: <P extends SearchParams<T>>(
     query?: string | null,
     options?: P,
-    method?: Methods
+    method?: Methods,
+    config?: Partial<Request>
   ) => Promise<SearchResponse<T, P>>
   show: () => Promise<IndexResponse>
   updateIndex: (indexData: IndexOptions) => Promise<IndexResponse>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,6 +1504,13 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-globals@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
@@ -2625,6 +2632,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 exec-sh@^0.3.2:
   version "0.3.4"


### PR DESCRIPTION
This PR adds the ability to insert additional config into the search request, e.g., `signal` to abort the request.

Resolve #630 