### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -153,7 +153,6 @@ get_indexes_stats_1: |-
   client.stats()
 get_health_1: |-
   client.isHealthy()
-update_health_1: |-
 get_version_1: |-
   client.version()
 distinct_attribute_guide_1: |-

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ controller.abort()
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## 💡 Learn More
 

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -107,45 +107,6 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     return await this.httpRequest.get(url).then(() => true)
   }
 
-  /**
-   * Change the healthyness to healthy
-   * @memberof MeiliSearch
-   * @method setHealthy
-   */
-  async setHealthy(): Promise<void> {
-    const url = '/health'
-
-    return await this.httpRequest.put(url, {
-      health: true,
-    })
-  }
-
-  /**
-   * Change the healthyness to unhealthy
-   * @memberof MeiliSearch
-   * @method setUnhealthy
-   */
-  async setUnhealthy(): Promise<void> {
-    const url = '/health'
-
-    return await this.httpRequest.put(url, {
-      health: false,
-    })
-  }
-
-  /**
-   * Set the healthyness to health value
-   * @memberof MeiliSearch
-   * @method changeHealthTo
-   */
-  async changeHealthTo(health: boolean): Promise<void> {
-    const url = '/health'
-
-    return await this.httpRequest.put(url, {
-      health,
-    })
-  }
-
   ///
   /// STATS
   ///

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,7 +175,7 @@ export interface Update {
 
 export interface EnqueuedDump {
   uid: string
-  status: 'processing' | 'dump_process_failed' | 'done'
+  status: 'in_progress' | 'failed' | 'done'
 }
 
 /*

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,9 +229,6 @@ export interface MeiliSearchInterface {
   createIndex: <T>(uid: string, options?: IndexOptions) => Promise<Index<T>>
   getKeys: () => Promise<Keys>
   isHealthy: () => Promise<true>
-  setHealthy: () => Promise<void>
-  setUnhealthy: () => Promise<void>
-  changeHealthTo: (health: boolean) => Promise<void>
   stats: () => Promise<Stats>
   version: () => Promise<Version>
   createDump: () => Promise<EnqueuedDump>

--- a/tests/dump_tests.ts
+++ b/tests/dump_tests.ts
@@ -19,7 +19,7 @@ describe.each([
   test(`${permission} key: create a new dump`, async () => {
     await client.createDump().then((response) => {
       expect(response.uid).toBeDefined()
-      expect(response.status).toEqual('processing')
+      expect(response.status).toEqual('in_progress')
     })
   })
 


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/52

- [x] Update README
- [x] Update dump status #669 
- [x] Remove the methods related to health update #670 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.