### PR TITLE
Implicit index creation

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.index('movies').getInfo()
+  client.index('movies').getRawInfo()
 list_all_indexes_1: |-
   client.listIndexes()
 create_an_index_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.getIndex('movies').show()
+  client.index('movies').show()
 list_all_indexes_1: |-
   client.listIndexes()
 create_an_index_1: |-
@@ -12,13 +12,13 @@ create_an_index_1: |-
 update_an_index_1: |-
   client.updateIndex('movies', { primaryKey: 'movie_review_id' })
 delete_an_index_1: |-
-  client.getIndex('movies').deleteIndex()
+  client.index('movies').deleteIndex()
 get_one_document_1: |-
   client.getDocument(25684)
 get_documents_1: |-
-  client.getIndex('movies').getDocuments({ limit: 2 })
+  client.index('movies').getDocuments({ limit: 2 })
 add_or_replace_documents_1: |-
-  client.getIndex('movies').addDocuments([{
+  client.index('movies').addDocuments([{
       id: 287947,
       title: 'Shazam',
       poster: 'https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg',
@@ -26,29 +26,29 @@ add_or_replace_documents_1: |-
       release_date: '2019-03-23'
   }])
 add_or_update_documents_1: |-
-  client.getIndex('movies').updateDocuments([{
+  client.index('movies').updateDocuments([{
       id: 287947,
       title: 'Shazam ⚡️',
       genres: 'comedy'
   }])
 delete_all_documents_1: |-
-  client.getIndex('movies').deleteAllDocuments()
+  client.index('movies').deleteAllDocuments()
 delete_one_document_1: |-
-  client.getIndex('movies').deleteDocument(25684)
+  client.index('movies').deleteDocument(25684)
 delete_documents_1: |-
-  client.getIndex('movies').deleteDocuments([23488, 153738, 437035, 363869])
+  client.index('movies').deleteDocuments([23488, 153738, 437035, 363869])
 search_1: |-
-  client.getIndex('movies').search('American ninja')
+  client.index('movies').search('American ninja')
 get_update_1: |-
-  client.getIndex('movies').getUpdateStatus(1)
+  client.index('movies').getUpdateStatus(1)
 get_all_updates_1: |-
-  client.getIndex('movies').getAllUpdateStatus()
+  client.index('movies').getAllUpdateStatus()
 get_keys_1: |-
   client.getKeys()
 get_settings_1: |-
-  client.getIndex('movies').getSettings()
+  client.index('movies').getSettings()
 update_settings_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
       rankingRules: [
           'typo',
           'words',
@@ -87,27 +87,27 @@ update_settings_1: |-
       }
   })
 reset_settings_1: |-
-  client.getIndex('movies').resetSettings()
+  client.index('movies').resetSettings()
 get_synonyms_1: |-
-  client.getIndex('movies').getSynonyms()
+  client.index('movies').getSynonyms()
 update_synonyms_1: |-
-  client.getIndex('movies').updateSynonym({
+  client.index('movies').updateSynonym({
     wolverine: ['xmen', 'logan'],
     logan: ['wolverine', 'xmen'],
     wow: ['world of warcraft']
   })
 reset_synonyms_1: |-
-  client.getIndex('movies').resetSynonym()
+  client.index('movies').resetSynonym()
 get_stop_words_1: |-
-  client.getIndex('movies').getStopWords()
+  client.index('movies').getStopWords()
 update_stop_words_1: |-
-  client.getIndex('movies').updateStopWords(['of', 'the', 'to'])
+  client.index('movies').updateStopWords(['of', 'the', 'to'])
 reset_stop_words_1: |-
-  client.getIndex('movies').resetStopWords()
+  client.index('movies').resetStopWords()
 get_ranking_rules_1: |-
-  client.getIndex('movies').getRankingRules()
+  client.index('movies').getRankingRules()
 update_ranking_rules_1: |-
-  client.getIndex('movies').updateRankingRules([
+  client.index('movies').updateRankingRules([
       'typo',
       'words',
       'proximity',
@@ -118,27 +118,27 @@ update_ranking_rules_1: |-
       'desc(rank)'
   ])
 reset_ranking_rules_1: |-
-  client.getIndex('movies').resetRankingRules()
+  client.index('movies').resetRankingRules()
 get_distinct_attribute_1: |-
-  client.getIndex('movies').getDistinctAttribute()
+  client.index('movies').getDistinctAttribute()
 update_distinct_attribute_1: |-
-  client.getIndex('movies').updateDistinctAttribute('movie_id')
+  client.index('movies').updateDistinctAttribute('movie_id')
 reset_distinct_attribute_1: |-
-  client.getIndex('movies').resetDistinctAttribute()
+  client.index('movies').resetDistinctAttribute()
 get_searchable_attributes_1: |-
-  client.getIndex('movies').getSearchableAttributes()
+  client.index('movies').getSearchableAttributes()
 update_searchable_attributes_1: |-
-  client.getIndex('movies').updateSearchableAttributes([
+  client.index('movies').updateSearchableAttributes([
       'title',
       'description',
       'uid'
   ])
 reset_searchable_attributes_1: |-
-  client.getIndex('movies').resetSearchableAttributes()
+  client.index('movies').resetSearchableAttributes()
 get_displayed_attributes_1: |-
-  client.getIndex('movies').getDisplayedAttributes()
+  client.index('movies').getDisplayedAttributes()
 update_displayed_attributes_1: |-
-  client.getIndex('movies').updateDisplayedAttributes([
+  client.index('movies').updateDisplayedAttributes([
       'title',
       'description',
       'release_date',
@@ -146,9 +146,9 @@ update_displayed_attributes_1: |-
       'poster'
   ])
 reset_displayed_attributes_1: |-
-  client.getIndex('movies').resetDisplayedAttributes()
+  client.index('movies').resetDisplayedAttributes()
 get_index_stats_1: |-
-  client.getIndex('movies').getStats()
+  client.index('movies').getStats()
 get_indexes_stats_1: |-
   client.stats()
 get_health_1: |-
@@ -156,9 +156,9 @@ get_health_1: |-
 get_version_1: |-
   client.version()
 distinct_attribute_guide_1: |-
-  client.getIndex('jackets').updateSettings({ distinctAttribute: 'product_id' })
+  client.index('jackets').updateSettings({ distinctAttribute: 'product_id' })
 field_properties_guide_searchable_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
         searchableAttributes: [
             'uid',
             'movie_id',
@@ -170,7 +170,7 @@ field_properties_guide_searchable_1: |-
         ]
     })
 field_properties_guide_displayed_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
       displayedAttributes: [
           'title',
           'description',
@@ -180,66 +180,66 @@ field_properties_guide_displayed_1: |-
       ]
   })
 filtering_guide_1: |-
-  client.getIndex('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     filters: 'release_date > 795484800'
   })
 filtering_guide_2: |-
-  client.getIndex('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     filters: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
   })
 filtering_guide_3: |-
-  client.getIndex('movies').search('horror', {
+  client.index('movies').search('horror', {
     filters: 'director = "Jordan Peele"'
   })
 filtering_guide_4: |-
-  client.getIndex('movies').search('Planet of the Apes', {
+  client.index('movies').search('Planet of the Apes', {
     filters: 'rating >= 3 AND (NOT director = "Tim Burton")'
   })
 search_parameter_guide_query_1: |-
-  client.getIndex('movies').search('shifu')
+  client.index('movies').search('shifu')
 search_parameter_guide_offset_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     offset: 1
   })
 search_parameter_guide_limit_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     limit: 2
   })
 search_parameter_guide_retrieve_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     attributesToRetrieve: ['overview', 'title']
   })
 search_parameter_guide_crop_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     attributesToCrop: ['overview'],
     cropLength: 10
   })
 search_parameter_guide_highlight_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     attributesToHighlight: ['overview']
   })
 search_parameter_guide_filter_1: |-
