### PR TITLE
Fix double slash error and refactor api routes

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -7,7 +7,7 @@ import {
 
 class HttpRequests {
   headers: {}
-  url: string
+  url: URL
 
   constructor(config: Types.Config) {
     this.headers = {
@@ -15,23 +15,14 @@ class HttpRequests {
       'Content-Type': 'application/json',
       ...(config.apiKey ? { 'X-Meili-API-Key': config.apiKey } : {}),
     }
-    this.url = config.host
+    this.url = new URL(config.host)
   }
-  static constructCorrectPath(pathname: string, url: string): string {
-    let slash = '/'
-    if (pathname.endsWith('/') || url.startsWith('/')) {
-      slash = ''
+
+  static addTrailingSlash(url: string): string {
+    if (!url.endsWith('/')) {
+      url = url + '/'
     }
-    if (pathname.endsWith('//')) {
-      pathname = pathname.substring(1)
-    }
-    if (url.endsWith('/')) {
-      url = url.slice(0, -1)
-    }
-    if (pathname.endsWith('/') && url.startsWith('/')) {
-      url = url.substring(1)
-    }
-    return pathname + slash + url
+    return url
   }
 
   async request({
@@ -48,11 +39,7 @@ class HttpRequests {
     config?: Partial<Request>
   }) {
     try {
-      const constructURL = new URL(this.url)
-      constructURL.pathname = HttpRequests.constructCorrectPath(
-        constructURL.pathname,
-        url
-      )
+      const constructURL = new URL(url, this.url)
       if (params) {
         const queryParams = new URLSearchParams()
         Object.keys(params)

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -20,7 +20,7 @@ class HttpRequests {
 
   static addTrailingSlash(url: string): string {
     if (!url.endsWith('/')) {
-      url = url + '/'
+      url += '/'
     }
     return url
   }

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -17,6 +17,22 @@ class HttpRequests {
     }
     this.url = config.host
   }
+  static constructCorrectPath(pathname: string, url: string): string {
+    let slash = '/'
+    if (pathname.endsWith('/') || url.startsWith('/')) {
+      slash = ''
+    }
+    if (pathname.endsWith('//')) {
+      pathname = pathname.substring(1)
+    }
+    if (url.endsWith('/')) {
+      url = url.slice(0, -1)
+    }
+    if (pathname.endsWith('/') && url.startsWith('/')) {
+      url = url.substring(1)
+    }
+    return pathname + slash + url
+  }
 
   async request({
     method,
@@ -33,8 +49,10 @@ class HttpRequests {
   }) {
     try {
       const constructURL = new URL(this.url)
-      constructURL.pathname = constructURL.pathname + url
-
+      constructURL.pathname = HttpRequests.constructCorrectPath(
+        constructURL.pathname,
+        url
+      )
       if (params) {
         const queryParams = new URLSearchParams()
         Object.keys(params)
@@ -42,7 +60,6 @@ class HttpRequests {
           .map((x: string) => queryParams.set(x, params[x]))
         constructURL.search = queryParams.toString()
       }
-
       const response: Response = await fetch(constructURL.toString(), {
         ...config,
         method,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,18 +29,20 @@ class Index<T> implements Types.IndexInterface<T> {
     [key: string]: createIndexPath
   } = {
     indexRoute: (indexUid: string) => {
-      return `${Index.apiRoutes.indexes}/${indexUid}/`
+      return `${Index.apiRoutes.indexes}/${indexUid}`
     },
     getUpdateStatus: (indexUid: string, updateId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `updates/${updateId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `updates/${updateId}`
       )
     },
     getAllUpdateStatus: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `updates`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `updates`
     },
     search: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `search`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `search`
     },
     getRawInfo: (indexUid: string) => {
       return `indexes/${indexUid}`
@@ -52,15 +54,17 @@ class Index<T> implements Types.IndexInterface<T> {
       return Index.routeConstructors.indexRoute(indexUid)
     },
     getStats: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `stats`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `stats`
     },
     getDocument: (indexUid: string, documentId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/${documentId}`
       )
     },
     getDocuments: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `documents`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `documents`
     },
     addDocuments: (indexUid: string) => {
       return Index.routeConstructors.getDocuments(indexUid)
@@ -73,16 +77,20 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     deleteDocument: (indexUid: string, documentId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/${documentId}`
       )
     },
     deleteDocuments: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/delete-batch`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/delete-batch`
       )
     },
     getSettings: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `settings`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `settings`
     },
     updateSettings: (indexUid: string) => {
       return Index.routeConstructors.getSettings(indexUid)
@@ -91,7 +99,9 @@ class Index<T> implements Types.IndexInterface<T> {
       return Index.routeConstructors.getSettings(indexUid)
     },
     getSynonyms: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `settings/synonyms`
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + '/' + `settings/synonyms`
+      )
     },
     updateSynonyms: (indexUid: string) => {
       return Index.routeConstructors.getSynonyms(indexUid)
@@ -101,7 +111,9 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     getStopWords: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `settings/stop-words`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `settings/stop-words`
       )
     },
     updateStopWords: (indexUid: string) => {
@@ -112,7 +124,9 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     getRankingRules: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `settings/ranking-rules`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `settings/ranking-rules`
       )
     },
     updateRankingRules: (indexUid: string) => {
@@ -124,6 +138,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getDistinctAttribute: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/distinct-attribute`
       )
     },
@@ -136,6 +151,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getAttributesForFaceting: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/attributes-for-faceting`
       )
     },
@@ -148,6 +164,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getSearchableAttributes: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/searchable-attributes`
       )
     },
@@ -160,6 +177,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getDisplayedAttributes: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/displayed-attributes`
       )
     },
@@ -175,6 +193,16 @@ class Index<T> implements Types.IndexInterface<T> {
     this.uid = uid
     this.primaryKey = primaryKey
     this.httpRequest = new HttpRequests(config)
+  }
+  ///
+  /// STATIC
+  ///
+
+  static getApiRoutes(): { [key: string]: string } {
+    return Index.apiRoutes
+  }
+  static getRouteConstructors(): { [key: string]: createIndexPath } {
+    return Index.routeConstructors
   }
 
   ///

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,7 +298,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getRawInfo(): Promise<Types.IndexResponse> {
     const url = Index.routeConstructors.indexRoute(this.uid)
-
     const res = await this.httpRequest.get<Types.IndexResponse>(url)
     this.primaryKey = res.primaryKey
     return res
@@ -335,7 +334,6 @@ class Index<T> implements Types.IndexInterface<T> {
     options: Types.IndexOptions = {}
   ): Promise<Index<T>> {
     const url = Index.apiRoutes.indexes
-
     const req = new HttpRequests(config)
     const index = await req.post(url, { ...options, uid })
     return new Index(config, uid, index.primaryKey)
@@ -348,7 +346,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async update(data: Types.IndexOptions): Promise<this> {
     const url = Index.routeConstructors.update(this.uid)
-
     const index = await this.httpRequest.put(url, data)
     this.primaryKey = index.primaryKey
     return this
@@ -361,7 +358,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async delete(): Promise<void> {
     const url = Index.routeConstructors.delete(this.uid)
-
     return await this.httpRequest.delete(url)
   }
 
@@ -376,7 +372,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getStats(): Promise<Types.IndexStats> {
     const url = `/indexes/${this.uid}/stats`
-
     return await this.httpRequest.get<Types.IndexStats>(url)
   }
   ///
@@ -410,7 +405,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getDocument(documentId: string | number): Promise<Types.Document<T>> {
     const url = Index.routeConstructors.getDocument(this.uid, documentId)
-
     return await this.httpRequest.get<Types.Document<T>>(url)
   }
 
@@ -424,7 +418,6 @@ class Index<T> implements Types.IndexInterface<T> {
     options?: Types.AddDocumentParams
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.addDocuments(this.uid)
-
     return await this.httpRequest.post(url, documents, options)
   }
 
@@ -438,7 +431,6 @@ class Index<T> implements Types.IndexInterface<T> {
     options?: Types.AddDocumentParams
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateDocuments(this.uid)
-
     return await this.httpRequest.put(url, documents, options)
   }
 
@@ -451,7 +443,6 @@ class Index<T> implements Types.IndexInterface<T> {
     documentId: string | number
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.deleteDocument(this.uid, documentId)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -475,7 +466,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async deleteAllDocuments(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.deleteAllDocuments(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -490,7 +480,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getSettings(): Promise<Types.Settings> {
     const url = Index.routeConstructors.getSettings(this.uid)
-
     return await this.httpRequest.get<Types.Settings>(url)
   }
 
@@ -504,7 +493,6 @@ class Index<T> implements Types.IndexInterface<T> {
     settings: Types.Settings
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateSettings(this.uid)
-
     return await this.httpRequest.post(url, settings)
   }
 
@@ -515,7 +503,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetSettings(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetSettings(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -530,7 +517,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getSynonyms(): Promise<object> {
     const url = Index.routeConstructors.getSynonyms(this.uid)
-
     return await this.httpRequest.get<object>(url)
   }
 
@@ -541,7 +527,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async updateSynonyms(synonyms: object): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateSynonyms(this.uid)
-
     return await this.httpRequest.post(url, synonyms)
   }
 
@@ -552,7 +537,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetSynonyms(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetSynonyms(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -567,7 +551,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getStopWords(): Promise<string[]> {
     const url = Index.routeConstructors.getStopWords(this.uid)
-
     return await this.httpRequest.get<string[]>(url)
   }
 
@@ -578,7 +561,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async updateStopWords(stopWords: string[]): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateStopWords(this.uid)
-
     return await this.httpRequest.post(url, stopWords)
   }
 
@@ -589,7 +571,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetStopWords(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetStopWords(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -604,7 +585,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getRankingRules(): Promise<string[]> {
     const url = Index.routeConstructors.getRankingRules(this.uid)
-
     return await this.httpRequest.get<string[]>(url)
   }
 
@@ -617,7 +597,6 @@ class Index<T> implements Types.IndexInterface<T> {
     rankingRules: string[]
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateRankingRules(this.uid)
-
     return await this.httpRequest.post(url, rankingRules)
   }
 
@@ -628,7 +607,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetRankingRules(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetRankingRules(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -643,7 +621,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getDistinctAttribute(): Promise<string | null> {
     const url = Index.routeConstructors.getDistinctAttribute(this.uid)
-
     return await this.httpRequest.get<string | null>(url)
   }
 
@@ -656,7 +633,6 @@ class Index<T> implements Types.IndexInterface<T> {
     distinctAttribute: string
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateDistinctAttribute(this.uid)
-
     return await this.httpRequest.post(url, distinctAttribute)
   }
 
@@ -667,7 +643,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetDistinctAttribute(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetDistinctAttribute(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -682,7 +657,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getAttributesForFaceting(): Promise<string[]> {
     const url = Index.routeConstructors.getAttributesForFaceting(this.uid)
-
     return await this.httpRequest.get<string[]>(url)
   }
 
@@ -695,7 +669,6 @@ class Index<T> implements Types.IndexInterface<T> {
     attributesForFaceting: string[]
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateAttributesForFaceting(this.uid)
-
     return await this.httpRequest.post(url, attributesForFaceting)
   }
 
@@ -706,7 +679,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetAttributesForFaceting(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetAttributesForFaceting(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -721,7 +693,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getSearchableAttributes(): Promise<string[]> {
     const url = Index.routeConstructors.getSearchableAttributes(this.uid)
-
     return await this.httpRequest.get<string[]>(url)
   }
 
@@ -734,7 +705,6 @@ class Index<T> implements Types.IndexInterface<T> {
     searchableAttributes: string[]
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateSearchableAttributes(this.uid)
-
     return await this.httpRequest.post(url, searchableAttributes)
   }
 
@@ -745,7 +715,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetSearchableAttributes(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetSearchableAttributes(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 
@@ -760,7 +729,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async getDisplayedAttributes(): Promise<string[]> {
     const url = Index.routeConstructors.getDisplayedAttributes(this.uid)
-
     return await this.httpRequest.get<string[]>(url)
   }
 
@@ -773,7 +741,6 @@ class Index<T> implements Types.IndexInterface<T> {
     displayedAttributes: string[]
   ): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.updateDisplayedAttributes(this.uid)
-
     return await this.httpRequest.post(url, displayedAttributes)
   }
 
@@ -784,7 +751,6 @@ class Index<T> implements Types.IndexInterface<T> {
    */
   async resetDisplayedAttributes(): Promise<Types.EnqueuedUpdate> {
     const url = Index.routeConstructors.resetDisplayedAttributes(this.uid)
-
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,163 @@ import * as Types from './types'
 import { sleep, removeUndefinedFromObject } from './utils'
 import HttpRequests from './http-requests'
 
+type objectId = string | number | undefined
+type createIndexPath = (indexUid: string, objectId?: objectId) => string
+
 class Index<T> implements Types.IndexInterface<T> {
   uid: string
   primaryKey: string | undefined
   httpRequest: HttpRequests
+  static apiRoutes: {
+    [key: string]: string
+  } = {
+    indexes: 'indexes',
+  }
+  static routeConstructors: {
+    [key: string]: createIndexPath
+  } = {
+    indexRoute: (indexUid: string) => {
+      return `${Index.apiRoutes.indexes}/${indexUid}/`
+    },
+    getUpdateStatus: (indexUid: string, updateId: objectId) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `updates/${updateId}`
+      )
+    },
+    getAllUpdateStatus: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `updates`
+    },
+    search: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `search`
+    },
+    getRawInfo: (indexUid: string) => {
+      return `indexes/${indexUid}`
+    },
+    update: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid)
+    },
+    delete: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid)
+    },
+    getStats: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `stats`
+    },
+    getDocument: (indexUid: string, documentId: objectId) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+      )
+    },
+    getDocuments: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `documents`
+    },
+    addDocuments: (indexUid: string) => {
+      return Index.routeConstructors.getDocuments(indexUid)
+    },
+    updateDocuments: (indexUid: string) => {
+      return Index.routeConstructors.getDocuments(indexUid)
+    },
+    deleteAllDocuments: (indexUid: string) => {
+      return Index.routeConstructors.getDocuments(indexUid)
+    },
+    deleteDocument: (indexUid: string, documentId: objectId) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+      )
+    },
+    deleteDocuments: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `documents/delete-batch`
+      )
+    },
+    getSettings: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `settings`
+    },
+    updateSettings: (indexUid: string) => {
+      return Index.routeConstructors.getSettings(indexUid)
+    },
+    resetSettings: (indexUid: string) => {
+      return Index.routeConstructors.getSettings(indexUid)
+    },
+    getSynonyms: (indexUid: string) => {
+      return Index.routeConstructors.indexRoute(indexUid) + `settings/synonyms`
+    },
+    updateSynonyms: (indexUid: string) => {
+      return Index.routeConstructors.getSynonyms(indexUid)
+    },
+    resetSynonyms: (indexUid: string) => {
+      return Index.routeConstructors.getSynonyms(indexUid)
+    },
+    getStopWords: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `settings/stop-words`
+      )
+    },
+    updateStopWords: (indexUid: string) => {
+      return Index.routeConstructors.getStopWords(indexUid)
+    },
+    resetStopWords: (indexUid: string) => {
+      return Index.routeConstructors.getStopWords(indexUid)
+    },
+    getRankingRules: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + `settings/ranking-rules`
+      )
+    },
+    updateRankingRules: (indexUid: string) => {
+      return Index.routeConstructors.getRankingRules(indexUid)
+    },
+    resetRankingRules: (indexUid: string) => {
+      return Index.routeConstructors.getRankingRules(indexUid)
+    },
+    getDistinctAttribute: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) +
+        `settings/distinct-attribute`
+      )
+    },
+    updateDistinctAttribute: (indexUid: string) => {
+      return Index.routeConstructors.getDistinctAttribute(indexUid)
+    },
+    resetDistinctAttribute: (indexUid: string) => {
+      return Index.routeConstructors.getDistinctAttribute(indexUid)
+    },
+    getAttributesForFaceting: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) +
+        `settings/attributes-for-faceting`
+      )
+    },
+    updateAttributesForFaceting: (indexUid: string) => {
+      return Index.routeConstructors.getAttributesForFaceting(indexUid)
+    },
+    resetAttributesForFaceting: (indexUid: string) => {
+      return Index.routeConstructors.getAttributesForFaceting(indexUid)
+    },
+    getSearchableAttributes: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) +
+        `settings/searchable-attributes`
+      )
+    },
+    updateSearchableAttributes: (indexUid: string) => {
+      return Index.routeConstructors.getSearchableAttributes(indexUid)
+    },
+    resetSearchableAttributes: (indexUid: string) => {
+      return Index.routeConstructors.getSearchableAttributes(indexUid)
+    },
+    getDisplayedAttributes: (indexUid: string) => {
+      return (
+        Index.routeConstructors.indexRoute(indexUid) +
+        `settings/displayed-attributes`
+      )
+    },
+    updateDisplayedAttributes: (indexUid: string) => {
+      return Index.routeConstructors.getDisplayedAttributes(indexUid)
+    },
+    resetDisplayedAttributes: (indexUid: string) => {
+      return Index.routeConstructors.getDisplayedAttributes(indexUid)
+    },
+  }
 
   constructor(config: Types.Config, uid: string, primaryKey?: string) {
     this.uid = uid
@@ -34,8 +187,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getUpdateStatus
    */
   async getUpdateStatus(updateId: number): Promise<Types.Update> {
-    const url = `/indexes/${this.uid}/updates/${updateId}`
-
+    const url = Index.routeConstructors.getUpdateStatus(this.uid, updateId)
     return await this.httpRequest.get<Types.Update>(url)
   }
 
@@ -63,8 +215,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getAllUpdateStatus
    */
   async getAllUpdateStatus(): Promise<Types.Update[]> {
-    const url = `/indexes/${this.uid}/updates`
-
+    const url = Index.routeConstructors.getAllUpdateStatus(this.uid)
     return await this.httpRequest.get<Types.Update[]>(url)
   }
 
@@ -83,7 +234,7 @@ class Index<T> implements Types.IndexInterface<T> {
     method: Types.Methods = 'POST',
     config?: Partial<Request>
   ): Promise<Types.SearchResponse<T, P>> {
-    const url = `/indexes/${this.uid}/search`
+    const url = Index.routeConstructors.search(this.uid)
     const params: Types.SearchRequest = {
       q: query,
       offset: options?.offset,
@@ -146,7 +297,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getRawInfo
    */
   async getRawInfo(): Promise<Types.IndexResponse> {
-    const url = `/indexes/${this.uid}`
+    const url = Index.routeConstructors.indexRoute(this.uid)
 
     const res = await this.httpRequest.get<Types.IndexResponse>(url)
     this.primaryKey = res.primaryKey
@@ -183,7 +334,7 @@ class Index<T> implements Types.IndexInterface<T> {
     uid: string,
     options: Types.IndexOptions = {}
   ): Promise<Index<T>> {
-    const url = '/indexes'
+    const url = Index.apiRoutes.indexes
 
     const req = new HttpRequests(config)
     const index = await req.post(url, { ...options, uid })
@@ -196,7 +347,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method update
    */
   async update(data: Types.IndexOptions): Promise<this> {
-    const url = `/indexes/${this.uid}`
+    const url = Index.routeConstructors.update(this.uid)
 
     const index = await this.httpRequest.put(url, data)
     this.primaryKey = index.primaryKey
@@ -209,7 +360,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method delete
    */
   async delete(): Promise<void> {
-    const url = `/indexes/${this.uid}`
+    const url = Index.routeConstructors.delete(this.uid)
 
     return await this.httpRequest.delete(url)
   }
@@ -240,7 +391,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async getDocuments<P extends Types.GetDocumentsParams<T>>(
     options?: P
   ): Promise<Types.GetDocumentsResponse<T, P>> {
-    const url = `/indexes/${this.uid}/documents`
+    const url = Index.routeConstructors.getDocuments(this.uid)
     let attr
     if (options !== undefined && Array.isArray(options.attributesToRetrieve)) {
       attr = options.attributesToRetrieve.join(',')
@@ -258,7 +409,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getDocument
    */
   async getDocument(documentId: string | number): Promise<Types.Document<T>> {
-    const url = `/indexes/${this.uid}/documents/${documentId}`
+    const url = Index.routeConstructors.getDocument(this.uid, documentId)
 
     return await this.httpRequest.get<Types.Document<T>>(url)
   }
@@ -272,7 +423,7 @@ class Index<T> implements Types.IndexInterface<T> {
     documents: Array<Types.Document<T>>,
     options?: Types.AddDocumentParams
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/documents`
+    const url = Index.routeConstructors.addDocuments(this.uid)
 
     return await this.httpRequest.post(url, documents, options)
   }
@@ -286,7 +437,7 @@ class Index<T> implements Types.IndexInterface<T> {
     documents: Array<Types.Document<T>>,
     options?: Types.AddDocumentParams
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/documents`
+    const url = Index.routeConstructors.updateDocuments(this.uid)
 
     return await this.httpRequest.put(url, documents, options)
   }
@@ -299,7 +450,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async deleteDocument(
     documentId: string | number
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/documents/${documentId}`
+    const url = Index.routeConstructors.deleteDocument(this.uid, documentId)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -312,7 +463,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async deleteDocuments(
     documentsIds: string[] | number[]
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/documents/delete-batch`
+    const url = Index.routeConstructors.deleteDocuments(this.uid)
 
     return await this.httpRequest.post(url, documentsIds)
   }
@@ -323,7 +474,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method deleteAllDocuments
    */
   async deleteAllDocuments(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/documents`
+    const url = Index.routeConstructors.deleteAllDocuments(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -338,7 +489,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getSettings
    */
   async getSettings(): Promise<Types.Settings> {
-    const url = `/indexes/${this.uid}/settings`
+    const url = Index.routeConstructors.getSettings(this.uid)
 
     return await this.httpRequest.get<Types.Settings>(url)
   }
@@ -352,7 +503,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateSettings(
     settings: Types.Settings
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings`
+    const url = Index.routeConstructors.updateSettings(this.uid)
 
     return await this.httpRequest.post(url, settings)
   }
@@ -363,7 +514,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetSettings
    */
   async resetSettings(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings`
+    const url = Index.routeConstructors.resetSettings(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -378,7 +529,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getSynonyms
    */
   async getSynonyms(): Promise<object> {
-    const url = `/indexes/${this.uid}/settings/synonyms`
+    const url = Index.routeConstructors.getSynonyms(this.uid)
 
     return await this.httpRequest.get<object>(url)
   }
@@ -389,7 +540,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method updateSynonyms
    */
   async updateSynonyms(synonyms: object): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/synonyms`
+    const url = Index.routeConstructors.updateSynonyms(this.uid)
 
     return await this.httpRequest.post(url, synonyms)
   }
@@ -400,7 +551,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetSynonyms
    */
   async resetSynonyms(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/synonyms`
+    const url = Index.routeConstructors.resetSynonyms(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -415,7 +566,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getStopWords
    */
   async getStopWords(): Promise<string[]> {
-    const url = `/indexes/${this.uid}/settings/stop-words`
+    const url = Index.routeConstructors.getStopWords(this.uid)
 
     return await this.httpRequest.get<string[]>(url)
   }
@@ -426,7 +577,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method updateStopWords
    */
   async updateStopWords(stopWords: string[]): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/stop-words`
+    const url = Index.routeConstructors.updateStopWords(this.uid)
 
     return await this.httpRequest.post(url, stopWords)
   }
@@ -437,7 +588,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetStopWords
    */
   async resetStopWords(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/stop-words`
+    const url = Index.routeConstructors.resetStopWords(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -452,7 +603,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getRankingRules
    */
   async getRankingRules(): Promise<string[]> {
-    const url = `/indexes/${this.uid}/settings/ranking-rules`
+    const url = Index.routeConstructors.getRankingRules(this.uid)
 
     return await this.httpRequest.get<string[]>(url)
   }
@@ -465,7 +616,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateRankingRules(
     rankingRules: string[]
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/ranking-rules`
+    const url = Index.routeConstructors.updateRankingRules(this.uid)
 
     return await this.httpRequest.post(url, rankingRules)
   }
@@ -476,7 +627,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetRankingRules
    */
   async resetRankingRules(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/ranking-rules`
+    const url = Index.routeConstructors.resetRankingRules(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -491,7 +642,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getDistinctAttribute
    */
   async getDistinctAttribute(): Promise<string | null> {
-    const url = `/indexes/${this.uid}/settings/distinct-attribute`
+    const url = Index.routeConstructors.getDistinctAttribute(this.uid)
 
     return await this.httpRequest.get<string | null>(url)
   }
@@ -504,7 +655,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateDistinctAttribute(
     distinctAttribute: string
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/distinct-attribute`
+    const url = Index.routeConstructors.updateDistinctAttribute(this.uid)
 
     return await this.httpRequest.post(url, distinctAttribute)
   }
@@ -515,7 +666,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetDistinctAttribute
    */
   async resetDistinctAttribute(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/distinct-attribute`
+    const url = Index.routeConstructors.resetDistinctAttribute(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -530,7 +681,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getAttributesForFaceting
    */
   async getAttributesForFaceting(): Promise<string[]> {
-    const url = `/indexes/${this.uid}/settings/attributes-for-faceting`
+    const url = Index.routeConstructors.getAttributesForFaceting(this.uid)
 
     return await this.httpRequest.get<string[]>(url)
   }
@@ -543,7 +694,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateAttributesForFaceting(
     attributesForFaceting: string[]
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/attributes-for-faceting`
+    const url = Index.routeConstructors.updateAttributesForFaceting(this.uid)
 
     return await this.httpRequest.post(url, attributesForFaceting)
   }
@@ -554,7 +705,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetAttributesForFaceting
    */
   async resetAttributesForFaceting(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/attributes-for-faceting`
+    const url = Index.routeConstructors.resetAttributesForFaceting(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -569,7 +720,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getSearchableAttributes
    */
   async getSearchableAttributes(): Promise<string[]> {
-    const url = `/indexes/${this.uid}/settings/searchable-attributes`
+    const url = Index.routeConstructors.getSearchableAttributes(this.uid)
 
     return await this.httpRequest.get<string[]>(url)
   }
@@ -582,7 +733,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateSearchableAttributes(
     searchableAttributes: string[]
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/searchable-attributes`
+    const url = Index.routeConstructors.updateSearchableAttributes(this.uid)
 
     return await this.httpRequest.post(url, searchableAttributes)
   }
@@ -593,7 +744,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetSearchableAttributes
    */
   async resetSearchableAttributes(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/searchable-attributes`
+    const url = Index.routeConstructors.resetSearchableAttributes(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }
@@ -608,7 +759,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method getDisplayedAttributes
    */
   async getDisplayedAttributes(): Promise<string[]> {
-    const url = `/indexes/${this.uid}/settings/displayed-attributes`
+    const url = Index.routeConstructors.getDisplayedAttributes(this.uid)
 
     return await this.httpRequest.get<string[]>(url)
   }
@@ -621,7 +772,7 @@ class Index<T> implements Types.IndexInterface<T> {
   async updateDisplayedAttributes(
     displayedAttributes: string[]
   ): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/displayed-attributes`
+    const url = Index.routeConstructors.updateDisplayedAttributes(this.uid)
 
     return await this.httpRequest.post(url, displayedAttributes)
   }
@@ -632,7 +783,7 @@ class Index<T> implements Types.IndexInterface<T> {
    * @method resetDisplayedAttributes
    */
   async resetDisplayedAttributes(): Promise<Types.EnqueuedUpdate> {
-    const url = `/indexes/${this.uid}/settings/displayed-attributes`
+    const url = Index.routeConstructors.resetDisplayedAttributes(this.uid)
 
     return await this.httpRequest.delete<Types.EnqueuedUpdate>(url)
   }

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -12,9 +12,28 @@ import MeiliSearchApiError from './errors/meilisearch-api-error'
 import * as Types from './types'
 import HttpRequests from './http-requests'
 
+type createPath = (x: string | number) => string
+
 class MeiliSearch implements Types.MeiliSearchInterface {
   config: Types.Config
   httpRequest: HttpRequests
+  static apiPaths: {
+    [key: string]: string
+  } = {
+    listIndexes: 'indexes',
+    getkeys: 'keys',
+    isHealthy: 'health',
+    stats: 'stats',
+    version: 'version',
+    createDump: 'dumps',
+  }
+  static apiPathConstructors: {
+    [key: string]: createPath
+  } = {
+    getDumpStatus: (dumpUid: string | number) => {
+      return `dumps/${dumpUid}/status`
+    },
+  }
 
   constructor(config: Types.Config) {
     this.config = config
@@ -66,8 +85,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method listIndexes
    */
   async listIndexes(): Promise<Types.IndexResponse[]> {
-    const url = '/indexes'
-
+    const url = MeiliSearch.apiPaths.listIndexes
     return await this.httpRequest.get<Types.IndexResponse[]>(url)
   }
 
@@ -114,8 +132,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getKey
    */
   async getKeys(): Promise<Types.Keys> {
-    const url = '/keys'
-
+    const url = MeiliSearch.apiPaths.getKeys
     return await this.httpRequest.get<Types.Keys>(url)
   }
 
@@ -130,9 +147,9 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method isHealthy
    */
   async isHealthy(): Promise<true> {
-    const url = '/health'
-
-    return await this.httpRequest.get(url).then(() => true)
+    return await this.httpRequest
+      .get(MeiliSearch.apiPaths.isHealthy)
+      .then(() => true)
   }
 
   ///
@@ -145,8 +162,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method stats
    */
   async stats(): Promise<Types.Stats> {
-    const url = '/stats'
-
+    const url = MeiliSearch.apiPaths.stats
     return await this.httpRequest.get<Types.Stats>(url)
   }
 
@@ -156,8 +172,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method version
    */
   async version(): Promise<Types.Version> {
-    const url = '/version'
-
+    const url = MeiliSearch.apiPaths.version
     return await this.httpRequest.get<Types.Version>(url)
   }
 
@@ -171,8 +186,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method createDump
    */
   async createDump(): Promise<Types.EnqueuedDump> {
-    const url = '/dumps'
-
+    const url = MeiliSearch.apiPaths.createDump
     return await this.httpRequest.post<undefined, Types.EnqueuedDump>(url)
   }
 
@@ -182,8 +196,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getDumpStatus
    */
   async getDumpStatus(dumpUid: string): Promise<Types.EnqueuedDump> {
-    const url = `/dumps/${dumpUid}/status`
-
+    const url = MeiliSearch.apiPathConstructors.getDumpStatus(dumpUid)
     return await this.httpRequest.get<Types.EnqueuedDump>(url)
   }
 }

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -17,7 +17,7 @@ type createPath = (x: string | number) => string
 class MeiliSearch implements Types.MeiliSearchInterface {
   config: Types.Config
   httpRequest: HttpRequests
-  static apiPaths: {
+  static apiRoutes: {
     [key: string]: string
   } = {
     listIndexes: 'indexes',
@@ -27,7 +27,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     version: 'version',
     createDump: 'dumps',
   }
-  static apiPathConstructors: {
+  static routeConstructors: {
     [key: string]: createPath
   } = {
     getDumpStatus: (dumpUid: string | number) => {
@@ -36,8 +36,16 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   }
 
   constructor(config: Types.Config) {
+    config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)
+  }
+
+  static getApiRoutes(): { [key: string]: string } {
+    return MeiliSearch.apiRoutes
+  }
+  static getRouteConstructors(): { [key: string]: createPath } {
+    return MeiliSearch.routeConstructors
   }
 
   /**
@@ -85,7 +93,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method listIndexes
    */
   async listIndexes(): Promise<Types.IndexResponse[]> {
-    const url = MeiliSearch.apiPaths.listIndexes
+    const url = MeiliSearch.apiRoutes.listIndexes
     return await this.httpRequest.get<Types.IndexResponse[]>(url)
   }
 
@@ -132,7 +140,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getKey
    */
   async getKeys(): Promise<Types.Keys> {
-    const url = MeiliSearch.apiPaths.getKeys
+    const url = MeiliSearch.apiRoutes.getKeys
     return await this.httpRequest.get<Types.Keys>(url)
   }
 
@@ -148,7 +156,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    */
   async isHealthy(): Promise<true> {
     return await this.httpRequest
-      .get(MeiliSearch.apiPaths.isHealthy)
+      .get(MeiliSearch.apiRoutes.isHealthy)
       .then(() => true)
   }
 
@@ -162,7 +170,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method stats
    */
   async stats(): Promise<Types.Stats> {
-    const url = MeiliSearch.apiPaths.stats
+    const url = MeiliSearch.apiRoutes.stats
     return await this.httpRequest.get<Types.Stats>(url)
   }
 
@@ -172,7 +180,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method version
    */
   async version(): Promise<Types.Version> {
-    const url = MeiliSearch.apiPaths.version
+    const url = MeiliSearch.apiRoutes.version
     return await this.httpRequest.get<Types.Version>(url)
   }
 
@@ -186,7 +194,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method createDump
    */
   async createDump(): Promise<Types.EnqueuedDump> {
-    const url = MeiliSearch.apiPaths.createDump
+    const url = MeiliSearch.apiRoutes.createDump
     return await this.httpRequest.post<undefined, Types.EnqueuedDump>(url)
   }
 
@@ -196,7 +204,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getDumpStatus
    */
   async getDumpStatus(dumpUid: string): Promise<Types.EnqueuedDump> {
-    const url = MeiliSearch.apiPathConstructors.getDumpStatus(dumpUid)
+    const url = MeiliSearch.routeConstructors.getDumpStatus(dumpUid)
     return await this.httpRequest.get<Types.EnqueuedDump>(url)
   }
 }

--- a/tests/attributes_for_faceting_tests.ts
+++ b/tests/attributes_for_faceting_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,52 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getAttributesForFaceting()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateAttributesForFaceting([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .resetAttributesForFaceting()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/displayed_attributes_tests.ts
+++ b/tests/displayed_attributes_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,50 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getDisplayedAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateDisplayedAttributes([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetDisplayedAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/distinct_attribute_tests.ts
+++ b/tests/distinct_attribute_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getDistinctAttribute()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateDistinctAttribute('')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetDistinctAttribute()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const uidNoPrimaryKey = {
@@ -499,3 +501,98 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocuments()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get request with options should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .getDocuments({ attributesToRetrieve: ['id'] })
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents?attributesToRetrieve=id`
+    )
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .updateDocuments([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete batch request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .deleteDocuments([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/delete-batch`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/delete-batch/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete all request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .deleteAllDocuments()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete one request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).deleteDocument(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get one request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocument(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/dump_tests.ts
+++ b/tests/dump_tests.ts
@@ -7,6 +7,8 @@ import {
   publicClient,
   anonymousClient,
   waitForDumpProcessing,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 beforeAll(async () => {
@@ -70,3 +72,25 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.createDump()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/dumps`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/dumps/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get status request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.getDumpStatus('1')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/dumps/1/status`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/dumps/1/status/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const uidNoPrimaryKey = {
@@ -406,3 +408,47 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Create request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.createIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.updateIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.deleteIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get all request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.listIndexes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -1,10 +1,12 @@
 import MeiliSearch from '../src/meilisearch'
+import { Index } from '../src/index'
 import * as Types from '../src/types'
 import { sleep } from '../src/utils'
 
 // testing
 const MASTER_KEY = 'masterKey'
 const HOST = 'http://127.0.0.1:7700'
+const BAD_HOST = HOST.slice(0, -1) + `1`
 const PRIVATE_KEY =
   '8dcbb482663333d0280fa9fedf0e0c16d52185cb67db494ce4cd34da32ce2092'
 const PUBLIC_KEY =
@@ -14,6 +16,10 @@ const config = {
   host: HOST,
   apiKey: MASTER_KEY,
 }
+const badHostClient = new MeiliSearch({
+  host: BAD_HOST,
+  apiKey: MASTER_KEY,
+})
 const masterClient = new MeiliSearch({
   host: HOST,
   apiKey: MASTER_KEY,
@@ -75,10 +81,13 @@ export {
   masterClient,
   privateClient,
   publicClient,
+  badHostClient,
   anonymousClient,
+  BAD_HOST,
   PUBLIC_KEY,
   PRIVATE_KEY,
   MASTER_KEY,
   MeiliSearch,
+  Index,
   waitForDumpProcessing,
 }

--- a/tests/ranking_rules_tests.ts
+++ b/tests/ranking_rules_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -154,3 +156,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getRankingRules()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateRankingRules([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetRankingRules()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -8,6 +8,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -590,4 +592,34 @@ describe.each([
       })
     })
   })
+})
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .search('prince', { limit: 1 }, 'GET')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .search('prince', { limit: 1 }, 'POST')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/search`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/search/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
 })

--- a/tests/searchable_attributes_tests.ts
+++ b/tests/searchable_attributes_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,50 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSearchableAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateSearchableAttributes([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSearchableAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -344,3 +346,36 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSettings()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateSettings({})
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSettings()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/stop_words_tests.ts
+++ b/tests/stop_words_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getStopWords()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateStopWords([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetStopWords()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/synonyms_tests.ts
+++ b/tests/synonyms_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -147,3 +149,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSynonyms()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateSynonyms([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSynonyms()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -7,6 +7,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -491,3 +493,33 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index<Movie>(index.uid)
+      .search('prince', { limit: 1 }, 'GET')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index<Movie>(index.uid)
+      .search('prince', { limit: 1 }, 'POST')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/search`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/search/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/unit_tests.ts
+++ b/tests/unit_tests.ts
@@ -1,0 +1,68 @@
+import {
+  clearAllIndexes,
+  config,
+  MeiliSearch,
+  Index,
+} from './meilisearch-test-utils'
+
+afterAll(() => {
+  return clearAllIndexes(config)
+})
+
+test(`Client handles host URL with domain and path`, () => {
+  const customHost = `${config.host}/api/`
+  const client = new MeiliSearch({
+    host: customHost,
+  })
+  expect(client.config.host).toBe(customHost)
+  expect(client.httpRequest.url.href).toBe(customHost)
+})
+
+test(`Client handles host URL with domain and path and no trailing slash`, () => {
+  const customHost = `${config.host}/api`
+  const client = new MeiliSearch({
+    host: customHost,
+  })
+  expect(client.config.host).toBe(customHost + '/')
+  expect(client.httpRequest.url.href).toBe(customHost + '/')
+})
+
+test(`Test for trailing and starting slashes in every MeiliSearch subroute`, () => {
+  const subroutes = MeiliSearch.getApiRoutes()
+  const subRoutesMethods = MeiliSearch.getRouteConstructors()
+
+  const meiliSearchSubRoutesCheck = Object.values(subroutes).filter(
+    (path) => path.endsWith('/') || path.startsWith('/')
+  )
+  const MeiliSearchSubRoutesConstructorsCheck = Object.values(
+    subRoutesMethods
+  ).filter((method) => {
+    const res = method(1)
+    return res.endsWith('/') || res.startsWith('/')
+  })
+  expect(meiliSearchSubRoutesCheck).toEqual([])
+  expect(MeiliSearchSubRoutesConstructorsCheck).toEqual([])
+
+  const health = true
+  expect(health).toBe(true) // Left here to trigger failed test if error is not thrown
+})
+
+test(`Test for trailing and starting slashes in every Index subroute`, () => {
+  const subroutes = Index.getApiRoutes()
+  const subRoutesMethods = Index.getRouteConstructors()
+
+  const IndexSubRoutesCheck = Object.values(subroutes).filter(
+    (path) => path.endsWith('/') || path.startsWith('/')
+  )
+  const IndexSubRoutesConstructorsCheck = Object.values(
+    subRoutesMethods
+  ).filter((method) => {
+    const res = method('1', '1')
+    return res.endsWith('/') || res.startsWith('/')
+  })
+  expect(IndexSubRoutesCheck).toEqual([])
+  expect(IndexSubRoutesConstructorsCheck).toEqual([])
+
+  const health = true
+  expect(health).toBe(true) // Left here to trigger failed test if error is not thrown
+})

--- a/tests/update_tests.ts
+++ b/tests/update_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -119,3 +121,25 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getAllUpdateStatus()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/updates`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/updates/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getUpdateStatus(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/updates/1`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/updates/1/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})


### PR DESCRIPTION
In this PR is linked to #652. This issue raises the problem where the requested URL has a double slash. This does not impact the usability of meilisearch-js but could potentially become a problem. Also the error handler shows clearly the double slash when a communication error occurs. 

To avoid this problem in the future this PR does the following: 
- REFACTO: Removed all starting slashes on sub-routes in the code
- FIX: Add multiple check inside the http handler for the following cases: 
    - If the pathname ends with a slash OR if the sub-route start with a slash, we do not add a slash
    - If the pathname ends with a slash AND if the sub-routes start with a slash, we remove the starting slash in the sub route
    - If the sub-routes ends with a slash, remove that slash for consistency  in URL request (ex: you could have the following requests: `http://localhost:7700/indexes/` and `http://localhost:7700/stats` both url are not consistent in their trailing slash)
    - if the pathname ends with two slashes, remove one.
- REFACTO: Center all routes at the start of both the Index and MeilISearch class. In order to have a better visibility on the different routes and to avoid having to scroll to find how a specific route was hard coded.

Some design choices: 
- You might ask why I kept `const url = ...` instead of directly adding the result in the returned function. I chose that for readability. If you think it is a bad idea tell me so. 
- The static lists that are at the top of each class tries to not repeat itself. Maybe it should repeat itself for readibility purposes. If you think the way I made it is not readable feel free to tell me. Also if you think they should be in another file feel free to also tell me. 

 This PR  tests are failing  ❌ because  of an update on slash handling. Working tests are here #732. They need to be merged here for this PR to pass its tests.
fixes: #731 #744 