### PR TITLE
Named exports

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -293,10 +293,22 @@ getting_started_add_documents_md: |-
   $ yarn add meilisearch
   ```
 
-  ```js
-  const MeiliSearch = require('meilisearch')
-  const movies = require('./movies.json')
+  **Import**
 
+  `require` syntax:
+  ```js
+  const { MeiliSearch } = require('meilisearch')
+  const movies = require('./movies.json')
+  ```
+
+  `import` syntax:
+  ```js
+  import { MeiliSearch } from 'meilisearch'
+  import movies from '../small_movies.json'
+  ```
+
+  **Use**
+  ```js
   const client = new MeiliSearch({ host: 'http://127.0.0.1:7700' })
   client.index('movie').addDocuments(movies)
     .then((res) => console.log(res))

--- a/README.md
+++ b/README.md
@@ -70,10 +70,14 @@ NB: you can also download MeiliSearch from **Homebrew** or **APT**.
 
 ### Import <!-- omit in toc -->
 
-#### Front End or ESmodule <!-- omit in toc -->
+Depending on the environment on which you are using MeiliSearch, imports may differ.
+
+#### Import Syntax <!-- omit in toc -->
+
+Usage in a ES module environment:
 
 ```javascript
-import MeiliSearch from 'meilisearch'
+import { MeiliSearch } from 'meilisearch'
 
 const client = new MeiliSearch({
   host: 'http://127.0.0.1:7700',
@@ -81,25 +85,26 @@ const client = new MeiliSearch({
 })
 ```
 
-#### HTML Import <!-- omit in toc -->
+#### Include Script Tag <!-- omit in toc -->
 
-```javascript
+Usage in an HTML (or alike) file:
+
+```html
 <script src="https://cdn.jsdelivr.net/npm/meilisearch@latest/dist/bundles/meilisearch.umd.js"></script>
 <script>
   const client = new MeiliSearch({
     host: 'http://127.0.0.1:7700',
     apiKey: 'masterKey',
   })
-  client.listIndexes().then(res => {
-    console.log({ res });
-  })
 </script>
 ```
 
-#### Back-End CommonJs <!-- omit in toc -->
+#### Require Syntax <!-- omit in toc -->
+
+Usage in a back-end node environment
 
 ```javascript
-const MeiliSearch = require('meilisearch')
+const { MeiliSearch } = require('meilisearch')
 
 const client = new MeiliSearch({
   host: 'http://127.0.0.1:7700',
@@ -116,9 +121,9 @@ To make this package work with React Native, please add the [react-native-url-po
 #### Add Documents <!-- omit in toc -->
 
 ```js
-const MeiliSearch = require('meilisearch')
-// Or if you are on a front-end environment:
-import MeiliSearch from 'meilisearch'
+const { MeiliSearch } = require('meilisearch')
+// Or if you are in a ES environment
+import { MeiliSearch } from 'meilisearch'
 
 ;(async () => {
   const client = new MeiliSearch({

--- a/examples/node/search_example.js
+++ b/examples/node/search_example.js
@@ -1,4 +1,4 @@
-const MeiliSearch = require('../../dist/bundles/meilisearch.umd.js')
+const { MeiliSearch } = require('../../dist/bundles/meilisearch.umd.js')
 const dataset = require('./small_movies.json')
 
 const config = {

--- a/examples/typescript-browser/package.json
+++ b/examples/typescript-browser/package.json
@@ -4,7 +4,7 @@
   "description": "MeiliSearch Typescript Demo",
   "main": "index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack --resolveJsonModule"
   },
   "keywords": [
     "demo",

--- a/examples/typescript-browser/src/index.ts
+++ b/examples/typescript-browser/src/index.ts
@@ -1,4 +1,4 @@
-import MeiliSearch, { IndexResponse } from '../../../'
+import { MeiliSearch, IndexResponse } from '../../../'
 
 const config = {
   host: 'http://127.0.0.1:7700',

--- a/examples/typescript-browser/tsconfig.json
+++ b/examples/typescript-browser/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   }
 }

--- a/examples/typescript-browser/webpack.config.js
+++ b/examples/typescript-browser/webpack.config.js
@@ -7,7 +7,7 @@ let config = {
     path: path.resolve(__dirname, './public'),
     filename: './bundle.js',
   },
-  mode: 'production',
+  mode: 'development',
   module: {
     rules: [
       {

--- a/examples/typescript-node/src/index.ts
+++ b/examples/typescript-node/src/index.ts
@@ -1,4 +1,4 @@
-import MeiliSearch, { IndexResponse } from '../../../'
+import { MeiliSearch, IndexResponse } from '../../../'
 
 const config = {
   host: 'http://127.0.0.1:7700',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,6 @@ function getOutputFileName(fileName, isProd = false) {
 }
 
 const env = process.env.NODE_ENV || 'development'
-const LIB_NAME = 'MeiliSearch'
 const ROOT = resolve(__dirname, '.')
 
 const PLUGINS = [
@@ -22,7 +21,6 @@ const PLUGINS = [
       allowJs: false,
       includes: ['src'],
       exclude: ['tests', 'examples', '*.js', 'scripts'],
-      esModuleInterop: true,
     },
   }),
 ]
@@ -33,7 +31,8 @@ module.exports = [
     input: 'src/meilisearch.ts', // directory to transpilation of typescript
     external: ['cross-fetch', 'cross-fetch/polyfill'],
     output: {
-      name: LIB_NAME,
+      name: 'window',
+      extend: true,
       file: getOutputFileName(
         // will add .min. in filename if in production env
         resolve(ROOT, pkg.browser),
@@ -88,7 +87,7 @@ module.exports = [
           resolve(ROOT, pkg.module),
           env === 'production'
         ),
-        exports: 'default',
+        exports: 'named',
         format: 'es',
         sourcemap: env === 'production', // create sourcemap for error reporting in production mode
       },

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -14,7 +14,7 @@ import HttpRequests from './http-requests'
 
 type createPath = (x: string | number) => string
 
-class MeiliSearch implements Types.MeiliSearchInterface {
+export class MeiliSearch implements Types.MeiliSearchInterface {
   config: Types.Config
   httpRequest: HttpRequests
   static apiRoutes: {
@@ -208,5 +208,3 @@ class MeiliSearch implements Types.MeiliSearchInterface {
     return await this.httpRequest.get<Types.EnqueuedDump>(url)
   }
 }
-
-export default MeiliSearch

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,12 @@
 // TypeScript Version: ^3.8.3
 
 import { Index } from './index'
-import MeiliSearch from './meilisearch'
+import { MeiliSearch } from './meilisearch'
 import MeiliSearchApiError from './errors/meilisearch-api-error'
 import MeiliSearchTimeOutError from './errors/meilisearch-timeout-error'
 import MeiliSearchError from './errors/meilisearch-error'
 export { Index }
+export { MeiliSearch }
 export { MeiliSearchApiError }
 export { MeiliSearchError }
 export { MeiliSearchTimeOutError }

--- a/tests/env/esm/src/index.js
+++ b/tests/env/esm/src/index.js
@@ -1,5 +1,6 @@
-import MeiliSearch from '../meilisearch.esm'
+import { MeiliSearch } from '../meilisearch.esm'
+import * as DefaultMeiliSearch from '../meilisearch.esm'
 
-console.log(MeiliSearch)
 const client = new MeiliSearch({ host:'http://localhost:7700', apiKey: 'masterKey'})
-console.log({ client })
+const defaultClient = new DefaultMeiliSearch.MeiliSearch({ host:'http://localhost:7700', apiKey: 'masterKey'})
+console.log({ client, defaultClient })

--- a/tests/env/esm/webpack.config.js
+++ b/tests/env/esm/webpack.config.js
@@ -2,7 +2,6 @@ const path = require('path')
 
 module.exports = {
   entry: './src/index.js',
-  target: 'node', // this means that the `main` field will be used
   mode: 'production',
   output: {
     path: path.resolve(__dirname, 'dist'),

--- a/tests/env/express/public/index.html
+++ b/tests/env/express/public/index.html
@@ -15,7 +15,8 @@
 <script>
   ;(async () => {
     try {
-      const client = new window.MeiliSearch({
+      // also works with window.MeiliSearch
+      const client = new MeiliSearch({
         host: 'http://127.0.0.1:7700',
         apiKey: 'masterKey',
       })

--- a/tests/env/node/index.js
+++ b/tests/env/node/index.js
@@ -1,4 +1,6 @@
-const UMDMeiliSearch = require('./meilisearch.umd')
+const { MeiliSearch } = require('./meilisearch.umd')
+const DefaultMeiliSearch = require('./meilisearch.umd')
 
-const UMDtest = new UMDMeiliSearch({ host:'http://localhost:7700', masterKey: 'masterKey'})
-console.log({ UMDtest })
+const UMDtest = new MeiliSearch({ host:'http://localhost:7700', masterKey: 'masterKey'})
+const DefaultUmdTest = new DefaultMeiliSearch.MeiliSearch({ host:'http://localhost:7700', masterKey: 'masterKey'})
+console.log({ UMDtest, DefaultUmdTest })

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -1,4 +1,5 @@
-import MeiliSearch, { IndexResponse } from '../../../../'
+import { MeiliSearch, IndexResponse } from '../../../../'
+import DefaultMeiliSearch from '../../../../'
 
 const config = {
   host: 'http://127.0.0.1:7700',
@@ -6,8 +7,11 @@ const config = {
 }
 
 const client = new MeiliSearch(config)
+const defaultClient = new DefaultMeiliSearch(config)
 
 ;(async () => {
   const indexes = await client.listIndexes()
+  const defaultIndexes = await defaultClient.listIndexes()
   indexes.map((index: IndexResponse) => index.uid)
+  defaultIndexes.map((index: IndexResponse) => index.uid)
 })()

--- a/tests/index_tests.ts
+++ b/tests/index_tests.ts
@@ -1,5 +1,6 @@
-import MeiliSearch, * as Types from '../src/types'
+import * as Types from '../src/types'
 import {
+  MeiliSearch,
   clearAllIndexes,
   config,
   masterClient,

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -1,4 +1,4 @@
-import MeiliSearch from '../src/meilisearch'
+import { MeiliSearch } from '../src/meilisearch'
 import { Index } from '../src/index'
 import * as Types from '../src/types'
 import { sleep } from '../src/utils'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,12 @@
       "declaration": true,
       "declarationMap": true,
       "declarationDir": "./dist/types",
-      "esModuleInterop": true,
       "allowSyntheticDefaultImports": true,
-      "lib": ["ES2015", "ESNext", "dom"]
+      "lib": ["ES2015", "ESNext", "dom"],
+      "noUnusedLocals": true,
+      "strictNullChecks": true,
+      "noImplicitAny": true,
+      "noImplicitThis": true,
   },
   "include": ["src"], // files to include during transpilation
 }


### PR DESCRIPTION
Fixes: #686
Based on: https://github.com/meilisearch/instant-meilisearch/issues/122

# Changes in README

To showcase named exports a few changes have been made in README and code-samples: 
- Separate ES, CJS and browser syntax for clarity
- Changed code-samples the same way

**These changes in the readme and code samples are open for discussion.**

# Named exports
MeiliSearch Js decided to go in the direction of new best practices in JS libraries by changing from default export to named export.

## New usage 

ES:
```javascript
import { MeiliSearch } from 'meilisearch' // ES
import DefaultMeiliSearch  from 'meilisearch' // ES

// new MeiliSearch(..)
// new DefaultMeiliSearch.MeiliSearch(..)
``` 

Node
```javascript
const { MeiliSearch } = require('meilisearch') // Node
const DefaultMeiliSearch = require('meilisearch') // Node

// new MeiliSearch(..)
// new DefaultMeiliSearch.MeiliSearch(..)
``` 

```javascript
MeiliSearch // browser
window.MeiliSearch // browser

// new MeiliSearch(..)
// new window.MeiliSearch(..)
``` 

### Typescript
```javascript
import { MeiliSearch, IndexResponse } from 'meilisearch' // ES
import DefaultMeiliSearch  from 'meilisearch' // ES

// IndexResponse
// DefaultMeiliSearch.IndexResponse
```

## Explanation

Default export brought a bunch of problems with it. Having as pros only easy of use (which becomes less and less true).

This is how it worked before this PR:

Most basic usage:
```javascript
import MeiliSearch from 'meilisearch' // ES
const MeiliSearch = require('meilisearch') // Node

// new MeiliSearch(...)
``` 

```js
window.MeiliSearch // browser
```

### Typescript
Where things got ugly: 

In typescript types are not exported by default as the default export is already used by `MeiliSearch`. 
Meaning you would have to do one of the following to get both MeiliSearch and a specific type.

```javascript
import MeiliSearch, { IndexResponse } from 'meilisearch'
```
Or this
```javascript
import MeiliSearch, * as Types from 'meilisearch'

// Types.IndexResponse
```

## Why the changes

Add to that, Some other arguments ( a [complete argument list is available here](https://github.com/meilisearch/instant-meilisearch/issues/122))

- `intellisense` does not work well with default export as it [lack in suggesting autocomplete](https://stackoverflow.com/questions/54427609/vscode-intellisense-not-fully-working-with-es6-imports)
- CommonJs interop. Without proper configuration of bundle, default export are weird to use in CJS. 
    ```javascript 
    const {default} = require('meilisearch');
    new default.MeiliSearch(...)
   ```
And other that you mind find in the linked github page.



