### PR TITLE
Add pre release CI

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -25,3 +25,5 @@ replacers:
     replace: ''
   - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
     replace: ''
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,13 +1,12 @@
-name: Tests
+# Testing the code base against the MeiliSearch pre-releases
+name: Pre-Release Tests
 
+# Will only run for PRs and pushes to bump-meilisearch-v*
 on:
-  pull_request:
   push:
-    # trying and staging branches are for BORS config
-    branches:
-      - trying
-      - staging
-      - master
+    branches: bump-meilisearch-v*
+  pull_request:
+    branches: bump-meilisearch-v*
 
 jobs:
   integration_tests:
@@ -15,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node: [ '10', '12', '14' ]
-    name: integration-tests (Node.js ${{ matrix.node }})
+    name: integration-tests-against-rc (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
@@ -26,8 +25,10 @@ jobs:
         run: node -v
       - name: Install dependencies
         run: yarn --dev
-      - name: MeiliSearch setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
+      - name: Get the latest MeiliSearch RC
+        run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/master/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+      - name: MeiliSearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} ./meilisearch --master-key=masterKey --no-analytics=true
       - name: Run tests
         run: yarn test
       - name: Build project
@@ -40,15 +41,3 @@ jobs:
         run: yarn test:env:browser
       - name: Run node typescript env
         run: yarn test:env:node-ts
-
-  linter_check:
-    runs-on: ubuntu-latest
-    name: linter-check
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v1
-      - name: Install dependencies
-        run: yarn --dev
-      - name: Run style check
-        run: yarn style

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    # trying and staging branches are for BORS config
+    branches:
+      - trying
+      - staging
+      - master
+
+jobs:
+  integration_tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '10', '12', '14' ]
+    name: integration-tests (Node.js ${{ matrix.node }})
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: print version
+        run: node -v
+      - name: Install dependencies
+        run: yarn --dev
+      - name: MeiliSearch (latest) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
+      - name: Run tests
+        run: yarn test
+      - name: Build project
+        run: yarn build
+      - name: Run ESM env
+        run: yarn test:env:esm
+      - name: Run Node.js env
+        run: yarn test:env:nodejs
+      - name: Run Browser env
+        run: yarn test:env:browser
+      - name: Run node typescript env
+        run: yarn test:env:node-ts
+
+  linter_check:
+    runs-on: ubuntu-latest
+    name: linter-check
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+      - name: Install dependencies
+        run: yarn --dev
+      - name: Run style check
+        run: yarn style


### PR DESCRIPTION
Add CI for the pre-release PRs = PRs to `bump-meilisearch-v*` during the pre-release week of MeiliSearch. This CI will run the tests against the MeilliSearch RC instead of the MeiliSearch `latest`.

For each PR to `bump-meilisearch-v*`:
- the `linter-check` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will be skipped
- the required jobs (for merging) in the settings will be: `linter-check` and `integration-tests-against-rc`

For each **push** to `bump-meilisearch-v*`:
- the `linter-check` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `linter-check` and `integration-tests`

For any other event (PRs and pushes):
- the `linter-check` job will run
- the `integration-tests-against-rc` job will NOT run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `linter-check` and `integration-tests`

⚠️ Bors will not work when trying to merge a PR into `bump-meilisearch-v*` since we can not apply conditional jobs for merging with Bors. 