### PR TITLE
Change import to a more safe way

### DIFF
--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -1,4 +1,4 @@
-import 'abort-controller/polyfill'
+import AbortController from "abort-controller"
 
 import * as Types from '../src/types'
 import {

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -1,4 +1,4 @@
-import AbortController from "abort-controller"
+import AbortController from 'abort-controller'
 
 import * as Types from '../src/types'
 import {


### PR DESCRIPTION
Change the import of `abort-controller` library to a more safe way where only the needed variable is imported.