### PR TITLE
Fix docker run documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Each PR should pass the tests and the linter to be accepted.
 ```bash
 # Tests
 $ docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
-$ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics true
+$ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
 $ yarn test
 # Linter
 $ yarn style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Each PR should pass the tests and the linter to be accepted.
 ```bash
 # Tests
 $ docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
-$ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics
+$ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics true
 $ yarn test
 # Linter
 $ yarn style


### PR DESCRIPTION
Without this PR, meilisearch does not start and shows the following error message:

```
error: The argument '--no-analytics <no-analytics>' requires a value but none was supplied
```