### PR TITLE
Standardize health method

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -146,7 +146,7 @@ get_index_stats_1: |-
 get_indexes_stats_1: |-
   client.stats()
 get_health_1: |-
-  client.isHealthy()
+  client.health()
 get_version_1: |-
   client.version()
 distinct_attribute_guide_1: |-

--- a/README.md
+++ b/README.md
@@ -494,11 +494,17 @@ Or using the index object:
 
 `client.getKeys(): Promise<Keys>`
 
-### Healthy <!-- omit in toc -->
+### isHealthy <!-- omit in toc -->
+
+- Return `true` or `false` depending on the health of the server.
+
+`client.isHealthy(): Promise<boolean>`
+
+### Health <!-- omit in toc -->
 
 - Check if the server is healthy
 
-`client.isHealthy(): Promise<true>`
+`client.health(): Promise<Health>`
 
 ### Stats <!-- omit in toc -->
 

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -22,7 +22,7 @@ export class MeiliSearch implements Types.MeiliSearchInterface {
   } = {
     listIndexes: 'indexes',
     getKeys: 'keys',
-    isHealthy: 'health',
+    health: 'health',
     stats: 'stats',
     version: 'version',
     createDump: 'dumps',
@@ -152,12 +152,27 @@ export class MeiliSearch implements Types.MeiliSearchInterface {
    * Checks if the server is healthy, otherwise an error will be thrown.
    *
    * @memberof MeiliSearch
+   * @method health
+   */
+  async health(): Promise<Types.Health> {
+    return await this.httpRequest.get<Types.Health>(
+      MeiliSearch.apiRoutes.health
+    )
+  }
+
+  /**
+   * Checks if the server is healthy, return true or false.
+   *
+   * @memberof MeiliSearch
    * @method isHealthy
    */
-  async isHealthy(): Promise<true> {
-    return await this.httpRequest
-      .get(MeiliSearch.apiRoutes.isHealthy)
-      .then(() => true)
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.httpRequest.get(MeiliSearch.apiRoutes.health)
+      return true
+    } catch (e) {
+      return false
+    }
   }
 
   ///

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,6 +201,14 @@ export interface EnqueuedDump {
 }
 
 /*
+ *** HEALTH
+ */
+
+export interface Health {
+  status: 'available'
+}
+
+/*
  *** STATS
  */
 
@@ -256,7 +264,8 @@ export interface MeiliSearchInterface {
   ) => Promise<Index<T>>
   deleteIndex: (uid: string) => Promise<void>
   getKeys: () => Promise<Keys>
-  isHealthy: () => Promise<true>
+  health: () => Promise<Health>
+  isHealthy: () => Promise<boolean>
   stats: () => Promise<Stats>
   version: () => Promise<Version>
   createDump: () => Promise<EnqueuedDump>


### PR DESCRIPTION
**Description**
Checking that method `health()` return `{'status': 'available'}` and added `isHealthy()` method who return boolean value

**Issue related**
meilisearch/integration-guides#55

**Some points of concern**
- `health` method didn't return json but JSObject
- I define `Health` interface this way, which means API should return `'available'` and this could lead to more maintenance but but it felt cleaner to me
```js
 export interface Health {
  status: 'available'
 }
```