### PR TITLE
Add tests on each route to ensure avoiding double slashes

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -7,7 +7,7 @@ import {
 
 class HttpRequests {
   headers: {}
-  url: string
+  url: URL
 
   constructor(config: Types.Config) {
     this.headers = {
@@ -15,23 +15,14 @@ class HttpRequests {
       'Content-Type': 'application/json',
       ...(config.apiKey ? { 'X-Meili-API-Key': config.apiKey } : {}),
     }
-    this.url = config.host
+    this.url = new URL(config.host)
   }
-  static constructCorrectPath(pathname: string, url: string): string {
-    let slash = '/'
-    if (pathname.endsWith('/') || url.startsWith('/')) {
-      slash = ''
+
+  static addTrailingSlash(url: string): string {
+    if (!url.endsWith('/')) {
+      url = url + '/'
     }
-    if (pathname.endsWith('//')) {
-      pathname = pathname.substring(1)
-    }
-    if (url.endsWith('/')) {
-      url = url.slice(0, -1)
-    }
-    if (pathname.endsWith('/') && url.startsWith('/')) {
-      url = url.substring(1)
-    }
-    return pathname + slash + url
+    return url
   }
 
   async request({
@@ -48,11 +39,7 @@ class HttpRequests {
     config?: Partial<Request>
   }) {
     try {
-      const constructURL = new URL(this.url)
-      constructURL.pathname = HttpRequests.constructCorrectPath(
-        constructURL.pathname,
-        url
-      )
+      const constructURL = new URL(url, this.url)
       if (params) {
         const queryParams = new URLSearchParams()
         Object.keys(params)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,18 +29,20 @@ class Index<T> implements Types.IndexInterface<T> {
     [key: string]: createIndexPath
   } = {
     indexRoute: (indexUid: string) => {
-      return `${Index.apiRoutes.indexes}/${indexUid}/`
+      return `${Index.apiRoutes.indexes}/${indexUid}`
     },
     getUpdateStatus: (indexUid: string, updateId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `updates/${updateId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `updates/${updateId}`
       )
     },
     getAllUpdateStatus: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `updates`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `updates`
     },
     search: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `search`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `search`
     },
     getRawInfo: (indexUid: string) => {
       return `indexes/${indexUid}`
@@ -52,15 +54,17 @@ class Index<T> implements Types.IndexInterface<T> {
       return Index.routeConstructors.indexRoute(indexUid)
     },
     getStats: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `stats`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `stats`
     },
     getDocument: (indexUid: string, documentId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/${documentId}`
       )
     },
     getDocuments: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `documents`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `documents`
     },
     addDocuments: (indexUid: string) => {
       return Index.routeConstructors.getDocuments(indexUid)
@@ -73,16 +77,20 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     deleteDocument: (indexUid: string, documentId: objectId) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/${documentId}`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/${documentId}`
       )
     },
     deleteDocuments: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `documents/delete-batch`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `documents/delete-batch`
       )
     },
     getSettings: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `settings`
+      return Index.routeConstructors.indexRoute(indexUid) + '/' + `settings`
     },
     updateSettings: (indexUid: string) => {
       return Index.routeConstructors.getSettings(indexUid)
@@ -91,7 +99,9 @@ class Index<T> implements Types.IndexInterface<T> {
       return Index.routeConstructors.getSettings(indexUid)
     },
     getSynonyms: (indexUid: string) => {
-      return Index.routeConstructors.indexRoute(indexUid) + `settings/synonyms`
+      return (
+        Index.routeConstructors.indexRoute(indexUid) + '/' + `settings/synonyms`
+      )
     },
     updateSynonyms: (indexUid: string) => {
       return Index.routeConstructors.getSynonyms(indexUid)
@@ -101,7 +111,9 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     getStopWords: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `settings/stop-words`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `settings/stop-words`
       )
     },
     updateStopWords: (indexUid: string) => {
@@ -112,7 +124,9 @@ class Index<T> implements Types.IndexInterface<T> {
     },
     getRankingRules: (indexUid: string) => {
       return (
-        Index.routeConstructors.indexRoute(indexUid) + `settings/ranking-rules`
+        Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
+        `settings/ranking-rules`
       )
     },
     updateRankingRules: (indexUid: string) => {
@@ -124,6 +138,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getDistinctAttribute: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/distinct-attribute`
       )
     },
@@ -136,6 +151,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getAttributesForFaceting: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/attributes-for-faceting`
       )
     },
@@ -148,6 +164,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getSearchableAttributes: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/searchable-attributes`
       )
     },
@@ -160,6 +177,7 @@ class Index<T> implements Types.IndexInterface<T> {
     getDisplayedAttributes: (indexUid: string) => {
       return (
         Index.routeConstructors.indexRoute(indexUid) +
+        '/' +
         `settings/displayed-attributes`
       )
     },
@@ -175,6 +193,16 @@ class Index<T> implements Types.IndexInterface<T> {
     this.uid = uid
     this.primaryKey = primaryKey
     this.httpRequest = new HttpRequests(config)
+  }
+  ///
+  /// STATIC
+  ///
+
+  static getApiRoutes(): { [key: string]: string } {
+    return Index.apiRoutes
+  }
+  static getRouteConstructors(): { [key: string]: createIndexPath } {
+    return Index.routeConstructors
   }
 
   ///

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -17,7 +17,7 @@ type createPath = (x: string | number) => string
 class MeiliSearch implements Types.MeiliSearchInterface {
   config: Types.Config
   httpRequest: HttpRequests
-  static apiPaths: {
+  static apiRoutes: {
     [key: string]: string
   } = {
     listIndexes: 'indexes',
@@ -27,7 +27,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     version: 'version',
     createDump: 'dumps',
   }
-  static apiPathConstructors: {
+  static routeConstructors: {
     [key: string]: createPath
   } = {
     getDumpStatus: (dumpUid: string | number) => {
@@ -36,8 +36,16 @@ class MeiliSearch implements Types.MeiliSearchInterface {
   }
 
   constructor(config: Types.Config) {
+    config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)
+  }
+
+  static getApiRoutes(): { [key: string]: string } {
+    return MeiliSearch.apiRoutes
+  }
+  static getRouteConstructors(): { [key: string]: createPath } {
+    return MeiliSearch.routeConstructors
   }
 
   /**
@@ -85,7 +93,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method listIndexes
    */
   async listIndexes(): Promise<Types.IndexResponse[]> {
-    const url = MeiliSearch.apiPaths.listIndexes
+    const url = MeiliSearch.apiRoutes.listIndexes
     return await this.httpRequest.get<Types.IndexResponse[]>(url)
   }
 
@@ -132,7 +140,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getKey
    */
   async getKeys(): Promise<Types.Keys> {
-    const url = MeiliSearch.apiPaths.getKeys
+    const url = MeiliSearch.apiRoutes.getKeys
     return await this.httpRequest.get<Types.Keys>(url)
   }
 
@@ -148,7 +156,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    */
   async isHealthy(): Promise<true> {
     return await this.httpRequest
-      .get(MeiliSearch.apiPaths.isHealthy)
+      .get(MeiliSearch.apiRoutes.isHealthy)
       .then(() => true)
   }
 
@@ -162,7 +170,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method stats
    */
   async stats(): Promise<Types.Stats> {
-    const url = MeiliSearch.apiPaths.stats
+    const url = MeiliSearch.apiRoutes.stats
     return await this.httpRequest.get<Types.Stats>(url)
   }
 
@@ -172,7 +180,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method version
    */
   async version(): Promise<Types.Version> {
-    const url = MeiliSearch.apiPaths.version
+    const url = MeiliSearch.apiRoutes.version
     return await this.httpRequest.get<Types.Version>(url)
   }
 
@@ -186,7 +194,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method createDump
    */
   async createDump(): Promise<Types.EnqueuedDump> {
-    const url = MeiliSearch.apiPaths.createDump
+    const url = MeiliSearch.apiRoutes.createDump
     return await this.httpRequest.post<undefined, Types.EnqueuedDump>(url)
   }
 
@@ -196,7 +204,7 @@ class MeiliSearch implements Types.MeiliSearchInterface {
    * @method getDumpStatus
    */
   async getDumpStatus(dumpUid: string): Promise<Types.EnqueuedDump> {
-    const url = MeiliSearch.apiPathConstructors.getDumpStatus(dumpUid)
+    const url = MeiliSearch.routeConstructors.getDumpStatus(dumpUid)
     return await this.httpRequest.get<Types.EnqueuedDump>(url)
   }
 }

--- a/tests/attributes_for_faceting_tests.ts
+++ b/tests/attributes_for_faceting_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,52 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getAttributesForFaceting()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateAttributesForFaceting([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .resetAttributesForFaceting()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/attributes-for-faceting/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -83,35 +83,6 @@ describe.each([
       expect(e.type).toBe('MeiliSearchCommunicationError')
     }
   })
-  test(`${permission} key: No double slash when on host with domain and path`, async () => {
-    try {
-      const customHost = `${BAD_HOST}/api`
-      const client = new MeiliSearch({
-        host: customHost,
-        apiKey: key,
-      })
-      const health = await client.isHealthy()
-      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
-    } catch (e) {
-      expect(e.message).toMatch(`${BAD_HOST}/api/health`)
-      expect(e.type).toBe('MeiliSearchCommunicationError')
-    }
-  })
-
-  test(`${permission} key: host with double slash should not double slash`, async () => {
-    try {
-      const customHost = `${BAD_HOST}//`
-      const client = new MeiliSearch({
-        host: customHost,
-        apiKey: key,
-      })
-      const health = await client.isHealthy()
-      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
-    } catch (e) {
-      expect(e.message).toMatch(`${BAD_HOST}/health`)
-      expect(e.type).toBe('MeiliSearchCommunicationError')
-    }
-  })
 
   test(`${permission} key: host with one slash should not double slash`, async () => {
     try {
@@ -122,22 +93,6 @@ describe.each([
       })
       const health = await client.isHealthy()
       expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
-    } catch (e) {
-      expect(e.message).toMatch(`${BAD_HOST}/health`)
-      expect(e.type).toBe('MeiliSearchCommunicationError')
-    }
-  })
-
-  test(`${permission} key: host with one slash should not double slash`, async () => {
-    try {
-      const customHost = `${BAD_HOST}/`
-      const client = new MeiliSearch({
-        host: customHost,
-        apiKey: key,
-      })
-      const health = await client.isHealthy()
-      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
-      await client.listIndexes()
     } catch (e) {
       expect(e.message).toMatch(`${BAD_HOST}/health`)
       expect(e.type).toBe('MeiliSearchCommunicationError')

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -63,7 +63,7 @@ describe.each([
     }
   })
 
-  test(`${permission} key: host with double slash  should not double slash`, async () => {
+  test(`${permission} key: host with double slash should not double slash`, async () => {
     try {
       const customHost = `${BAD_HOST}//`
       const client = new MeiliSearch({

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -39,16 +39,22 @@ describe.each([
     expect(health).toBe(true)
   })
 
-  test(`${permission} key: Client handles host URL with domain and path`, () => {
-    const customHost = `${config.host}/api`
-    const client = new MeiliSearch({
-      host: customHost,
-      apiKey: key,
-    })
-    expect(client.config.host).toBe(customHost)
-    expect(client.httpRequest.url).toBe(customHost)
+  test(`${permission} key: No double slash when on host with domain and path and trailing slash`, async () => {
+    try {
+      const customHost = `${BAD_HOST}/api/`
+      const client = new MeiliSearch({
+        host: customHost,
+        apiKey: key,
+      })
+      const health = await client.isHealthy()
+      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+    } catch (e) {
+      expect(e.message).toMatch(`${BAD_HOST}/api/health`)
+      expect(e.type).toBe('MeiliSearchCommunicationError')
+    }
   })
-  test(`${permission} key: No double slash when on host with domain and path`, async () => {
+
+  test(`${permission} key: No double slash when on host with domain and path and no trailing slash`, async () => {
     try {
       const customHost = `${BAD_HOST}/api`
       const client = new MeiliSearch({
@@ -63,7 +69,7 @@ describe.each([
     }
   })
 
-  test(`${permission} key: host with double slash should not double slash`, async () => {
+  test(`${permission} key: host with double slash should keep double slash`, async () => {
     try {
       const customHost = `${BAD_HOST}//`
       const client = new MeiliSearch({
@@ -73,7 +79,7 @@ describe.each([
       const health = await client.isHealthy()
       expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
     } catch (e) {
-      expect(e.message).toMatch(`${BAD_HOST}/health`)
+      expect(e.message).toMatch(`${BAD_HOST}//health`)
       expect(e.type).toBe('MeiliSearchCommunicationError')
     }
   })
@@ -90,22 +96,6 @@ describe.each([
     } catch (e) {
       expect(e.message).toMatch(`${BAD_HOST}/health`)
       expect(e.type).toBe('MeiliSearchCommunicationError')
-    }
-  })
-
-  test(`${permission} key: Client uses complete URL with domain and additionnal path in MeiliSearch call`, async () => {
-    try {
-      const customHost = `${config.host}/api`
-      const client = new MeiliSearch({
-        host: customHost,
-        apiKey: key,
-      })
-      const health = await client.isHealthy()
-      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
-      await client.listIndexes()
-    } catch (e) {
-      expect(e.type).toBe('MeiliSearchCommunicationError')
-      expect(e.message).toBe('Not Found') // Expect 404 because host does not exist
     }
   })
 })

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -5,6 +5,7 @@ import {
   MeiliSearch,
   MASTER_KEY,
   PRIVATE_KEY,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 afterAll(() => {
@@ -47,6 +48,50 @@ describe.each([
     expect(client.config.host).toBe(customHost)
     expect(client.httpRequest.url).toBe(customHost)
   })
+  test(`${permission} key: No double slash when on host with domain and path`, async () => {
+    try {
+      const customHost = `${BAD_HOST}/api`
+      const client = new MeiliSearch({
+        host: customHost,
+        apiKey: key,
+      })
+      const health = await client.isHealthy()
+      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+    } catch (e) {
+      expect(e.message).toMatch(`${BAD_HOST}/api/health`)
+      expect(e.type).toBe('MeiliSearchCommunicationError')
+    }
+  })
+
+  test(`${permission} key: host with double slash  should not double slash`, async () => {
+    try {
+      const customHost = `${BAD_HOST}//`
+      const client = new MeiliSearch({
+        host: customHost,
+        apiKey: key,
+      })
+      const health = await client.isHealthy()
+      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+    } catch (e) {
+      expect(e.message).toMatch(`${BAD_HOST}/health`)
+      expect(e.type).toBe('MeiliSearchCommunicationError')
+    }
+  })
+
+  test(`${permission} key: host with one slash should not double slash`, async () => {
+    try {
+      const customHost = `${BAD_HOST}/`
+      const client = new MeiliSearch({
+        host: customHost,
+        apiKey: key,
+      })
+      const health = await client.isHealthy()
+      expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+    } catch (e) {
+      expect(e.message).toMatch(`${BAD_HOST}/health`)
+      expect(e.type).toBe('MeiliSearchCommunicationError')
+    }
+  })
 
   test(`${permission} key: Client uses complete URL with domain and additionnal path in MeiliSearch call`, async () => {
     try {
@@ -57,6 +102,7 @@ describe.each([
       })
       const health = await client.isHealthy()
       expect(health).toBe(false) // Left here to trigger failed test if error is not thrown
+      await client.listIndexes()
     } catch (e) {
       expect(e.type).toBe('MeiliSearchCommunicationError')
       expect(e.message).toBe('Not Found') // Expect 404 because host does not exist

--- a/tests/displayed_attributes_tests.ts
+++ b/tests/displayed_attributes_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,50 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getDisplayedAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateDisplayedAttributes([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetDisplayedAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/displayed-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/distinct_attribute_tests.ts
+++ b/tests/distinct_attribute_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getDistinctAttribute()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateDistinctAttribute('')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetDistinctAttribute()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/distinct-attribute/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const uidNoPrimaryKey = {
@@ -499,3 +501,121 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocuments()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocuments()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get request with options should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .getDocuments({ attributesToRetrieve: ['id'] })
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents?attributesToRetrieve=id`
+    )
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .updateDocuments([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete batch request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .deleteDocuments([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/delete-batch`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/delete-batch/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete all request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(uidNoPrimaryKey.uid)
+      .deleteAllDocuments()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete one request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).deleteDocument(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get one request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocument(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+test(`Get one request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocument(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/documents/1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -607,15 +607,3 @@ test(`Get one request should not add double slash nor a trailing slash`, async (
     expect(e.type).toBe('MeiliSearchCommunicationError')
   }
 })
-test(`Get one request should not add double slash nor a trailing slash`, async () => {
-  try {
-    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocument(1)
-    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
-  } catch (e) {
-    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents/1`)
-    expect(e.message).not.toMatch(
-      `${BAD_HOST}/indexes/movies_test/documents/1/`
-    )
-    expect(e.type).toBe('MeiliSearchCommunicationError')
-  }
-})

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -513,17 +513,6 @@ test(`Get request should not add double slash nor a trailing slash`, async () =>
   }
 })
 
-test(`Get request should not add double slash nor a trailing slash`, async () => {
-  try {
-    const res = await badHostClient.index(uidNoPrimaryKey.uid).getDocuments()
-    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
-  } catch (e) {
-    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/documents`)
-    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/documents/`)
-    expect(e.type).toBe('MeiliSearchCommunicationError')
-  }
-})
-
 test(`Get request with options should not add double slash nor a trailing slash`, async () => {
   try {
     const res = await badHostClient

--- a/tests/dump_tests.ts
+++ b/tests/dump_tests.ts
@@ -7,6 +7,8 @@ import {
   publicClient,
   anonymousClient,
   waitForDumpProcessing,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 beforeAll(async () => {
@@ -70,3 +72,25 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.createDump()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/dumps`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/dumps/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get status request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.getDumpStatus('1')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/dumps/1/status`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/dumps/1/status/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const uidNoPrimaryKey = {
@@ -406,3 +408,47 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Create request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.createIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.updateIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Delete request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.deleteIndex(uidNoPrimaryKey.uid)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/${uidNoPrimaryKey.uid}/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Get all request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.listIndexes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -1,4 +1,5 @@
 import MeiliSearch from '../src/meilisearch'
+import { Index } from '../src/index'
 import * as Types from '../src/types'
 import { sleep } from '../src/utils'
 
@@ -87,5 +88,6 @@ export {
   PRIVATE_KEY,
   MASTER_KEY,
   MeiliSearch,
+  Index,
   waitForDumpProcessing,
 }

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -5,6 +5,7 @@ import { sleep } from '../src/utils'
 // testing
 const MASTER_KEY = 'masterKey'
 const HOST = 'http://127.0.0.1:7700'
+const BAD_HOST = HOST.slice(0, -1) + `1`
 const PRIVATE_KEY =
   '8dcbb482663333d0280fa9fedf0e0c16d52185cb67db494ce4cd34da32ce2092'
 const PUBLIC_KEY =
@@ -14,6 +15,10 @@ const config = {
   host: HOST,
   apiKey: MASTER_KEY,
 }
+const badHostClient = new MeiliSearch({
+  host: BAD_HOST,
+  apiKey: MASTER_KEY,
+})
 const masterClient = new MeiliSearch({
   host: HOST,
   apiKey: MASTER_KEY,
@@ -75,7 +80,9 @@ export {
   masterClient,
   privateClient,
   publicClient,
+  badHostClient,
   anonymousClient,
+  BAD_HOST,
   PUBLIC_KEY,
   PRIVATE_KEY,
   MASTER_KEY,

--- a/tests/ranking_rules_tests.ts
+++ b/tests/ranking_rules_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -154,3 +156,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getRankingRules()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateRankingRules([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetRankingRules()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/ranking-rules/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -8,6 +8,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -590,4 +592,34 @@ describe.each([
       })
     })
   })
+})
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .search('prince', { limit: 1 }, 'GET')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .search('prince', { limit: 1 }, 'POST')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/search`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/search/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
 })

--- a/tests/searchable_attributes_tests.ts
+++ b/tests/searchable_attributes_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,50 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSearchableAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index(index.uid)
+      .updateSearchableAttributes([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSearchableAttributes()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/searchable-attributes/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -344,3 +346,36 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSettings()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateSettings({})
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSettings()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/settings`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/settings/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/stop_words_tests.ts
+++ b/tests/stop_words_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -145,3 +147,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getStopWords()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateStopWords([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetStopWords()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/stop-words/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/synonyms_tests.ts
+++ b/tests/synonyms_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -147,3 +149,48 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getSynonyms()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).updateSynonyms([])
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Reset request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).resetSynonyms()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/settings/synonyms/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -7,6 +7,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -491,3 +493,33 @@ describe.each([{ client: anonymousClient, permission: 'Client' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index<Movie>(index.uid)
+      .search('prince', { limit: 1 }, 'GET')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1`
+    )
+    expect(e.message).not.toMatch(
+      `${BAD_HOST}/indexes/movies_test/search?q=prince&limit=1/`
+    )
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Post request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient
+      .index<Movie>(index.uid)
+      .search('prince', { limit: 1 }, 'POST')
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/search`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/search/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})

--- a/tests/unit_tests.ts
+++ b/tests/unit_tests.ts
@@ -1,0 +1,68 @@
+import {
+  clearAllIndexes,
+  config,
+  MeiliSearch,
+  Index,
+} from './meilisearch-test-utils'
+
+afterAll(() => {
+  return clearAllIndexes(config)
+})
+
+test(`Client handles host URL with domain and path`, () => {
+  const customHost = `${config.host}/api/`
+  const client = new MeiliSearch({
+    host: customHost,
+  })
+  expect(client.config.host).toBe(customHost)
+  expect(client.httpRequest.url.href).toBe(customHost)
+})
+
+test(`Client handles host URL with domain and path and no trailing slash`, () => {
+  const customHost = `${config.host}/api`
+  const client = new MeiliSearch({
+    host: customHost,
+  })
+  expect(client.config.host).toBe(customHost + '/')
+  expect(client.httpRequest.url.href).toBe(customHost + '/')
+})
+
+test(`Test for trailing and starting slashes in every MeiliSearch subroute`, () => {
+  const subroutes = MeiliSearch.getApiRoutes()
+  const subRoutesMethods = MeiliSearch.getRouteConstructors()
+
+  const meiliSearchSubRoutesCheck = Object.values(subroutes).filter(
+    (path) => path.endsWith('/') || path.startsWith('/')
+  )
+  const MeiliSearchSubRoutesConstructorsCheck = Object.values(
+    subRoutesMethods
+  ).filter((method) => {
+    const res = method(1)
+    return res.endsWith('/') || res.startsWith('/')
+  })
+  expect(meiliSearchSubRoutesCheck).toEqual([])
+  expect(MeiliSearchSubRoutesConstructorsCheck).toEqual([])
+
+  const health = true
+  expect(health).toBe(true) // Left here to trigger failed test if error is not thrown
+})
+
+test(`Test for trailing and starting slashes in every Index subroute`, () => {
+  const subroutes = Index.getApiRoutes()
+  const subRoutesMethods = Index.getRouteConstructors()
+
+  const IndexSubRoutesCheck = Object.values(subroutes).filter(
+    (path) => path.endsWith('/') || path.startsWith('/')
+  )
+  const IndexSubRoutesConstructorsCheck = Object.values(
+    subRoutesMethods
+  ).filter((method) => {
+    const res = method('1', '1')
+    return res.endsWith('/') || res.startsWith('/')
+  })
+  expect(IndexSubRoutesCheck).toEqual([])
+  expect(IndexSubRoutesConstructorsCheck).toEqual([])
+
+  const health = true
+  expect(health).toBe(true) // Left here to trigger failed test if error is not thrown
+})

--- a/tests/update_tests.ts
+++ b/tests/update_tests.ts
@@ -6,6 +6,8 @@ import {
   privateClient,
   publicClient,
   anonymousClient,
+  badHostClient,
+  BAD_HOST,
 } from './meilisearch-test-utils'
 
 const index = {
@@ -119,3 +121,25 @@ describe.each([{ client: anonymousClient, permission: 'No' }])(
     })
   }
 )
+
+test(`Get request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getAllUpdateStatus()
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/updates`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/updates/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})
+
+test(`Update request should not add double slash nor a trailing slash`, async () => {
+  try {
+    const res = await badHostClient.index(index.uid).getUpdateStatus(1)
+    expect(res).toBe(undefined) // Left here to trigger failed test if error is not thrown
+  } catch (e) {
+    expect(e.message).toMatch(`${BAD_HOST}/indexes/movies_test/updates/1`)
+    expect(e.message).not.toMatch(`${BAD_HOST}/indexes/movies_test/updates/1/`)
+    expect(e.type).toBe('MeiliSearchCommunicationError')
+  }
+})


### PR DESCRIPTION
This pr is pointing to the PR that fixes the issue #731 

In this PR we tests every route and sub-route used by this library to ensure there is no route that creates a double slash. 
It also tests the following cases
- http://localhost:7700// => should work and become http://localhost:7700/
- Every request made by meilisearch-js should not have a trailing slash
    - http://localhost:7700/indexes/ ❌
    - http://localhost:7700/indexes ✅
- Sub routes are not lost:  `http://localhost:7700/api/` + `indexes` should become `http://localhost:7700/api/indexes`
