### PR TITLE
Remove unecessary type complexity on searchParameters

### DIFF
--- a/src/lib/indexes.ts
+++ b/src/lib/indexes.ts
@@ -37,7 +37,7 @@ import {
 import { sleep, removeUndefinedFromObject } from './utils'
 import { HttpRequests } from './http-requests'
 
-class Index<T> {
+class Index<T = Record<string, any>> {
   uid: string
   primaryKey: string | undefined
   httpRequest: HttpRequests
@@ -79,11 +79,11 @@ class Index<T> {
    * @memberof Index
    * @method search
    */
-  async search<P extends SearchParams<T>>(
+  async search<T = Record<string, any>>(
     query?: string | null,
-    options?: P,
+    options?: SearchParams,
     config?: Partial<Request>
-  ): Promise<SearchResponse<T, P>> {
+  ): Promise<SearchResponse<T>> {
     const url = `indexes/${this.uid}/search`
 
     return await this.httpRequest.post(
@@ -99,11 +99,11 @@ class Index<T> {
    * @memberof Index
    * @method search
    */
-  async searchGet<P extends SearchParams<T>>(
+  async searchGet<T = Record<string, any>>(
     query?: string | null,
-    options?: P,
+    options?: SearchParams,
     config?: Partial<Request>
-  ): Promise<SearchResponse<T, P>> {
+  ): Promise<SearchResponse<T>> {
     const url = `indexes/${this.uid}/search`
 
     const parseFilter = (filter?: Filter): string | undefined => {
@@ -134,7 +134,7 @@ class Index<T> {
         : undefined,
     }
 
-    return await this.httpRequest.get<SearchResponse<T, P>>(
+    return await this.httpRequest.get<SearchResponse<T>>(
       url,
       removeUndefinedFromObject(getParams),
       config
@@ -182,7 +182,7 @@ class Index<T> {
    * @memberof Index
    * @method create
    */
-  static async create<T = any>(
+  static async create<T = Record<string, any>>(
     config: Config,
     uid: string,
     options: IndexOptions = {}
@@ -278,16 +278,16 @@ class Index<T> {
    * @memberof Index
    * @method getDocuments
    */
-  async getDocuments<P extends GetDocumentsParams<T>>(
-    options?: P
-  ): Promise<GetDocumentsResponse<T, P>> {
+  async getDocuments<T = Record<string, any>>(
+    options?: GetDocumentsParams<T>
+  ): Promise<GetDocumentsResponse<T>> {
     const url = `indexes/${this.uid}/documents`
     let attr
     if (options !== undefined && Array.isArray(options.attributesToRetrieve)) {
       attr = options.attributesToRetrieve.join(',')
     }
 
-    return await this.httpRequest.get<GetDocumentsResponse<T, P>>(url, {
+    return await this.httpRequest.get<GetDocumentsResponse<T>>(url, {
       ...options,
       ...(attr !== undefined ? { attributesToRetrieve: attr } : {}),
     })

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -37,13 +37,13 @@ export type AddDocumentParams = {
 
 export type Filter = string | Array<string | string[]>
 
-export type SearchParams<T> = {
+export type SearchParams = {
   offset?: number
   limit?: number
-  attributesToRetrieve?: Array<Extract<keyof T, string> | '*'>
-  attributesToCrop?: Array<Extract<keyof T, string> | '*'>
+  attributesToRetrieve?: string[]
+  attributesToCrop?: string[]
   cropLength?: number
-  attributesToHighlight?: Array<Extract<keyof T, string> | '*'>
+  attributesToHighlight?: string[]
   filter?: Filter
   sort?: string[]
   facetsDistribution?: string[]
@@ -88,26 +88,19 @@ export type _matchesInfo<T> = Partial<
   Record<keyof T, Array<{ start: number; length: number }>>
 >
 
-export type Hit<T> = T & {
+export type document = {
+  [field: string]: any
+}
+
+export type Hit<T = document> = T & {
   _formatted?: Partial<T>
   _matchesInfo?: _matchesInfo<T>
 }
 
-export type Hits<
-  T,
-  P extends SearchParams<T>
-> = P['attributesToRetrieve'] extends Array<'*'>
-  ? Array<Hit<T>>
-  : P['attributesToRetrieve'] extends Array<infer K> // if P['attributesToRetrieve'] is an array, we use `infer K` to extract the keys in the array in place
-  ? Array<Hit<Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>>> // Same extraction method as above when we have a single `attributesToRetrieve`
-  : Array<Hit<T>> // Finally return the full type as `attributesToRetrieve` is neither a single key nor an array of keys
+export type Hits<T = document> = Array<Hit<T>>
 
-// The second generic P is used to capture the SearchParams type
-export type SearchResponse<T, P extends SearchParams<T>> = {
-  // P represents the SearchParams
-  // and by using the indexer P['attributesToRetrieve'], we're able to pick the type of `attributesToRetrieve`
-  // and check whether the attribute is a single key present in the generic
-  hits: Hits<T, P>
+export type SearchResponse<T = Record<string, any>> = {
+  hits: Hits<T>
   offset: number
   limit: number
   processingTimeMs: number
@@ -125,7 +118,7 @@ export type FieldDistribution = {
 /*
  ** Documents
  */
-export type GetDocumentsParams<T> = {
+export type GetDocumentsParams<T = Record<string, any>> = {
   offset?: number
   limit?: number
   attributesToRetrieve?:
@@ -133,20 +126,9 @@ export type GetDocumentsParams<T> = {
     | Extract<keyof T, string>
 }
 
-export type GetDocumentsResponse<
-  T,
-  P extends GetDocumentsParams<T>
-> = P['attributesToRetrieve'] extends keyof T
-  ? Array<
-      Document<
-        Pick<T, Exclude<keyof T, Exclude<keyof T, P['attributesToRetrieve']>>>
-      >
-    >
-  : P['attributesToRetrieve'] extends Array<infer K>
-  ? Array<Document<Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>>>
-  : Array<Document<T>>
+export type GetDocumentsResponse<T = Record<string, any>> = Array<Document<T>>
 
-export type Document<T> = T
+export type Document<T = Record<string, any>> = T
 
 /*
  ** Settings

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -29,21 +29,20 @@ const client = new MeiliSearch(config)
     // console.log(index.something) -> ERROR
   })
 
-  const searchParams: SearchParams<Movie> = {
+  const searchParams: SearchParams = {
     limit: 5,
     attributesToRetrieve: ['title', 'genre'],
     attributesToHighlight: ['title'],
     // test: true -> ERROR Test does not exist on type SearchParams
   }
   indexes.map((index: IndexResponse) => index.uid)
-  const res: SearchResponse<Movie, SearchParams<Movie>> = await index.search(
+  const res: SearchResponse<Movie> = await index.search(
     'avenger',
     searchParams
   )
 
   // both work
-  const { hits }: { hits: Hits<Movie, typeof searchParams> } = res
-  // const { hits } : { hits: Hits<Movie, SearchParams<Movie>> } = res;
+  const { hits }: { hits: Hits<Movie> } = res
 
   hits.map((hit: Hit<Movie>) => {
     console.log(hit?.genre)


### PR DESCRIPTION
This level of type complexity was not maintainable and not exhaustive as it would require a lot of work to make it consistent around the whole codebase. 

It also made the usage of the library to limiting in projects that would want different degrees of severity