-  client.getIndex('movies').search('n', {
+  client.index('movies').search('n', {
     filters: 'title = Nightshift'
   })
 search_parameter_guide_filter_2: |-
-  client.getIndex('movies').search('n', {
+  client.index('movies').search('n', {
     filters: 'title="Kung Fu Panda"'
   })
 search_parameter_guide_matches_1: |-
-  client.getIndex('movies').search('n', {
+  client.index('movies').search('n', {
     filters: 'title="Kung Fu Panda"',
     attributesToHighlight: ['overview'],
     matches: true
   })
 settings_guide_synonyms_1: |-
-  client.getIndex('tops').updateSettings({
+  client.index('tops').updateSettings({
     synonyms: {
       sweater: ['jumper'],
       jumper: ['sweater']
   })
 settings_guide_stop_words_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
     stopWords: [
       'the',
       'a',
@@ -247,7 +247,7 @@ settings_guide_stop_words_1: |-
     ]
   })
 settings_guide_ranking_rules_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
     rankingRules: [
         'typo',
         'words',
@@ -260,11 +260,11 @@ settings_guide_ranking_rules_1: |-
     ]
   })
 settings_guide_distinct_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
     distinctAttribute: 'product_id'
   })
 settings_guide_searchable_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
     searchableAttributes: [
       'uid',
       'movie_id',
@@ -276,7 +276,7 @@ settings_guide_searchable_1: |-
     ]
   })
 settings_guide_displayed_1: |-
-  client.getIndex('movies').updateSettings({
+  client.index('movies').updateSettings({
     displayedAttributes: [
       'title',
       'description',
@@ -294,12 +294,12 @@ documents_guide_add_movie_1: |-
     "title": "Amelie Poulain"
   }])
 search_guide_1: |-
-  client.getIndex('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     limit: 5,
     offset: 10
   })
 search_guide_2: |-
-  client.getIndex('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     filters: 'release_date > 795484800',
   })
 getting_started_create_index_md: |-
@@ -333,33 +333,33 @@ getting_started_search_md: |-
 
   [About this package](https://github.com/meilisearch/meilisearch-js/)
 get_attributes_for_faceting_1: |-
-  client.getIndex('movies').getAttributesForFaceting()
+  client.index('movies').getAttributesForFaceting()
 update_attributes_for_faceting_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .updateAttributesForFaceting([
       'genres',
       'director'
     ])
 reset_attributes_for_faceting_1: |-
-  client.getIndex('movies').resetAttributesForFaceting()
+  client.index('movies').resetAttributesForFaceting()
 faceted_search_update_settings_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .updateAttributesForFaceting([
       'director',
       'genres'
     ])
 faceted_search_facet_filters_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .search('thriller', {
       facetFilters: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
     })
 faceted_search_facets_distribution_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .search('Batman', {
       facetsDistribution: ['genres']
     })
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .updateAttributesForFaceting([
       'director',
       'producer',
@@ -367,12 +367,12 @@ faceted_search_walkthrough_attributes_for_faceting_1: |-
       'production_companies'
     ])
 faceted_search_walkthrough_facet_filters_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .search('thriller', {
       facetFilters: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
     })
 faceted_search_walkthrough_facets_distribution_1: |-
-  client.getIndex('movies')
+  client.index('movies')
     .search('Batman', {
       facetsDistribution: ['genres']
     })

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.index('movies').show()
+  client.index('movies').getInfo()
 list_all_indexes_1: |-
   client.listIndexes()
 create_an_index_1: |-
@@ -12,7 +12,7 @@ create_an_index_1: |-
 update_an_index_1: |-
   client.updateIndex('movies', { primaryKey: 'movie_review_id' })
 delete_an_index_1: |-
-  client.index('movies').deleteIndex()
+  client.deleteIndex('movies')
 get_one_document_1: |-
   client.getDocument(25684)
 get_documents_1: |-

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Get Index information:
 
-`index.getInfo(): Promise<IndexResponse>`
+`index.getRawInfo(): Promise<IndexResponse>`
 
 - Update Index:
 

--- a/README.md
+++ b/README.md
@@ -326,11 +326,16 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Update Index:
 
-`index.update(data: IndexOptions): Promise<IndexResponse>`
+`client.updateIndex(uid): Promise<Index>`
+Or using the index object:
+`index.update(data: IndexOptions): Promise<Index>`
 
 - Delete Index:
 
+`client.deleteIndex(uid): Promise<void>`
+Or using the index object:
 `index.delete(): Promise<void>`
+
 
 - Get specific index stats
 
@@ -338,7 +343,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Return Index instance with updated information:
 
-`index.fetchInfo(): Promise<IndexResponse>`
+`index.fetchInfo(): Promise<Index>`
 
 - Get Primary Key of an Index:
 

--- a/README.md
+++ b/README.md
@@ -322,15 +322,15 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Get Index information:
 
-`index.show(): Promise<IndexResponse>`
+`index.getInfo(): Promise<IndexResponse>`
 
 - Update Index:
 
-`index.updateIndex(data: IndexOptions): Promise<IndexResponse>`
+`index.update(data: IndexOptions): Promise<IndexResponse>`
 
 - Delete Index:
 
-`index.deleteIndex(): Promise<void>`
+`index.delete(): Promise<void>`
 
 - Get specific index stats
 
@@ -342,7 +342,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Get Primary Key of an Index:
 
-`index.getPrimaryKey(): Promise<string | undefined>`
+`index.fetchPrimaryKey(): Promise<string | undefined>`
 
 ### Updates <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -308,11 +308,11 @@ If you want to know more about the development workflow or want to contribute, p
 
 `client.createIndex<T>(uid: string, options?: IndexOptions): Promise<Index<T>>`
 
-- Get index object:
+- Create a local reference to an index:
 
 `client.index<T>(uid: string): Index<T>`
 
-- Get an existing index and return an instance of Index:
+- Get an index:
 
 `client.getIndex<T>(uid: string): Index<T>`
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,8 @@ import MeiliSearch from 'meilisearch'
     apiKey: 'masterKey',
   })
 
-  const index = await client.createIndex('books') // If your index does not exist
-  // OR
-  const index = client.getIndex('books') // If your index exists
+  // An index is where the documents are stored.
+  const index = client.index('books') // If your index exists
 
   const documents = [
     { book_id: 123, title: 'Pride and Prejudice' },
@@ -139,7 +138,9 @@ import MeiliSearch from 'meilisearch'
     { book_id: 42, title: "The Hitchhiker's Guide to the Galaxy", genre: 'fantasy' }
   ]
 
+  // If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
   let response = await index.addDocuments(documents)
