### PR TITLE
Remove jsnext main

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "browser": "./dist/bundles/meilisearch.umd.js",
   "typings": "./dist/types/types.d.ts",
   "types": "./dist/types/types.d.ts",
-  "jsnext:main": "./dist/bundles/meilisearch.esm.js",
   "sideEffects": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION

`jsnext:main` is deprecated: https://github.com/rollup/plugins/pull/81#issuecomment-562956077
Only rollup used to use it but rollup just decided to remove it as well: https://github.com/rollup/plugins/pull/85

Should be merged after: https://github.com/meilisearch/meilisearch-js/pull/709