### PR TITLE
v0.21: update `.code-samples.meilisearch.yaml`

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -52,11 +52,10 @@ get_settings_1: |-
 update_settings_1: |-
   client.index('movies').updateSettings({
       rankingRules: [
-          'typo',
           'words',
+          'typo',
           'proximity',
           'attribute',
-          'wordsPosition',
           'exactness',
           'desc(release_date)',
           'desc(rank)'
@@ -105,11 +104,10 @@ get_ranking_rules_1: |-
   client.index('movies').getRankingRules()
 update_ranking_rules_1: |-
   client.index('movies').updateRankingRules([
-      'typo',
       'words',
+      'typo',
       'proximity',
       'attribute',
-      'wordsPosition',
       'exactness',
       'asc(release_date)',
       'desc(rank)'
@@ -172,19 +170,19 @@ field_properties_guide_displayed_1: |-
   })
 filtering_guide_1: |-
   client.index('movies').search('Avengers', {
-    filters: 'release_date > 795484800'
+    filter: 'release_date > 795484800'
   })
 filtering_guide_2: |-
   client.index('movies').search('Batman', {
-    filters: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
+    filter: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
   })
 filtering_guide_3: |-
   client.index('movies').search('horror', {
-    filters: 'director = "Jordan Peele"'
+    filter: 'director = "Jordan Peele"'
   })
 filtering_guide_4: |-
   client.index('movies').search('Planet of the Apes', {
-    filters: 'rating >= 3 AND (NOT director = "Tim Burton")'
+    filter: 'rating >= 3 AND (NOT director = "Tim Burton")'
   })
 search_parameter_guide_query_1: |-
   client.index('movies').search('shifu')
@@ -211,15 +209,15 @@ search_parameter_guide_highlight_1: |-
   })
 search_parameter_guide_filter_1: |-
   client.index('movies').search('n', {
-    filters: 'title = Nightshift'
+    filter: 'title = Nightshift'
   })
 search_parameter_guide_filter_2: |-
   client.index('movies').search('n', {
-    filters: 'title="Kung Fu Panda"'
+    filter: 'title="Kung Fu Panda"'
   })
 search_parameter_guide_matches_1: |-
   client.index('movies').search('n', {
-    filters: 'title="Kung Fu Panda"',
+    filter: 'title="Kung Fu Panda"',
     attributesToHighlight: ['overview'],
     matches: true
   })
@@ -240,11 +238,10 @@ settings_guide_stop_words_1: |-
 settings_guide_ranking_rules_1: |-
   client.index('movies').updateSettings({
     rankingRules: [
-        'typo',
         'words',
+        'typo',
         'proximity',
         'attribute',
-        'wordsPosition',
         'exactness',
         'asc(release_date)',
         'desc(rank)'
@@ -286,7 +283,7 @@ search_guide_1: |-
   })
 search_guide_2: |-
   client.index('movies').search('Avengers', {
-    filters: 'release_date > 795484800',
+    filter: 'release_date > 795484800',
   })
 getting_started_add_documents_md: |-
   ```bash
@@ -327,25 +324,25 @@ getting_started_search_md: |-
 
   [About this SDK](https://github.com/meilisearch/meilisearch-js/)
 get_attributes_for_faceting_1: |-
-  client.index('movies').getAttributesForFaceting()
+  client.index('movies').getFilterableAttributes()
 update_attributes_for_faceting_1: |-
   client.index('movies')
-    .updateAttributesForFaceting([
+    .updateFilterableAttributes([
       'genres',
       'director'
     ])
 reset_attributes_for_faceting_1: |-
-  client.index('movies').resetAttributesForFaceting()
+  client.index('movies').resetFilterableAttributes()
 faceted_search_update_settings_1: |-
   client.index('movies')
-    .updateAttributesForFaceting([
+    .updateFilterableAttributes([
       'director',
       'genres'
     ])
 faceted_search_facet_filters_1: |-
   client.index('movies')
     .search('thriller', {
-      facetFilters: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
+      filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
     })
 faceted_search_facets_distribution_1: |-
   client.index('movies')
@@ -354,7 +351,7 @@ faceted_search_facets_distribution_1: |-
     })
 faceted_search_walkthrough_attributes_for_faceting_1: |-
   client.index('movies')
-    .updateAttributesForFaceting([
+    .updateFilterableAttributes([
       'director',
       'producer',
       'genres',
@@ -363,7 +360,7 @@ faceted_search_walkthrough_attributes_for_faceting_1: |-
 faceted_search_walkthrough_facet_filters_1: |-
   client.index('movies')
     .search('thriller', {
-      facetFilters: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
+      filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
     })
 faceted_search_walkthrough_facets_distribution_1: |-
   client.index('movies')

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -204,7 +204,7 @@ search_parameter_guide_crop_1: |-
     cropLength: 10
   })
 search_parameter_guide_highlight_1: |-
-  client.index('movies').search('shifu', {
+  client.index('movies').search('winter feast', {
     attributesToHighlight: ['overview']
   })
 search_parameter_guide_filter_1: |-
@@ -216,9 +216,7 @@ search_parameter_guide_filter_2: |-
     filter: 'title="Kung Fu Panda"'
   })
 search_parameter_guide_matches_1: |-
-  client.index('movies').search('n', {
-    filter: 'title="Kung Fu Panda"',
-    attributesToHighlight: ['overview'],
+  client.index('movies').search('winter feast', {
     matches: true
   })
 settings_guide_synonyms_1: |-
@@ -323,15 +321,15 @@ getting_started_search_md: |-
   ```
 
   [About this SDK](https://github.com/meilisearch/meilisearch-js/)
-get_attributes_for_faceting_1: |-
+get_filterable_attributes_1: |-
   client.index('movies').getFilterableAttributes()
-update_attributes_for_faceting_1: |-
+update_filterable_attributes_1: |-
   client.index('movies')
     .updateFilterableAttributes([
       'genres',
       'director'
     ])
-reset_attributes_for_faceting_1: |-
+reset_filterable_attributes_1: |-
   client.index('movies').resetFilterableAttributes()
 faceted_search_update_settings_1: |-
   client.index('movies')
@@ -339,7 +337,7 @@ faceted_search_update_settings_1: |-
       'director',
       'genres'
     ])
-faceted_search_facet_filters_1: |-
+faceted_search_filter_1: |-
   client.index('movies')
     .search('thriller', {
       filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
@@ -349,7 +347,7 @@ faceted_search_facets_distribution_1: |-
     .search('Batman', {
       facetsDistribution: ['genres']
     })
-faceted_search_walkthrough_attributes_for_faceting_1: |-
+faceted_search_walkthrough_filterable_attributes_1: |-
   client.index('movies')
     .updateFilterableAttributes([
       'director',
@@ -357,7 +355,7 @@ faceted_search_walkthrough_attributes_for_faceting_1: |-
       'genres',
       'production_companies'
     ])
-faceted_search_walkthrough_facet_filters_1: |-
+faceted_search_walkthrough_filter_1: |-
   client.index('movies')
     .search('thriller', {
       filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
@@ -371,3 +369,5 @@ post_dump_1: |-
   client.createDump()
 get_dump_status_1: |-
   client.getDumpStatus("20201101-110357260")
+phrase_search_1: |-
+  client.index('movies').search('"neo"')

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -340,7 +340,7 @@ faceted_search_update_settings_1: |-
 faceted_search_filter_1: |-
   client.index('movies')
     .search('thriller', {
-      filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
+      filter: [['genres = Horror', 'genres = Mystery'], 'director = \"Jordan Peele\"']
     })
 faceted_search_facets_distribution_1: |-
   client.index('movies')
@@ -358,7 +358,7 @@ faceted_search_walkthrough_filterable_attributes_1: |-
 faceted_search_walkthrough_filter_1: |-
   client.index('movies')
     .search('thriller', {
-      filter: [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
+      filter: [['genres = Horror', 'genres = Mystery'], 'director = \"Jordan Peele\"']
     })
 faceted_search_walkthrough_facets_distribution_1: |-
   client.index('movies')
@@ -370,4 +370,4 @@ post_dump_1: |-
 get_dump_status_1: |-
   client.getDumpStatus("20201101-110357260")
 phrase_search_1: |-
-  client.index('movies').search('"neo"')
+  client.index('movies').search('"african american" horror')


### PR DESCRIPTION
### Changes from v0.21:

- `attributesForFaceting` changed to `filterableAttributes` https://github.com/meilisearch/transplant/issues/187
- `filters` changed to `filter` https://github.com/meilisearch/transplant/issues/81
- `facetFilters` removed and replaced with `filter` ^ same as above
- `wordsPosition` ranking rule removed https://github.com/meilisearch/transplant/issues/85
- `typo` ranking rule drops one position in the default order ^ same as above

### ID updates:
- `get_attributes_for_faceting_1` -> `get_filterable_attributes_1`
- `update_attributes_for_faceting_1` -> `update_filterable_attributes_1`
- `reset_attributes_for_faceting_1` -> `reset_filterable_attributes_1`
- `faceted_search_walkthrough_attributes_for_faceting_1` -> `faceted_search_walkthrough_filterable_attributes_1`
- `faceted_search_facet_filters_1` -> `faceted_search_filter_1`
- `faceted_search_walkthrough_facet_filters_1` -> `faceted_search_walkthrough_filter_1`

### Other small improvements

`search_parameter_guide_matches_1` and `search_parameter_guide_highlight_1` **have been altered**: the query has been changed from `shifu` to `winter feast` and highlighting has been removed from the former. The former is because the terms occur earlier in the value, making it a better demonstration of matches and highlighting, and the latter is because we don't want to encourage using both `matches` and `attributesToHighlight` at the same time—one is sufficient for most use-cases.

### Phrase search

Finally, a brand new sample has been added to demonstrate the use of **Phrase Search**: `phrase_search_1`.
We are still working on the example for this, so please hold off on merging for the moment.