### PR TITLE
Update error handling in tests (message -> errorCode)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -355,4 +355,87 @@ export interface MSApiError extends Error {
   errorLink?: string
 }
 
+export const enum ErrorStatusCode {
+  /** @see https://docs.meilisearch.com/errors/#index_creation_failed */
+  INDEX_CREATION_FAILED = 'index_creation_failed',
+
+  /** @see https://docs.meilisearch.com/errors/#index_already_exists */
+  INDEX_ALREADY_EXISTS = 'index_already_exists',
+
+  /** @see https://docs.meilisearch.com/errors/#index_not_found */
+  INDEX_NOT_FOUND = 'index_not_found',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_index_uid */
+  INVALID_INDEX_UID = 'invalid_index_uid',
+
+  /** @see https://docs.meilisearch.com/errors/#index_not_accessible */
+  INDEX_NOT_ACCESSIBLE = 'index_not_accessible',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_state */
+  INVALID_STATE = 'invalid_state',
+
+  /** @see https://docs.meilisearch.com/errors/#missing_primary_key */
+  MISSING_PRIMARY_KEY = 'missing_primary_key',
+
+  /** @see https://docs.meilisearch.com/errors/#primary_key_already_present */
+  PRIMARY_KEY_ALREADY_PRESENT = 'primary_key_already_present',
+
+  /** @see https://docs.meilisearch.com/errors/#max_fields_limit_exceeded */
+  MAX_FIELDS_LIMIT_EXCEEDED = 'max_fields_limit_exceeded',
+
+  /** @see https://docs.meilisearch.com/errors/#missing_document_id */
+  MISSING_DOCUMENT_ID = 'missing_document_id',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_facet */
+  INVALID_FACET = 'invalid_facet',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_filter */
+  INVALID_FILTER = 'invalid_filter',
+
+  /** @see https://docs.meilisearch.com/errors/#bad_parameter */
+  BAD_PARAMETER = 'bad_parameter',
+
+  /** @see https://docs.meilisearch.com/errors/#bad_request */
+  BAD_REQUEST = 'bad_request',
+
+  /** @see https://docs.meilisearch.com/errors/#document_not_found */
+  DOCUMENT_NOT_FOUND = 'document_not_found',
+
+  /** @see https://docs.meilisearch.com/errors/#internal */
+  INTERNAL = 'internal',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_token */
+  INVALID_TOKEN = 'invalid_token',
+
+  /** @see https://docs.meilisearch.com/errors/#maintenance */
+  MAINTENANCE = 'maintenance',
+
+  /** @see https://docs.meilisearch.com/errors/#missing_authorization_header */
+  MISSING_AUTHORIZATION_HEADER = 'missing_authorization_header',
+
+  /** @see https://docs.meilisearch.com/errors/#missing_header */
+  MISSING_HEADER = 'missing_header',
+
+  /** @see https://docs.meilisearch.com/errors/#not_found */
+  NOT_FOUND = 'not_found',
+
+  /** @see https://docs.meilisearch.com/errors/#payload_too_large */
+  PAYLOAD_TOO_LARGE = 'payload_too_large',
+
+  /** @see https://docs.meilisearch.com/errors/#unretrievable_document */
+  UNRETRIEVABLE_DOCUMENT = 'unretrievable_document',
+
+  /** @see https://docs.meilisearch.com/errors/#search_error */
+  SEARCH_ERROR = 'search_error',
+
+  /** @see https://docs.meilisearch.com/errors/#unsupported_media_type */
+  UNSUPPORTED_MEDIA_TYPE = 'unsupported_media_type',
+
+  /** @see https://docs.meilisearch.com/errors/#dump_already_in_progress */
+  DUMP_ALREADY_IN_PROGRESS = 'dump_already_in_progress',
+
+  /** @see https://docs.meilisearch.com/errors/#dump_process_failed */
+  DUMP_PROCESS_FAILED = 'dump_process_failed',
+}
+
 export default MeiliSearch

