### PR TITLE
Add lint tests for yaml files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
   versioning-strategy: increase
   rebase-strategy: disabled
   ignore:
-      - dependency-name: "eslint*"
-      - dependency-name: "babel-eslint"
-      - dependency-name: "*prettier*"
+    - dependency-name: "eslint*"
+    - dependency-name: "babel-eslint"
+    - dependency-name: "*prettier*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  labels:
-  - skip-changelog
-  - dependencies
-  versioning-strategy: increase
-  rebase-strategy: disabled
-  ignore:
-    - dependency-name: "eslint*"
-    - dependency-name: "babel-eslint"
-    - dependency-name: "*prettier*"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 10
+    labels:
+      - skip-changelog
+      - dependencies
+    versioning-strategy: increase
+    rebase-strategy: disabled
+    ignore:
+      - dependency-name: "eslint*"
+      - dependency-name: "babel-eslint"
+      - dependency-name: "*prettier*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,6 @@ jobs:
         run: yarn --dev
       - name: Run style check
         run: yarn style
-
-  yaml-lint:
-    name: yaml-lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ jobs:
     name: yaml-lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: yaml-lint
-      uses: ibiqlik/action-yamllint@v3
-      with:
-        config_file: .yamllint.yml
+      - uses: actions/checkout@v1
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,3 +56,13 @@ jobs:
         run: yarn --dev
       - name: Run style check
         run: yarn style
+
+  yaml-lint:
+    name: yaml-lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        config_file: .yamllint.yml

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,10 +3,7 @@ ignore: |
   node_modules
 
 rules:
-  # 80 chars should be enough, but don't fail if a line is longer
   line-length: disable
-
-  # don't bother me with this rule
   document-start: disable
   brackets: disable
   truthy: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+extends: default
+ignore: |
+  node_modules
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length: disable
+
+  # don't bother me with this rule
+  document-start: disable
+  brackets: disable
+  truthy: disable


### PR DESCRIPTION
Yaml linter to avoid the following errors: https://github.com/meilisearch/meilisearch-go/issues/173

Example on error: 

```
Error: -samples.meilisearch.yaml:374:1: [error] syntax error: could not find expected ':' (syntax)
Error: ub/dependabot.yml:3:1: [error] wrong indentation: expected 2 but found 0 (indentation)
Error: ub/dependabot.yml:10:3: [error] wrong indentation: expected 4 but found 2 (indentation)
Error: ub/workflows/tests.yml:64:5: [error] wrong indentation: expected 6 but found 4 (indentation)
Error: Process completed with exit code 1.
```