+
   console.log(response) // => { "updateId": 0 }
 })()
 ```
@@ -309,13 +310,17 @@ If you want to know more about the development workflow or want to contribute, p
 
 - Get index object:
 
+`client.index<T>(uid: string): Index<T>`
+
+- Get an existing index and return an instance of Index:
+
 `client.getIndex<T>(uid: string): Index<T>`
 
 - Get or create index if it does not exist
 
 `client.getOrCreateIndex<T>(uid: string, options?: IndexOptions): Promise<Index<T>>`
 
-- Show Index information:
+- Get Index information:
 
 `index.show(): Promise<IndexResponse>`
 
@@ -330,6 +335,14 @@ If you want to know more about the development workflow or want to contribute, p
 - Get specific index stats
 
 `index.getStats(): Promise<IndexStats>`
+
+- Return Index instance with updated information:
+
+`index.fetchInfo(): Promise<IndexResponse>`
+
+- Get Primary Key of an Index:
+
+`index.getPrimaryKey(): Promise<string | undefined>`
 
 ### Updates <!-- omit in toc -->
 

--- a/examples/node/search_example.js
+++ b/examples/node/search_example.js
@@ -20,7 +20,7 @@ const addDataset = async () => {
 
 ;(async () => {
   await addDataset()
-  const index = await client.getIndex('movies')
+  const index = await client.index('movies')
   const resp = await index.search('Avengers', {
     limit: 1,
     attributesToHighlight: ['title'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,9 +143,9 @@ class Index<T> implements Types.IndexInterface<T> {
   /**
    * Get index information.
    * @memberof Index
-   * @method getInfo
+   * @method getRawInfo
    */
-  async getInfo(): Promise<Types.IndexResponse> {
+  async getRawInfo(): Promise<Types.IndexResponse> {
     const url = `/indexes/${this.uid}`
 
     const res = await this.httpRequest.get<Types.IndexResponse>(url)
@@ -159,7 +159,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method fetchInfo
    */
   async fetchInfo(): Promise<this> {
-    await this.getInfo()
+    await this.getRawInfo()
     return this
   }
 
@@ -169,7 +169,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method fetchPrimaryKey
    */
   async fetchPrimaryKey(): Promise<string | undefined> {
-    this.primaryKey = (await this.getInfo()).primaryKey
+    this.primaryKey = (await this.getRawInfo()).primaryKey
     return this.primaryKey
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,11 +141,11 @@ class Index<T> implements Types.IndexInterface<T> {
   /// INDEX
   ///
   /**
-   * Show index information.
+   * Get index information.
    * @memberof Index
-   * @method show
+   * @method getInfo
    */
-  async show(): Promise<Types.IndexResponse> {
+  async getInfo(): Promise<Types.IndexResponse> {
     const url = `/indexes/${this.uid}`
 
     const res = await this.httpRequest.get<Types.IndexResponse>(url)
@@ -156,27 +156,27 @@ class Index<T> implements Types.IndexInterface<T> {
   /**
    * Fetch and update Index information.
    * @memberof Index
-   * @method show
+   * @method fetchInfo
    */
   async fetchInfo(): Promise<this> {
-    await this.show()
+    await this.getInfo()
     return this
   }
 
   /**
    * Get Primary Key.
    * @memberof Index
-   * @method getPrimaryKey
+   * @method fetchPrimaryKey
    */
-  async getPrimaryKey(): Promise<string | undefined> {
-    this.primaryKey = (await this.show()).primaryKey
+  async fetchPrimaryKey(): Promise<string | undefined> {
+    this.primaryKey = (await this.getInfo()).primaryKey
     return this.primaryKey
   }
 
   /**
-   * Update an index.
+   * Create an index.
    * @memberof Index
-   * @method updateIndex
+   * @method create
    */
   static async create<T = any>(
     config: Types.Config,
@@ -193,9 +193,9 @@ class Index<T> implements Types.IndexInterface<T> {
   /**
    * Update an index.
    * @memberof Index
-   * @method updateIndex
+   * @method update
    */
-  async updateIndex(data: Types.IndexOptions): Promise<Types.IndexResponse> {
+  async update(data: Types.IndexOptions): Promise<Types.IndexResponse> {
     const url = `/indexes/${this.uid}`
 
     const index = await this.httpRequest.put(url, data)
@@ -206,9 +206,9 @@ class Index<T> implements Types.IndexInterface<T> {
   /**
    * Delete an index.
    * @memberof Index
-   * @method deleteIndex
+   * @method delete
    */
-  async deleteIndex(): Promise<void> {
+  async delete(): Promise<void> {
     const url = `/indexes/${this.uid}`
 
     return await this.httpRequest.delete(url)

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,12 +195,12 @@ class Index<T> implements Types.IndexInterface<T> {
    * @memberof Index
    * @method update
    */
-  async update(data: Types.IndexOptions): Promise<Types.IndexResponse> {
+  async update(data: Types.IndexOptions): Promise<this> {
     const url = `/indexes/${this.uid}`
 
     const index = await this.httpRequest.put(url, data)
     this.primaryKey = index.primaryKey
-    return index
+    return this
   }
 
   /**

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -22,21 +22,22 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   }
 
   /**
-   * Return information about an existing Index
-   * @memberof MeiliSearch
-   * @method getIndex
-   */
-  async getIndex<T = any>(indexUid: string): Promise<Index<T>> {
-    return new Index<T>(this.config, indexUid).fetchInfo()
-  }
-
-  /**
    * Return an Index instance
    * @memberof MeiliSearch
    * @method index
    */
   index<T = any>(indexUid: string): Index<T> {
     return new Index<T>(this.config, indexUid)
+  }
+
+  /**
+   * Gather information about an index by calling MeiliSearch and
+   * return an Index instance with the gathered information
+   * @memberof MeiliSearch
+   * @method getIndex
+   */
+  async getIndex<T = any>(indexUid: string): Promise<Index<T>> {
+    return new Index<T>(this.config, indexUid).fetchInfo()
   }
 
   /**

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -33,7 +33,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   /**
    * Return an Index instance
    * @memberof MeiliSearch
-   * @method getIndex
+   * @method index
    */
   index<T = any>(indexUid: string): Index<T> {
     return new Index<T>(this.config, indexUid)
@@ -82,10 +82,27 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     return await Index.create<T>(this.config, uid, options)
   }
 
-    const index = await this.httpRequest.post(url, { ...options, uid })
-
-    return new Index(this.config, index.uid)
+  /**
+   * Update an index
+   * @memberof MeiliSearch
+   * @method updateIndex
+   */
+  async updateIndex<T = any>(
+    uid: string,
+    options: Types.IndexOptions = {}
+  ): Promise<Types.IndexResponse> {
+    return new Index<T>(this.config, uid).update(options)
   }
+
+  /**
+   * Delete an index
+   * @memberof MeiliSearch
+   * @method deleteIndex
+   */
+  async deleteIndex<T = any>(uid: string): Promise<void> {
+    return new Index<T>(this.config, uid).delete()
+  }
+
   ///
   /// KEYS
   ///

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -91,7 +91,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   async updateIndex<T = any>(
     uid: string,
     options: Types.IndexOptions = {}
-  ): Promise<Types.IndexResponse> {
+  ): Promise<Index<T>> {
     return new Index<T>(this.config, uid).update(options)
   }
 

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -22,11 +22,20 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   }
 
   /**
+   * Return information about an existing Index
+   * @memberof MeiliSearch
+   * @method getIndex
+   */
+  async getIndex<T = any>(indexUid: string): Promise<Index<T>> {
+    return new Index<T>(this.config, indexUid).fetchInfo()
+  }
+
+  /**
    * Return an Index instance
    * @memberof MeiliSearch
    * @method getIndex
    */
-  getIndex<T = any>(indexUid: string): Index<T> {
+  index<T = any>(indexUid: string): Index<T> {
     return new Index<T>(this.config, indexUid)
   }
 
@@ -40,11 +49,11 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     options: Types.IndexOptions = {}
   ): Promise<Index<T>> {
     try {
-      const index = await this.createIndex(uid, options)
+      const index = await this.getIndex(uid)
       return index
     } catch (e) {
-      if (e.errorCode === 'index_already_exists') {
-        return this.getIndex(uid)
+      if (e.errorCode === 'index_not_found') {
+        return this.createIndex(uid, options)
       }
       throw new MeiliSearchApiError(e, e.status)
     }
@@ -70,7 +79,8 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     uid: string,
     options: Types.IndexOptions = {}
   ): Promise<Index<T>> {
-    const url = '/indexes'
+    return await Index.create<T>(this.config, uid, options)
+  }
 
     const index = await this.httpRequest.post(url, { ...options, uid })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,7 +249,7 @@ export interface IndexInterface<T = any> {
     method?: Methods,
     config?: Partial<Request>
   ) => Promise<SearchResponse<T, P>>
-  getInfo: () => Promise<IndexResponse>
+  getRawInfo: () => Promise<IndexResponse>
   fetchInfo(): Promise<this>
   fetchPrimaryKey(): Promise<string | undefined>
   update: (indexData: IndexOptions) => Promise<IndexResponse>

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,7 +221,8 @@ export interface Version {
 
 export interface MeiliSearchInterface {
   config: Config
-  getIndex: <T>(indexUid: string) => Index<T>
+  getIndex: <T>(indexUid: string) => Promise<Index<T>>
+  index: <T>(indexUid: string) => Index<T>
   getOrCreateIndex: <T>(
     uid: string,
     options?: IndexOptions
@@ -249,6 +250,8 @@ export interface IndexInterface<T = any> {
     config?: Partial<Request>
   ) => Promise<SearchResponse<T, P>>
   show: () => Promise<IndexResponse>
+  fetchInfo(): Promise<this>
+  getPrimaryKey(): Promise<string | undefined>
   updateIndex: (indexData: IndexOptions) => Promise<IndexResponse>
   deleteIndex: () => Promise<void>
   getStats: () => Promise<IndexStats>

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,11 +249,11 @@ export interface IndexInterface<T = any> {
     method?: Methods,
     config?: Partial<Request>
   ) => Promise<SearchResponse<T, P>>
-  show: () => Promise<IndexResponse>
+  getInfo: () => Promise<IndexResponse>
   fetchInfo(): Promise<this>
-  getPrimaryKey(): Promise<string | undefined>
-  updateIndex: (indexData: IndexOptions) => Promise<IndexResponse>
-  deleteIndex: () => Promise<void>
+  fetchPrimaryKey(): Promise<string | undefined>
+  update: (indexData: IndexOptions) => Promise<IndexResponse>
+  delete: () => Promise<void>
   getStats: () => Promise<IndexStats>
   getDocuments: <P extends GetDocumentsParams<T>>(
     options?: P

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,11 @@ export interface MeiliSearchInterface {
   ) => Promise<Index<T>>
   listIndexes: () => Promise<IndexResponse[]>
   createIndex: <T>(uid: string, options?: IndexOptions) => Promise<Index<T>>
+  updateIndex: <T = any>(
+    uid: string,
+    options?: IndexOptions
+  ) => Promise<Index<T>>
+  deleteIndex: <T = any>(uid: string) => Promise<void>
   getKeys: () => Promise<Keys>
   isHealthy: () => Promise<true>
   stats: () => Promise<Stats>
@@ -252,7 +257,7 @@ export interface IndexInterface<T = any> {
   getRawInfo: () => Promise<IndexResponse>
   fetchInfo(): Promise<this>
   fetchPrimaryKey(): Promise<string | undefined>
-  update: (indexData: IndexOptions) => Promise<IndexResponse>
+  update: (indexData: IndexOptions) => Promise<this>
   delete: () => Promise<void>
   getStats: () => Promise<IndexStats>
   getDocuments: <P extends GetDocumentsParams<T>>(

--- a/tests/attributes_for_faceting_tests.ts
+++ b/tests/attributes_for_faceting_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await masterClient.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default attributes for filtering`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getAttributesForFaceting()
       .then((response: string[]) => {
         expect(response.sort()).toEqual([])
@@ -55,15 +55,15 @@ describe.each([
   test(`${permission} key: Update attributes for filtering`, async () => {
     const newAttributesForFaceting = ['genre']
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateAttributesForFaceting(newAttributesForFaceting)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getAttributesForFaceting()
       .then((response: string[]) => {
         expect(response).toEqual(newAttributesForFaceting)
@@ -71,15 +71,15 @@ describe.each([
   })
   test(`${permission} key: Reset attributes for filtering`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetAttributesForFaceting()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getAttributesForFaceting()
       .then((response: string[]) => {
         expect(response.sort()).toEqual([])
@@ -96,17 +96,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getAttributesForFaceting()
+        client.index(index.uid).getAttributesForFaceting()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateAttributesForFaceting([])
+        client.index(index.uid).updateAttributesForFaceting([])
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetAttributesForFaceting()
+        client.index(index.uid).resetAttributesForFaceting()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -121,7 +121,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getAttributesForFaceting()
+        client.index(index.uid).getAttributesForFaceting()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -129,7 +129,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateAttributesForFaceting([])
+        client.index(index.uid).updateAttributesForFaceting([])
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -137,7 +137,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset attributes for filtering and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetAttributesForFaceting()
+        client.index(index.uid).resetAttributesForFaceting()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/displayed_attributes_tests.ts
+++ b/tests/displayed_attributes_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default displayed attributes`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDisplayedAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(['*'])
@@ -55,15 +55,15 @@ describe.each([
   test(`${permission} key: Update displayed attributes`, async () => {
     const newDisplayedAttribute = ['title']
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateDisplayedAttributes(newDisplayedAttribute)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDisplayedAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(newDisplayedAttribute)
@@ -71,15 +71,15 @@ describe.each([
   })
   test(`${permission} key: Reset displayed attributes`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetDisplayedAttributes()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDisplayedAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(['*'])
@@ -96,17 +96,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getDisplayedAttributes()
+        client.index(index.uid).getDisplayedAttributes()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateDisplayedAttributes([])
+        client.index(index.uid).updateDisplayedAttributes([])
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetDisplayedAttributes()
+        client.index(index.uid).resetDisplayedAttributes()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -121,7 +121,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getDisplayedAttributes()
+        client.index(index.uid).getDisplayedAttributes()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -129,7 +129,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateDisplayedAttributes([])
+        client.index(index.uid).updateDisplayedAttributes([])
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -137,7 +137,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset displayed attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetDisplayedAttributes()
+        client.index(index.uid).resetDisplayedAttributes()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/distinct_attribute_tests.ts
+++ b/tests/distinct_attribute_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default distinct attribute`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDistinctAttribute()
       .then((response: string | null) => {
         expect(response).toEqual(null)
@@ -55,15 +55,15 @@ describe.each([
   test(`${permission} key: Update distinct attribute`, async () => {
     const newDistinctAttribute = 'title'
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateDistinctAttribute(newDistinctAttribute)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDistinctAttribute()
       .then((response: string | null) => {
         expect(response).toEqual(newDistinctAttribute)
@@ -71,15 +71,15 @@ describe.each([
   })
   test(`${permission} key: Reset distinct attribute`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetDistinctAttribute()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getDistinctAttribute()
       .then((response: string | null) => {
         expect(response).toEqual(null)
@@ -96,17 +96,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getDistinctAttribute()
+        client.index(index.uid).getDistinctAttribute()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateDistinctAttribute('title')
+        client.index(index.uid).updateDistinctAttribute('title')
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetDistinctAttribute()
+        client.index(index.uid).resetDistinctAttribute()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -121,7 +121,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getDistinctAttribute()
+        client.index(index.uid).getDistinctAttribute()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -129,7 +129,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateDistinctAttribute('title')
+        client.index(index.uid).updateDistinctAttribute('title')
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -137,7 +137,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset distinct attribute and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetDistinctAttribute()
+        client.index(index.uid).resetDistinctAttribute()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -48,27 +48,27 @@ describe.each([
   })
   test(`${permission} key: Add documents to uid with NO primary key`, async () => {
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Add documents to uid with primary key`, async () => {
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get documents with string attributesToRetrieve`, async () => {
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments({
         attributesToRetrieve: 'id',
       })
@@ -81,7 +81,7 @@ describe.each([
 
   test(`${permission} key: Get documents with array attributesToRetrieve`, async () => {
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments({
         attributesToRetrieve: ['id'],
       })
@@ -94,7 +94,7 @@ describe.each([
 
   test(`${permission} key: Get documents from index that has no primary key`, async () => {
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments({
         attributesToRetrieve: 'id',
       })
@@ -104,7 +104,7 @@ describe.each([
   })
   test(`${permission} key: Get documents from index that has a primary key`, async () => {
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length)
@@ -115,15 +115,15 @@ describe.each([
     const id = 2
     const title = 'The Red And The Black'
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .addDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
@@ -134,15 +134,15 @@ describe.each([
     const id = 2
     const title = 'The Red And The Black'
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .addDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
@@ -154,15 +154,15 @@ describe.each([
     const id = 456
     const title = 'The Little Prince'
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
@@ -173,15 +173,15 @@ describe.each([
     const id = 456
     const title = 'The Little Prince'
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
@@ -193,22 +193,22 @@ describe.each([
     const id = 9
     const title = '1984'
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
         expect(response).toHaveProperty('title', title)
       })
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length + 1)
@@ -218,22 +218,22 @@ describe.each([
     const id = 9
     const title = '1984'
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .updateDocuments([{ id, title }])
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocument(id)
       .then((response) => {
         expect(response).toHaveProperty('id', id)
         expect(response).toHaveProperty('title', title)
       })
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length + 1)
@@ -242,15 +242,15 @@ describe.each([
   test(`${permission} key: Delete a document from index that has NO primary key`, async () => {
     const id = 9
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .deleteDocument(id)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length)
@@ -259,15 +259,15 @@ describe.each([
   test(`${permission} key: Delete a document from index that has a primary key`, async () => {
     const id = 9
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .deleteDocument(id)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length)
@@ -277,15 +277,15 @@ describe.each([
   test(`${permission} key: Delete some documents from index that has NO primary key`, async () => {
     const ids = [1, 2]
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .deleteDocuments(ids)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length - 2)
@@ -297,15 +297,15 @@ describe.each([
   test(`${permission} key: Delete some documents from index that has a primary key`, async () => {
     const ids = [1, 2]
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .deleteDocuments(ids)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(dataset.length - 2)
@@ -316,15 +316,15 @@ describe.each([
   })
   test(`${permission} key: Delete all document from index that has NO primary key`, async () => {
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .deleteAllDocuments()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(0)
@@ -332,15 +332,15 @@ describe.each([
   })
   test(`${permission} key: Delete all document from index that has a primary key`, async () => {
     const { updateId } = await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .deleteAllDocuments()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidAndPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidAndPrimaryKey.uid)
+      .index(uidAndPrimaryKey.uid)
       .getDocuments()
       .then((response) => {
         expect(response.length).toEqual(0)
@@ -348,7 +348,7 @@ describe.each([
   })
   test(`${permission} key: Try to get deleted document from index that has NO primary key`, async () => {
     await expect(
-      client.getIndex(uidNoPrimaryKey.uid).getDocument(1)
+      client.index(uidNoPrimaryKey.uid).getDocument(1)
     ).rejects.toHaveProperty(
       'errorCode',
       Types.ErrorStatusCode.DOCUMENT_NOT_FOUND
@@ -356,7 +356,7 @@ describe.each([
   })
   test(`${permission} key: Try to get deleted document from index that has a primary key`, async () => {
     await expect(
-      client.getIndex(uidAndPrimaryKey.uid).getDocument(1)
+      client.index(uidAndPrimaryKey.uid).getDocument(1)
     ).rejects.toHaveProperty(
       'errorCode',
       Types.ErrorStatusCode.DOCUMENT_NOT_FOUND
@@ -375,15 +375,15 @@ describe.each([
       expect(response).toHaveProperty('uid', 'updateUid')
     })
     const { updateId } = await client
-      .getIndex('updateUid')
+      .index('updateUid')
       .addDocuments(docs, { primaryKey: 'unique' })
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex('updateUid').waitForPendingUpdate(updateId)
+    await client.index('updateUid').waitForPendingUpdate(updateId)
     await client
-      .getIndex('updateUid')
+      .index('updateUid')
       .show()
       .then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', 'updateUid')
@@ -398,15 +398,15 @@ describe.each([
       },
     ]
     const { updateId } = await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .addDocuments(docs)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
+    await client.index(uidNoPrimaryKey.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(uidNoPrimaryKey.uid)
+      .index(uidNoPrimaryKey.uid)
       .getAllUpdateStatus()
       .then((response: Types.Update[]) => {
         const lastUpdate = response[response.length - 1]

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -384,7 +384,7 @@ describe.each([
     await client.index('updateUid').waitForPendingUpdate(updateId)
     await client
       .index('updateUid')
-      .getInfo()
+      .getRawInfo()
       .then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', 'updateUid')
         expect(response).toHaveProperty('primaryKey', 'unique')

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -384,7 +384,7 @@ describe.each([
     await client.index('updateUid').waitForPendingUpdate(updateId)
     await client
       .index('updateUid')
-      .show()
+      .getInfo()
       .then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', 'updateUid')
         expect(response).toHaveProperty('primaryKey', 'unique')

--- a/tests/env/express/public/index.html
+++ b/tests/env/express/public/index.html
@@ -20,14 +20,14 @@
         apiKey: 'masterKey',
       })
       await client.getOrCreateIndex("createdIndexTest")
-      const index = await client.getIndex("createdIndexTest").show()
+      const index = await client.index("createdIndexTest").show()
       // Create dynamic element to wait on with puppeteer
       const newDiv = document.createElement("div");
       newDiv.setAttribute("id", "indexes");
       newDiv.innerHTML = index.uid
 
       document.body.insertBefore(newDiv, document.querySelector("#content"));
-      await client.getIndex("createdIndexTest").deleteIndex()
+      await client.index("createdIndexTest").deleteIndex()
     } catch(e) {
       console.error(e);
     }

--- a/tests/env/express/public/index.html
+++ b/tests/env/express/public/index.html
@@ -20,7 +20,7 @@
         apiKey: 'masterKey',
       })
       await client.getOrCreateIndex("createdIndexTest")
-      const index = await client.index("createdIndexTest").getInfo()
+      const index = await client.index("createdIndexTest").getRawInfo()
       // Create dynamic element to wait on with puppeteer
       const newDiv = document.createElement("div");
       newDiv.setAttribute("id", "indexes");

--- a/tests/env/express/public/index.html
+++ b/tests/env/express/public/index.html
@@ -20,14 +20,14 @@
         apiKey: 'masterKey',
       })
       await client.getOrCreateIndex("createdIndexTest")
-      const index = await client.index("createdIndexTest").show()
+      const index = await client.index("createdIndexTest").getInfo()
       // Create dynamic element to wait on with puppeteer
       const newDiv = document.createElement("div");
       newDiv.setAttribute("id", "indexes");
       newDiv.innerHTML = index.uid
 
       document.body.insertBefore(newDiv, document.querySelector("#content"));
-      await client.index("createdIndexTest").deleteIndex()
+      await client.index("createdIndexTest").delete()
     } catch(e) {
       console.error(e);
     }

--- a/tests/get_or_create_tests.ts
+++ b/tests/get_or_create_tests.ts
@@ -28,7 +28,7 @@ describe.each([
   test(`${permission} key: getOrCreateIndex without index created before`, async () => {
     const newIndex = await client.getOrCreateIndex(index.uid)
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.index(newIndex.uid).show()
+    const newIndexInfo = await client.index(newIndex.uid).getInfo()
     expect(newIndexInfo.primaryKey).toEqual(null)
   })
   test(`${permission} key: getOrCreateIndex on already existing index`, async () => {
@@ -42,7 +42,7 @@ describe.each([
       primaryKey: 'primaryKey',
     })
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.index(newIndex.uid).show()
+    const newIndexInfo = await client.index(newIndex.uid).getInfo()
     expect(newIndexInfo.primaryKey).toEqual('primaryKey')
   })
 })

--- a/tests/get_or_create_tests.ts
+++ b/tests/get_or_create_tests.ts
@@ -28,7 +28,7 @@ describe.each([
   test(`${permission} key: getOrCreateIndex without index created before`, async () => {
     const newIndex = await client.getOrCreateIndex(index.uid)
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.getIndex(newIndex.uid).show()
+    const newIndexInfo = await client.index(newIndex.uid).show()
     expect(newIndexInfo.primaryKey).toEqual(null)
   })
   test(`${permission} key: getOrCreateIndex on already existing index`, async () => {
@@ -42,7 +42,7 @@ describe.each([
       primaryKey: 'primaryKey',
     })
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.getIndex(newIndex.uid).show()
+    const newIndexInfo = await client.index(newIndex.uid).show()
     expect(newIndexInfo.primaryKey).toEqual('primaryKey')
   })
 })

--- a/tests/get_or_create_tests.ts
+++ b/tests/get_or_create_tests.ts
@@ -28,7 +28,7 @@ describe.each([
   test(`${permission} key: getOrCreateIndex without index created before`, async () => {
     const newIndex = await client.getOrCreateIndex(index.uid)
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.index(newIndex.uid).getInfo()
+    const newIndexInfo = await client.index(newIndex.uid).getRawInfo()
     expect(newIndexInfo.primaryKey).toEqual(null)
   })
   test(`${permission} key: getOrCreateIndex on already existing index`, async () => {
@@ -42,7 +42,7 @@ describe.each([
       primaryKey: 'primaryKey',
     })
     expect(newIndex.uid).toEqual(index.uid)
-    const newIndexInfo = await client.index(newIndex.uid).getInfo()
+    const newIndexInfo = await client.index(newIndex.uid).getRawInfo()
     expect(newIndexInfo.primaryKey).toEqual('primaryKey')
   })
 })

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -162,7 +162,7 @@ describe.each([
       const index = client.index(uidNoPrimaryKey.uid)
       await index
         .update({ primaryKey: 'newPrimaryKey' })
-        .then((response: Types.IndexResponse) => {
+        .then((response: Types.Index<any>) => {
           expect(response).toHaveProperty('uid', uidNoPrimaryKey.uid)
           expect(response).toHaveProperty('primaryKey', 'newPrimaryKey')
         })
@@ -172,7 +172,7 @@ describe.each([
       await client.createIndex('tempIndex')
       await client
         .updateIndex('tempIndex', { primaryKey: 'newPrimaryKey' })
-        .then((response: Types.IndexResponse) => {
+        .then((response: Types.Index<any>) => {
           expect(response).toHaveProperty('uid', 'tempIndex')
           expect(response).toHaveProperty('primaryKey', 'newPrimaryKey')
         })

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -43,7 +43,7 @@ describe.each([
 
       await client
         .index(uidNoPrimaryKey.uid)
-        .getInfo()
+        .getRawInfo()
         .then((response: Types.IndexResponse) => {
           expect(response).toHaveProperty('uid', uidNoPrimaryKey.uid)
           expect(response).toHaveProperty('primaryKey', null)
@@ -70,7 +70,7 @@ describe.each([
         })
       await client
         .index(uidAndPrimaryKey.uid)
-        .getInfo()
+        .getRawInfo()
         .then((response: Types.IndexResponse) => {
           expect(response).toHaveProperty(
             'primaryKey',
@@ -108,7 +108,7 @@ describe.each([
 
     test(`${permission} key: Get index info with primary key`, async () => {
       const index = client.index(uidAndPrimaryKey.uid)
-      await index.getInfo().then((response: Types.IndexResponse) => {
+      await index.getRawInfo().then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', uidAndPrimaryKey.uid)
         expect(response).toHaveProperty(
           'primaryKey',
@@ -119,7 +119,7 @@ describe.each([
 
     test(`${permission} key: Get index info with NO primary key`, async () => {
       const index = client.index(uidNoPrimaryKey.uid)
-      await index.getInfo().then((response: Types.IndexResponse) => {
+      await index.getRawInfo().then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', uidNoPrimaryKey.uid)
         expect(response).toHaveProperty('primaryKey', null)
       })
@@ -215,7 +215,7 @@ describe.each([
     })
     test(`${permission} key: fetch deleted index should fail`, async () => {
       const index = client.index(uidNoPrimaryKey.uid)
-      await expect(index.getInfo()).rejects.toHaveProperty(
+      await expect(index.getRawInfo()).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.INDEX_NOT_FOUND
       )
@@ -293,7 +293,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
       })
       test(`${permission} key: try to get index info and be denied`, async () => {
         await expect(
-          client.index(uidNoPrimaryKey.uid).getInfo()
+          client.index(uidNoPrimaryKey.uid).getRawInfo()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.INVALID_TOKEN
@@ -365,7 +365,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
       })
       test(`${permission} key: try to get index info and be denied`, async () => {
         await expect(
-          client.index(uidNoPrimaryKey.uid).getInfo()
+          client.index(uidNoPrimaryKey.uid).getRawInfo()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -41,7 +41,7 @@ describe.each([
       })
 
       await client
-        .getIndex(uidNoPrimaryKey.uid)
+        .index(uidNoPrimaryKey.uid)
         .show()
         .then((response: Types.IndexResponse) => {
           expect(response).toHaveProperty('uid', uidNoPrimaryKey.uid)
@@ -59,7 +59,7 @@ describe.each([
           expect(response).toHaveProperty('uid', uidAndPrimaryKey.uid)
         })
       await client
-        .getIndex(uidAndPrimaryKey.uid)
+        .index(uidAndPrimaryKey.uid)
         .show()
         .then((response: Types.IndexResponse) => {
           expect(response).toHaveProperty(
@@ -79,7 +79,7 @@ describe.each([
       })
     })
     test(`${permission} key: show index with primary key`, async () => {
-      const index = client.getIndex(uidAndPrimaryKey.uid)
+      const index = client.index(uidAndPrimaryKey.uid)
       await index.show().then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', uidAndPrimaryKey.uid)
         expect(response).toHaveProperty(
@@ -90,7 +90,7 @@ describe.each([
     })
 
     test(`${permission} key: show index with NO primary key`, async () => {
-      const index = client.getIndex(uidNoPrimaryKey.uid)
+      const index = client.index(uidNoPrimaryKey.uid)
       await index.show().then((response: Types.IndexResponse) => {
         expect(response).toHaveProperty('uid', uidNoPrimaryKey.uid)
         expect(response).toHaveProperty('primaryKey', null)
@@ -98,7 +98,7 @@ describe.each([
     })
 
     test(`${permission} key: update primary key on an index that has no primary key already`, async () => {
-      const index = client.getIndex(uidNoPrimaryKey.uid)
+      const index = client.index(uidNoPrimaryKey.uid)
       await index
         .updateIndex({ primaryKey: 'newPrimaryKey' })
         .then((response: Types.IndexResponse) => {
@@ -108,7 +108,7 @@ describe.each([
     })
 
     test(`${permission} key: update primary key on an index that has already a primary key and fail`, async () => {
-      const index = client.getIndex(uidAndPrimaryKey.uid)
+      const index = client.index(uidAndPrimaryKey.uid)
       await expect(
         index.updateIndex({ primaryKey: 'newPrimaryKey' })
       ).rejects.toHaveProperty(
@@ -118,7 +118,7 @@ describe.each([
     })
 
     test(`${permission} key: delete index`, async () => {
-      const index = client.getIndex(uidNoPrimaryKey.uid)
+      const index = client.index(uidNoPrimaryKey.uid)
       await index.deleteIndex().then((response: void) => {
         expect(response).toBe(undefined)
       })
@@ -133,7 +133,7 @@ describe.each([
       }
     })
     test(`${permission} key: show deleted index should fail`, async () => {
-      const index = client.getIndex(uidNoPrimaryKey.uid)
+      const index = client.index(uidNoPrimaryKey.uid)
       await expect(index.show()).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.INDEX_NOT_FOUND
@@ -152,7 +152,7 @@ describe.each([
     })
 
     test(`${permission} key: delete index with uid that does not exist should fail`, async () => {
-      const index = client.getIndex(uidNoPrimaryKey.uid)
+      const index = client.index(uidNoPrimaryKey.uid)
       await expect(index.deleteIndex()).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.INDEX_NOT_FOUND
@@ -212,7 +212,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
       })
       test(`${permission} key: try to get index info and be denied`, async () => {
         await expect(
-          client.getIndex(uidNoPrimaryKey.uid).show()
+          client.index(uidNoPrimaryKey.uid).show()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.INVALID_TOKEN
@@ -220,7 +220,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
       })
       test(`${permission} key: try to delete index and be denied`, async () => {
         await expect(
-          client.getIndex(uidAndPrimaryKey.uid).deleteIndex()
+          client.index(uidAndPrimaryKey.uid).deleteIndex()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.INVALID_TOKEN
@@ -229,7 +229,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
       test(`${permission} key: try to update index and be denied`, async () => {
         await expect(
           client
-            .getIndex(uidAndPrimaryKey.uid)
+            .index(uidAndPrimaryKey.uid)
             .updateIndex({ primaryKey: uidAndPrimaryKey.primaryKey })
         ).rejects.toHaveProperty(
           'errorCode',
@@ -284,7 +284,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
       })
       test(`${permission} key: try to get index info and be denied`, async () => {
         await expect(
-          client.getIndex(uidNoPrimaryKey.uid).show()
+          client.index(uidNoPrimaryKey.uid).show()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -292,7 +292,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
       })
       test(`${permission} key: try to delete index and be denied`, async () => {
         await expect(
-          client.getIndex(uidAndPrimaryKey.uid).deleteIndex()
+          client.index(uidAndPrimaryKey.uid).deleteIndex()
         ).rejects.toHaveProperty(
           'errorCode',
           Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -301,7 +301,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
       test(`${permission} key: try to update index and be denied`, async () => {
         await expect(
           client
-            .getIndex(uidAndPrimaryKey.uid)
+            .index(uidAndPrimaryKey.uid)
             .updateIndex({ primaryKey: uidAndPrimaryKey.primaryKey })
         ).rejects.toHaveProperty(
           'errorCode',

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -40,7 +40,7 @@ const clearAllIndexes = async (config: Types.Config): Promise<void> => {
 
   for (const indexUid of indexes) {
     await client
-      .getIndex(indexUid)
+      .index(indexUid)
       .deleteIndex()
       .catch((err) => {
         expect(err).toBe(null)

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -41,7 +41,7 @@ const clearAllIndexes = async (config: Types.Config): Promise<void> => {
   for (const indexUid of indexes) {
     await client
       .index(indexUid)
-      .deleteIndex()
+      .delete()
       .catch((err) => {
         expect(err).toBe(null)
       })

--- a/tests/ranking_rules_tests.ts
+++ b/tests/ranking_rules_tests.ts
@@ -49,13 +49,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default ranking rules`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getRankingRules()
       .then((response: string[]) => {
         expect(response).toEqual(defaultRankingRules)
@@ -64,15 +64,15 @@ describe.each([
   test(`${permission} key: Update ranking rules`, async () => {
     const newRankingRules = ['asc(title)', 'typo', 'desc(description)']
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateRankingRules(newRankingRules)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getRankingRules()
       .then((response: string[]) => {
         expect(response).toEqual(newRankingRules)
@@ -80,15 +80,15 @@ describe.each([
   })
   test(`${permission} key: Reset ranking rules`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetRankingRules()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getRankingRules()
       .then((response: string[]) => {
         expect(response).toEqual(defaultRankingRules)
@@ -105,17 +105,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getRankingRules()
+        client.index(index.uid).getRankingRules()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateRankingRules([])
+        client.index(index.uid).updateRankingRules([])
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetRankingRules()
+        client.index(index.uid).resetRankingRules()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -130,7 +130,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getRankingRules()
+        client.index(index.uid).getRankingRules()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -138,7 +138,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateRankingRules([])
+        client.index(index.uid).updateRankingRules([])
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -146,7 +146,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset ranking rules and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetRankingRules()
+        client.index(index.uid).resetRankingRules()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -87,9 +87,7 @@ describe.each([
           expect(response).toHaveProperty('updateId', expect.any(Number))
           return response
         })
-      await masterClient
-        .index(index.uid)
-        .waitForPendingUpdate(settingUpdateId)
+      await masterClient.index(index.uid).waitForPendingUpdate(settingUpdateId)
       const { updateId } = await masterClient
         .index(index.uid)
         .addDocuments(dataset)

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -81,23 +81,23 @@ describe.each([
       await masterClient.createIndex(emptyIndex.uid)
       const newAttributesForFaceting = ['genre']
       const { updateId: settingUpdateId } = await masterClient
-        .getIndex(index.uid)
+        .index(index.uid)
         .updateAttributesForFaceting(newAttributesForFaceting)
         .then((response: Types.EnqueuedUpdate) => {
           expect(response).toHaveProperty('updateId', expect.any(Number))
           return response
         })
       await masterClient
-        .getIndex(index.uid)
+        .index(index.uid)
         .waitForPendingUpdate(settingUpdateId)
       const { updateId } = await masterClient
-        .getIndex(index.uid)
+        .index(index.uid)
         .addDocuments(dataset)
-      await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+      await masterClient.index(index.uid).waitForPendingUpdate(updateId)
     })
     test(`${permission} key: Basic ${method} search`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search('prince', {}, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -114,7 +114,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with options`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search('prince', { limit: 1 }, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -131,7 +131,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with options`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search('prince', { limit: 1 }, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -147,7 +147,7 @@ describe.each([
     })
     test(`${permission} key: ${method} search with limit and offset`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'prince',
           {
@@ -178,7 +178,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with matches parameter and small croplength`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'prince',
           {
@@ -208,7 +208,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with all options but not all fields`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'prince',
           {
@@ -256,7 +256,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with all options and all fields`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'prince',
           {
@@ -298,7 +298,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with all options but specific fields`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'prince',
           {
@@ -348,7 +348,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with facetFilters and facetsDistribution`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'a',
           {
@@ -370,7 +370,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with facetFilters with spaces`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'h',
           {
@@ -386,7 +386,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           'a',
           {
@@ -408,7 +408,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters and undefined query (placeholder)`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           undefined,
           {
@@ -427,7 +427,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters and null query (placeholder)`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           null,
           {
@@ -447,7 +447,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters and empty string query (placeholder)`, async () => {
       await client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(
           '',
           {
@@ -466,7 +466,7 @@ describe.each([
 
     test(`${permission} key: ${method} search on index with no documents and no primary key`, async () => {
       await client
-        .getIndex(emptyIndex.uid)
+        .index(emptyIndex.uid)
         .search('prince', {}, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', [])
@@ -482,9 +482,9 @@ describe.each([
     })
 
     test(`${permission} key: Try to ${method} search on deleted index and fail`, async () => {
-      await masterClient.getIndex(index.uid).deleteIndex()
+      await masterClient.index(index.uid).deleteIndex()
       await expect(
-        client.getIndex(index.uid).search('prince', {}, method)
+        client.index(index.uid).search('prince', {}, method)
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.INDEX_NOT_FOUND
@@ -502,7 +502,7 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     })
     test(`${permission} key: Try Basic search and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).search('prince')
+        client.index(index.uid).search('prince')
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -532,7 +532,7 @@ describe.each([
       const controller = new AbortController()
 
       const searchPromise = client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search('unreachable', {}, method, {
           signal: controller.signal,
         })
@@ -552,25 +552,25 @@ describe.each([
       const searchQuery = 'prince'
 
       const searchAPromise = client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(searchQuery, {}, method, {
           signal: controllerA.signal,
         })
 
       const searchBPromise = client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(searchQuery, {}, method, {
           signal: controllerB.signal,
         })
 
       const searchCPromise = client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(searchQuery, {}, method, {
           signal: controllerC.signal,
         })
 
       const searchDPromise = client
-        .getIndex(index.uid)
+        .index(index.uid)
         .search(searchQuery, {}, method)
 
       controllerB.abort()

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -482,7 +482,7 @@ describe.each([
     })
 
     test(`${permission} key: Try to ${method} search on deleted index and fail`, async () => {
-      await masterClient.index(index.uid).deleteIndex()
+      await masterClient.index(index.uid).delete()
       await expect(
         client.index(index.uid).search('prince', {}, method)
       ).rejects.toHaveProperty(

--- a/tests/searchable_attributes_tests.ts
+++ b/tests/searchable_attributes_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await masterClient.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default searchable attributes`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSearchableAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(['*'])
@@ -55,15 +55,15 @@ describe.each([
   test(`${permission} key: Update searchable attributes`, async () => {
     const newSearchableAttributes = ['title']
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateSearchableAttributes(newSearchableAttributes)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSearchableAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(newSearchableAttributes)
@@ -71,15 +71,15 @@ describe.each([
   })
   test(`${permission} key: Reset searchable attributes`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetSearchableAttributes()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSearchableAttributes()
       .then((response: string[]) => {
         expect(response).toEqual(['*'])
@@ -96,17 +96,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSearchableAttributes()
+        client.index(index.uid).getSearchableAttributes()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSearchableAttributes([])
+        client.index(index.uid).updateSearchableAttributes([])
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSearchableAttributes()
+        client.index(index.uid).resetSearchableAttributes()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -121,7 +121,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSearchableAttributes()
+        client.index(index.uid).getSearchableAttributes()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -129,7 +129,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSearchableAttributes([])
+        client.index(index.uid).updateSearchableAttributes([])
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -137,7 +137,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset searchable attributes and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSearchableAttributes()
+        client.index(index.uid).resetSearchableAttributes()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -74,13 +74,13 @@ describe.each([
       primaryKey: indexAndPK.primaryKey,
     })
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await masterClient.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default settings of an index`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -94,7 +94,7 @@ describe.each([
 
   test(`${permission} key: Get default settings of empty index with primary key`, async () => {
     await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -114,15 +114,15 @@ describe.each([
       attributesForFaceting: [],
     }
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty(
@@ -147,15 +147,15 @@ describe.each([
       stopWords: ['the'],
     }
     const { updateId } = await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
+    await client.index(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty(
@@ -175,15 +175,15 @@ describe.each([
 
   test(`${permission} key: Reset settings`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetSettings()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -197,15 +197,15 @@ describe.each([
 
   test(`${permission} key: Reset settings of empty index`, async () => {
     const { updateId } = await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .resetSettings()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
+    await client.index(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -222,15 +222,15 @@ describe.each([
       searchableAttributes: ['title'],
     }
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -256,15 +256,15 @@ describe.each([
       searchableAttributes: ['title'],
     }
     const { updateId } = await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .updateSettings(newSettings)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(indexAndPK.uid).waitForPendingUpdate(updateId)
+    await client.index(indexAndPK.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(indexAndPK.uid)
+      .index(indexAndPK.uid)
       .getSettings()
       .then((response: Types.Settings) => {
         expect(response).toHaveProperty('rankingRules', defaultRankingRules)
@@ -295,17 +295,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSettings()
+        client.index(index.uid).getSettings()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSettings({})
+        client.index(index.uid).updateSettings({})
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSettings()
+        client.index(index.uid).resetSettings()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -320,7 +320,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSettings()
+        client.index(index.uid).getSettings()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -328,7 +328,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSettings({})
+        client.index(index.uid).updateSettings({})
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -336,7 +336,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset settings and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSettings()
+        client.index(index.uid).resetSettings()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/stop_words_tests.ts
+++ b/tests/stop_words_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await masterClient.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default stop words`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getStopWords()
       .then((response: string[]) => {
         expect(response).toEqual([])
@@ -55,15 +55,15 @@ describe.each([
   test(`${permission} key: Update stop words`, async () => {
     const newStopWords = ['the']
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateStopWords(newStopWords)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getStopWords()
       .then((response: string[]) => {
         expect(response).toEqual(newStopWords)
@@ -71,15 +71,15 @@ describe.each([
   })
   test(`${permission} key: Reset stop words`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetStopWords()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getStopWords()
       .then((response: string[]) => {
         expect(response).toEqual([])
@@ -96,17 +96,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getStopWords()
+        client.index(index.uid).getStopWords()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateStopWords([])
+        client.index(index.uid).updateStopWords([])
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetStopWords()
+        client.index(index.uid).resetStopWords()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -121,7 +121,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getStopWords()
+        client.index(index.uid).getStopWords()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -129,7 +129,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateStopWords([])
+        client.index(index.uid).updateStopWords([])
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -137,7 +137,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset stop words and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetStopWords()
+        client.index(index.uid).resetStopWords()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/synonyms_tests.ts
+++ b/tests/synonyms_tests.ts
@@ -40,13 +40,13 @@ describe.each([
     await clearAllIndexes(config)
     await masterClient.createIndex(index.uid)
     const { updateId } = await masterClient
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
-    await masterClient.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await masterClient.index(index.uid).waitForPendingUpdate(updateId)
   })
   test(`${permission} key: Get default synonyms`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSynonyms()
       .then((response: object) => {
         expect(response).toEqual({})
@@ -57,15 +57,15 @@ describe.each([
       hp: ['harry potter'],
     }
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .updateSynonyms(newSynonyms)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSynonyms()
       .then((response: object) => {
         expect(response).toEqual(newSynonyms)
@@ -73,15 +73,15 @@ describe.each([
   })
   test(`${permission} key: Reset synonyms`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .resetSynonyms()
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getSynonyms()
       .then((response: object) => {
         expect(response).toEqual({})
@@ -98,17 +98,17 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: try to get synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSynonyms()
+        client.index(index.uid).getSynonyms()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to update synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSynonyms({})
+        client.index(index.uid).updateSynonyms({})
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
     test(`${permission} key: try to reset synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSynonyms()
+        client.index(index.uid).resetSynonyms()
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -123,7 +123,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to get synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getSynonyms()
+        client.index(index.uid).getSynonyms()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -131,7 +131,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to update synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).updateSynonyms({})
+        client.index(index.uid).updateSynonyms({})
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -139,7 +139,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: try to reset synonyms and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).resetSynonyms()
+        client.index(index.uid).resetSynonyms()
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -84,25 +84,25 @@ describe.each([
       await masterClient.createIndex(emptyIndex.uid)
       const newAttributesForFaceting = ['genre']
       const { updateId: settingUpdateId } = await masterClient
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .updateAttributesForFaceting(newAttributesForFaceting)
         .then((response: Types.EnqueuedUpdate) => {
           expect(response).toHaveProperty('updateId', expect.any(Number))
           return response
         })
       await masterClient
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .waitForPendingUpdate(settingUpdateId)
       const { updateId } = await masterClient
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .addDocuments(dataset)
       await masterClient
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .waitForPendingUpdate(updateId)
     })
     test(`${permission} key: Basic search`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search('prince', {}, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -119,7 +119,7 @@ describe.each([
 
     test(`${permission} key: Search with options`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search('prince', { limit: 1 }, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -136,7 +136,7 @@ describe.each([
 
     test(`${permission} key: Search with options`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search('prince', { limit: 1 }, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', expect.any(Array))
@@ -152,7 +152,7 @@ describe.each([
     })
     test(`${permission} key: Search with limit and offset`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'prince',
           {
@@ -183,7 +183,7 @@ describe.each([
 
     test(`${permission} key: Search with matches parameter and small croplength`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'prince',
           {
@@ -213,7 +213,7 @@ describe.each([
 
     test(`${permission} key: Search with all options but not all fields`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'prince',
           {
@@ -261,7 +261,7 @@ describe.each([
 
     test(`${permission} key: Search with all options and all fields`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'prince',
           {
@@ -303,7 +303,7 @@ describe.each([
 
     test(`${permission} key: Search with all options but specific fields`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'prince',
           {
@@ -353,7 +353,7 @@ describe.each([
 
     test(`${permission} key: Search with facetFilters and facetsDistribution`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'a',
           {
@@ -374,7 +374,7 @@ describe.each([
 
     test(`${permission} key: Search with facetFilters with spaces`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'h',
           {
@@ -390,7 +390,7 @@ describe.each([
 
     test(`${permission} key: Search with multiple facetFilters`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           'a',
           {
@@ -411,7 +411,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters and placeholder search`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           undefined,
           {
@@ -430,7 +430,7 @@ describe.each([
 
     test(`${permission} key: ${method} search with multiple facetFilters and placeholder search`, async () => {
       await client
-        .getIndex<Movie>(index.uid)
+        .index<Movie>(index.uid)
         .search(
           null,
           {
@@ -449,7 +449,7 @@ describe.each([
 
     test(`${permission} key: Search on index with no documents and no primary key`, async () => {
       await client
-        .getIndex(emptyIndex.uid)
+        .index(emptyIndex.uid)
         .search('prince', {}, method)
         .then((response) => {
           expect(response).toHaveProperty('hits', [])
@@ -465,9 +465,9 @@ describe.each([
     })
 
     test(`${permission} key: Try to Search on deleted index and fail`, async () => {
-      await masterClient.getIndex<Movie>(index.uid).deleteIndex()
+      await masterClient.index<Movie>(index.uid).deleteIndex()
       await expect(
-        client.getIndex<Movie>(index.uid).search('prince')
+        client.index<Movie>(index.uid).search('prince')
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.INDEX_NOT_FOUND
@@ -485,7 +485,7 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     })
     test(`${permission} key: Try Basic search and be denied`, async () => {
       await expect(
-        client.getIndex<Movie>(index.uid).search('prince')
+        client.index<Movie>(index.uid).search('prince')
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -96,9 +96,7 @@ describe.each([
       const { updateId } = await masterClient
         .index<Movie>(index.uid)
         .addDocuments(dataset)
-      await masterClient
-        .index<Movie>(index.uid)
-        .waitForPendingUpdate(updateId)
+      await masterClient.index<Movie>(index.uid).waitForPendingUpdate(updateId)
     })
     test(`${permission} key: Basic search`, async () => {
       await client

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -465,7 +465,7 @@ describe.each([
     })
 
     test(`${permission} key: Try to Search on deleted index and fail`, async () => {
-      await masterClient.index<Movie>(index.uid).deleteIndex()
+      await masterClient.index<Movie>(index.uid).delete()
       await expect(
         client.index<Movie>(index.uid).search('prince')
       ).rejects.toHaveProperty(

--- a/tests/update_tests.ts
+++ b/tests/update_tests.ts
@@ -42,15 +42,15 @@ describe.each([
   })
   test(`${permission} key: Get one update`, async () => {
     const { updateId } = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .addDocuments(dataset)
       .then((response: Types.EnqueuedUpdate) => {
         expect(response).toHaveProperty('updateId', expect.any(Number))
         return response
       })
-    await client.getIndex(index.uid).waitForPendingUpdate(updateId)
+    await client.index(index.uid).waitForPendingUpdate(updateId)
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getUpdateStatus(updateId)
       .then((response: Types.Update) => {
         expect(response).toHaveProperty('status', 'processed')
@@ -66,7 +66,7 @@ describe.each([
 
   test(`${permission} key: Get all updates`, async () => {
     await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .getAllUpdateStatus()
       .then((response: Types.Update[]) => {
         expect(response.length).toEqual(1)
@@ -82,7 +82,7 @@ describe.each([
   })
   test(`${permission} key: Try to get update that does not exist`, async () => {
     await expect(
-      client.getIndex(index.uid).getUpdateStatus(2545)
+      client.index(index.uid).getUpdateStatus(2545)
     ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.NOT_FOUND)
   })
 })
@@ -96,7 +96,7 @@ describe.each([{ client: publicClient, permission: 'Public' }])(
     })
     test(`${permission} key: Try to get a update and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getUpdateStatus(0)
+        client.index(index.uid).getUpdateStatus(0)
       ).rejects.toHaveProperty('errorCode', Types.ErrorStatusCode.INVALID_TOKEN)
     })
   }
@@ -111,7 +111,7 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
     test(`${permission} key: Try to get an update and be denied`, async () => {
       await expect(
-        client.getIndex(index.uid).getUpdateStatus(0)
+        client.index(index.uid).getUpdateStatus(0)
       ).rejects.toHaveProperty(
         'errorCode',
         Types.ErrorStatusCode.MISSING_AUTHORIZATION_HEADER

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -39,9 +39,7 @@ describe.each([
   })
   test(`${permission} key: Get WaitForPendingStatus until done and resolved`, async () => {
     const { updateId } = await client.index(index.uid).addDocuments(dataset)
-    const update = await client
-      .index(index.uid)
-      .waitForPendingUpdate(updateId)
+    const update = await client.index(index.uid).waitForPendingUpdate(updateId)
     expect(update).toHaveProperty('status', 'processed')
   })
   test(`${permission} key: Get WaitForPendingStatus with custom interval and timeout until done and resolved`, async () => {
@@ -68,9 +66,7 @@ describe.each([
   test(`${permission} key: Try to WaitForPendingStatus with small timeout and raise an error`, async () => {
     const { updateId } = await client.index(index.uid).addDocuments(dataset)
     await expect(
-      client
-        .index(index.uid)
-        .waitForPendingUpdate(updateId, { timeOutMs: 0 })
+      client.index(index.uid).waitForPendingUpdate(updateId, { timeOutMs: 0 })
     ).rejects.toHaveProperty('name', 'MeiliSearchTimeOutError')
   })
 })

--- a/tests/wait_for_pending_update_tests.ts
+++ b/tests/wait_for_pending_update_tests.ts
@@ -38,16 +38,16 @@ describe.each([
     await masterClient.createIndex(index.uid)
   })
   test(`${permission} key: Get WaitForPendingStatus until done and resolved`, async () => {
-    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const { updateId } = await client.index(index.uid).addDocuments(dataset)
     const update = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .waitForPendingUpdate(updateId)
     expect(update).toHaveProperty('status', 'processed')
   })
   test(`${permission} key: Get WaitForPendingStatus with custom interval and timeout until done and resolved`, async () => {
-    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const { updateId } = await client.index(index.uid).addDocuments(dataset)
     const update = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .waitForPendingUpdate(updateId, {
         timeOutMs: 6000,
         intervalMs: 100,
@@ -55,9 +55,9 @@ describe.each([
     expect(update).toHaveProperty('status', 'processed')
   })
   test(`${permission} key: Get WaitForPendingStatus with custom timeout and interval at 0 done and resolved`, async () => {
-    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const { updateId } = await client.index(index.uid).addDocuments(dataset)
     const update = await client
-      .getIndex(index.uid)
+      .index(index.uid)
       .waitForPendingUpdate(updateId, {
         timeOutMs: 6000,
         intervalMs: 0,
@@ -66,10 +66,10 @@ describe.each([
   })
 
   test(`${permission} key: Try to WaitForPendingStatus with small timeout and raise an error`, async () => {
-    const { updateId } = await client.getIndex(index.uid).addDocuments(dataset)
+    const { updateId } = await client.index(index.uid).addDocuments(dataset)
     await expect(
       client
-        .getIndex(index.uid)
+        .index(index.uid)
         .waitForPendingUpdate(updateId, { timeOutMs: 0 })
     ).rejects.toHaveProperty('name', 'MeiliSearchTimeOutError')
   })


### PR DESCRIPTION
This PR implements the following: 

## Breaking changes

- `client.getIndex()` is still usable as previously but now does an HTTP call
-  `client.getOrCreateIndex()` now does at least one HTTP call (and two sometimes)
- `index.show()` is now called `index.getRawInfo()`. 
- `index.updateIndex()` is now called `index.update`
- `index.update()` now returns an Index object instead of the JSON response of MeiliSearch
- `index.deleteIndex()` is now called `index.delete()`

## New

- `index.fetchInfo()` returns the same instance with updated information found in MeiliSearch
- `client.index()` return an index object
- `Static Index.create()` create an index in MeiliSearch
- `primaryKey` is now a parameter of an Index Object
- `client.updateIndex()` lets you update an index without having to use the Index class
- `client.deleteIndex()` lets you update an index without having to use the Index class


### Implementation
Adding the following methods 
in MeiliSearch: 
- `client.index` => no HTTP call returns an instance of Index
- `client.getIndex` => HTTP call, returns an instance of index

In Index:
- `index.fetchInfo` => HTTP call, return same instance but with updated info
- `index.fetchPrimaryKey` => HTTP call, updates the instance and returns the fetched primary key
- `STATIC Index.create` => HTTP call, creates an Index in MeiliSearch and returns an instance of Index()

Edit was done on the following methods/class: 
in MeiliSearch: 
- `client.getOrCreate()` => Now starts with a getIndex and if the index does not exists, creates one

In Index:
- Added PrimaryKey as a class parameter and a constructor parameter
- `index.updateIndex()` => Updates the primaryKey stored in the object instance

The `types.ts` was updated accordingly

### TESTS
- [x] Add tests for getPrimaryKey 
- [x] Add tests for client.getIndex()
- [x] Add tests for client.deleteIndex()
- [x] Add tests for client.updateIndex()