--- a/tests/attributes_for_faceting_tests.ts
+++ b/tests/attributes_for_faceting_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -98,17 +97,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getAttributesForFaceting()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateAttributesForFaceting([])
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetAttributesForFaceting()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -123,17 +122,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getAttributesForFaceting()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateAttributesForFaceting([])
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset attributes for filtering and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetAttributesForFaceting()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/displayed_attributes_tests.ts
+++ b/tests/displayed_attributes_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -98,17 +97,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getDisplayedAttributes()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateDisplayedAttributes([])
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetDisplayedAttributes()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -123,17 +122,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getDisplayedAttributes()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateDisplayedAttributes([])
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset displayed attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetDisplayedAttributes()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/distinct_attribute_tests.ts
+++ b/tests/distinct_attribute_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -98,17 +97,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getDistinctAttribute()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateDistinctAttribute('title')
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetDistinctAttribute()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -123,17 +122,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getDistinctAttribute()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateDistinctAttribute('title')
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset distinct attribute and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetDistinctAttribute()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const uidNoPrimaryKey = {
@@ -350,12 +349,18 @@ describe.each([
   test(`${permission} key: Try to get deleted document from index that has NO primary key`, async () => {
     await expect(
       client.getIndex(uidNoPrimaryKey.uid).getDocument(1)
-    ).rejects.toThrowError('Document with id 1 not found')
+    ).rejects.toHaveProperty(
+      'errorCode',
+      Types.ErrorStatusCode.DOCUMENT_NOT_FOUND
+    )
   })
   test(`${permission} key: Try to get deleted document from index that has a primary key`, async () => {
     await expect(
       client.getIndex(uidAndPrimaryKey.uid).getDocument(1)
-    ).rejects.toThrowError('Document with id 1 not found')
+    ).rejects.toHaveProperty(
+      'errorCode',
+      Types.ErrorStatusCode.DOCUMENT_NOT_FOUND
+    )
   })
   test(`${permission} key: Add documents from index with no primary key by giving a primary key as parameter`, async () => {
     const docs = [
@@ -415,33 +420,39 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
   'Test on documents',
   ({ client, permission }) => {
     test(`${permission} key: Try to add documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
     test(`${permission} key: Try to update documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
     test(`${permission} key: Try to get documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
     test(`${permission} key: Try to delete one document and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
     test(`${permission} key: Try to delete some documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
     test(`${permission} key: Try to delete all documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
   }
@@ -451,33 +462,39 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
   'Test on documents',
   ({ client, permission }) => {
     test(`${permission} key: Try to add documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
     test(`${permission} key: Try to update documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
     test(`${permission} key: Try to get documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
     test(`${permission} key: Try to delete one document and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
     test(`${permission} key: Try to delete some documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
     test(`${permission} key: Try to delete all documents and be denied`, async () => {
-      await expect(client.listIndexes()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.listIndexes()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
   }

--- a/tests/dump_tests.ts
+++ b/tests/dump_tests.ts
@@ -1,3 +1,4 @@
+import * as Types from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -5,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 beforeAll(async () => {
@@ -36,14 +36,16 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
   'Test on dump with public api key should not have access',
   ({ client, permission }) => {
     test(`${permission} key: try to create dump with public key and be denied`, async () => {
-      await expect(client.createDump()).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.createDump()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
 
     test(`${permission} key: try to get dump status with public key and be denied`, async () => {
-      await expect(client.getDumpStatus('dumpUid')).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.getDumpStatus('dumpUid')).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
   }
@@ -53,14 +55,16 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
   'Test on dump without api key should not have access',
   ({ client, permission }) => {
     test(`${permission} key: try to create dump with no key and be denied`, async () => {
-      await expect(client.createDump()).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.createDump()).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
 
     test(`${permission} key: try to get dump status with no key and be denied`, async () => {
-      await expect(client.getDumpStatus('dumpUid')).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.getDumpStatus('dumpUid')).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
   }

--- a/tests/get_or_create_tests.ts
+++ b/tests/get_or_create_tests.ts
@@ -1,3 +1,4 @@
+import * as Types from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -5,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -51,8 +51,9 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
   'Test on getOrCreateIndex',
   ({ client, permission }) => {
     test(`${permission} key: try to getOrCreateIndex and be denied`, async () => {
-      await expect(client.getOrCreateIndex(index.uid)).rejects.toThrowError(
-        `Invalid API key: ${PUBLIC_KEY}`
+      await expect(client.getOrCreateIndex(index.uid)).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INVALID_TOKEN
       )
     })
   }
@@ -62,8 +63,9 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
   'Test on getOrCreateIndex',
   ({ client, permission }) => {
     test(`${permission} key: try to getOrCreateIndex and be denied`, async () => {
-      await expect(client.getOrCreateIndex(index.uid)).rejects.toThrowError(
-        `You must have an authorization token`
+      await expect(client.getOrCreateIndex(index.uid)).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
       )
     })
   }

--- a/tests/ranking_rules_tests.ts
+++ b/tests/ranking_rules_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -107,17 +106,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getRankingRules()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateRankingRules([])
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetRankingRules()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -132,17 +131,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getRankingRules()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateRankingRules([])
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset ranking rules and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetRankingRules()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -1,4 +1,4 @@
-import { EnqueuedUpdate, Methods } from '../src/types'
+import * as Types from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -70,8 +70,8 @@ describe.each([
   { client: publicClient, permission: 'Public' },
 ])('Test on search', ({ client, permission }) => {
   describe.each([
-    { method: 'POST' as Methods, permission, client },
-    { method: 'GET' as Methods, permission, client },
+    { method: 'POST' as Types.Methods, permission, client },
+    { method: 'GET' as Types.Methods, permission, client },
   ])('Test on search', ({ client, permission, method }) => {
     beforeAll(async () => {
       await clearAllIndexes(config)
@@ -81,7 +81,7 @@ describe.each([
       const { updateId: settingUpdateId } = await masterClient
         .getIndex(index.uid)
         .updateAttributesForFaceting(newAttributesForFaceting)
-        .then((response: EnqueuedUpdate) => {
+        .then((response: Types.EnqueuedUpdate) => {
           expect(response).toHaveProperty('updateId', expect.any(Number))
           return response
         })
@@ -481,7 +481,10 @@ describe.each([
       await masterClient.getIndex(index.uid).deleteIndex()
       await expect(
         client.getIndex(index.uid).search('prince', {}, method)
-      ).rejects.toThrowError(`Index movies_test not found`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INDEX_NOT_FOUND
+      )
     })
   })
 })
@@ -496,7 +499,10 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     test(`${permission} key: Try Basic search and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).search('prince')
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/searchable_attributes_tests.ts
+++ b/tests/searchable_attributes_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -98,17 +97,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSearchableAttributes()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSearchableAttributes([])
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSearchableAttributes()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -123,17 +122,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSearchableAttributes()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSearchableAttributes([])
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset searchable attributes and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSearchableAttributes()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -297,17 +296,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSettings()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSettings({})
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSettings()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -322,17 +321,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSettings()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSettings({})
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset settings and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSettings()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/stop_words_tests.ts
+++ b/tests/stop_words_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -98,17 +97,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getStopWords()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateStopWords([])
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetStopWords()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -123,17 +122,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getStopWords()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateStopWords([])
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset stop words and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetStopWords()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/synonyms_tests.ts
+++ b/tests/synonyms_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -100,17 +99,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: try to get synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSynonyms()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSynonyms({})
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSynonyms()
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -125,17 +124,26 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: try to get synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getSynonyms()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to update synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).updateSynonyms({})
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
     test(`${permission} key: try to reset synonyms and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).resetSynonyms()
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -1,4 +1,5 @@
-import { EnqueuedUpdate, Methods } from '../src/types'
+import * as Types from '../src/types'
+
 import {
   clearAllIndexes,
   config,
@@ -74,8 +75,8 @@ describe.each([
   { client: publicClient, permission: 'Public' },
 ])('Test on search', ({ client, permission }) => {
   describe.each([
-    { method: 'POST' as Methods, permission, client },
-    { method: 'GET' as Methods, permission, client },
+    { method: 'POST' as Types.Methods, permission, client },
+    { method: 'GET' as Types.Methods, permission, client },
   ])('Test on search', ({ client, permission, method }) => {
     beforeAll(async () => {
       await clearAllIndexes(config)
@@ -85,7 +86,7 @@ describe.each([
       const { updateId: settingUpdateId } = await masterClient
         .getIndex<Movie>(index.uid)
         .updateAttributesForFaceting(newAttributesForFaceting)
-        .then((response: EnqueuedUpdate) => {
+        .then((response: Types.EnqueuedUpdate) => {
           expect(response).toHaveProperty('updateId', expect.any(Number))
           return response
         })
@@ -467,7 +468,10 @@ describe.each([
       await masterClient.getIndex<Movie>(index.uid).deleteIndex()
       await expect(
         client.getIndex<Movie>(index.uid).search('prince')
-      ).rejects.toThrowError(`Index movies_test not found`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.INDEX_NOT_FOUND
+      )
     })
   })
 })
@@ -482,7 +486,10 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     test(`${permission} key: Try Basic search and be denied`, async () => {
       await expect(
         client.getIndex<Movie>(index.uid).search('prince')
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/update_tests.ts
+++ b/tests/update_tests.ts
@@ -6,7 +6,6 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
-  PUBLIC_KEY,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -84,7 +83,7 @@ describe.each([
   test(`${permission} key: Try to get update that does not exist`, async () => {
     await expect(
       client.getIndex(index.uid).getUpdateStatus(2545)
-    ).rejects.toThrowError(`Update 2545 not found`)
+    ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.NOT_FOUND)
   })
 })
 
@@ -98,7 +97,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     test(`${permission} key: Try to get a update and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getUpdateStatus(0)
-      ).rejects.toThrowError(`Invalid API key: ${PUBLIC_KEY}`)
+      ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
 )
@@ -113,7 +112,10 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     test(`${permission} key: Try to get an update and be denied`, async () => {
       await expect(
         client.getIndex(index.uid).getUpdateStatus(0)
-      ).rejects.toThrowError(`You must have an authorization token`)
+      ).rejects.toHaveProperty(
+        'errorCode',
+        Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
+      )
     })
   }
 )

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -71,8 +71,6 @@ describe.each([
       client
         .getIndex(index.uid)
         .waitForPendingUpdate(updateId, { timeOutMs: 0 })
-    ).rejects.toThrowError(
-      `timeout of 0ms has exceeded on process 0 when waiting for pending update to resolve.`
-    )
+    ).rejects.toHaveProperty('name', 'MeiliSearchTimeOutError')
   })
 })


### PR DESCRIPTION
This PR updates the error handling in tests, so that they do not rely on error messages anymore  and uses `errorCode` instead.

Resolve #623 