### PR TITLE
Move jest timeout outside test

### DIFF
--- a/tests/env/express/jest.config.js
+++ b/tests/env/express/jest.config.js
@@ -1,4 +1,5 @@
 // jest.config.js
 module.exports = {
   preset: 'jest-puppeteer',
+  setupFilesAfterEnv: ['./jest.setup.js']
 }

--- a/tests/env/express/jest.setup.js
+++ b/tests/env/express/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000)

--- a/tests/env/express/tests/client.test.js
+++ b/tests/env/express/tests/client.test.js
@@ -8,5 +8,5 @@ describe('MeiliSearch JS Browser test', () => {
     await expect(
       page.content()
       ).resolves.toMatch('createdIndexTest')
-  }, 30000)
+  })
 })

--- a/tests/env/express/tests/client.test.js
+++ b/tests/env/express/tests/client.test.js
@@ -3,12 +3,10 @@ describe('MeiliSearch JS Browser test', () => {
     await page.goto('http://localhost:3000')
   })
 
-  jest.setTimeout(100 * 1000)
-
   it('Should have generated a meilisearch client and displayed', async () => {
     await page.waitForSelector("#indexes")
     await expect(
       page.content()
       ).resolves.toMatch('createdIndexTest')
-  }, 10000)
+  }, 30000)
 })

--- a/tests/env/express/tests/client.test.js
+++ b/tests/env/express/tests/client.test.js
@@ -3,8 +3,9 @@ describe('MeiliSearch JS Browser test', () => {
     await page.goto('http://localhost:3000')
   })
 
+  jest.setTimeout(100 * 1000)
+
   it('Should have generated a meilisearch client and displayed', async () => {
-    jest.setTimeout(100 * 1000)
     await page.waitForSelector("#indexes")
     await expect(
       page.content()


### PR DESCRIPTION
Because #713 also timeoud like usual I dig into the same problem again. 
I think maybe it is due to the fact that it is not the `tests` that timeout but the whole jest setup. 
So I tried following this stack overflow: 
https://stackoverflow.com/questions/49603939/message-async-callback-was-not-invoked-within-the-5000-ms-timeout-specified-by

who suggests the following: 
> But this would be specific to the test. Or you can set up the configuration file for the framework.
>
>Configuring Jest
>
>// jest.config.js
>module.exports = {
>  // setupTestFrameworkScriptFile has been deprecated in
>  // favor of setupFilesAfterEnv in jest 24
>  setupFilesAfterEnv: ['./jest.setup.js']
>}
>
>// jest.setup.js
>jest.setTimeout(30000)
