### PR TITLE
Add http protocol at the beginning of the URL if not present

### DIFF
--- a/src/lib/meilisearch.ts
+++ b/src/lib/meilisearch.ts
@@ -20,14 +20,14 @@ import {
   EnqueuedDump,
 } from '../types'
 import { HttpRequests } from './http-requests'
-import { addProtocolIfNotPresent } from './utils';
+import { addProtocolIfNotPresent } from './utils'
 
 class MeiliSearch {
   config: Config
   httpRequest: HttpRequests
 
   constructor(config: Config) {
-    config = addProtocolIfNotPresent(config);
+    config = addProtocolIfNotPresent(config)
     config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)

--- a/src/lib/meilisearch.ts
+++ b/src/lib/meilisearch.ts
@@ -20,12 +20,14 @@ import {
   EnqueuedDump,
 } from '../types'
 import { HttpRequests } from './http-requests'
+import { addProtocolIfNotPresent } from './utils';
 
 class MeiliSearch {
   config: Config
   httpRequest: HttpRequests
 
   constructor(config: Config) {
+    config = addProtocolIfNotPresent(config);
     config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)

--- a/src/lib/meilisearch.ts
+++ b/src/lib/meilisearch.ts
@@ -27,7 +27,7 @@ class MeiliSearch {
   httpRequest: HttpRequests
 
   constructor(config: Config) {
-    config = addProtocolIfNotPresent(config)
+    config.host = addProtocolIfNotPresent(config.host)
     config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,3 @@
-import { Config } from '../types'
-
 /**
  * Removes undefined entries from object
  */
@@ -15,16 +13,11 @@ async function sleep(ms: number): Promise<void> {
   return await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function addProtocolIfNotPresent(config: Config): Config {
-  if (
-    !(config.host.startsWith('https://') || config.host.startsWith('http://'))
-  ) {
-    return {
-      ...config,
-      host: 'http://' + config.host,
-    }
+function addProtocolIfNotPresent(host: string): string {
+  if (!(host.startsWith('https://') || host.startsWith('http://'))) {
+    return `http://${host}`
   }
-  return config
+  return host
 }
 
 export { sleep, removeUndefinedFromObject, addProtocolIfNotPresent }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { Config } from "../types"
+
 /**
  * Removes undefined entries from object
  */
@@ -13,4 +15,15 @@ async function sleep(ms: number): Promise<void> {
   return await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-export { sleep, removeUndefinedFromObject }
+function addProtocolIfNotPresent(config: Config): Config {
+  if(!!!(config.host.startsWith('https://')||config.host.startsWith('http://'))){
+    let newConfig: Config = {
+      ...config,
+      host: 'http://' + config.host
+    }
+    return newConfig;
+  }
+  return config;
+}
+
+export { sleep, removeUndefinedFromObject, addProtocolIfNotPresent }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Config } from "../types"
+import { Config } from '../types'
 
 /**
  * Removes undefined entries from object
@@ -16,14 +16,15 @@ async function sleep(ms: number): Promise<void> {
 }
 
 function addProtocolIfNotPresent(config: Config): Config {
-  if(!!!(config.host.startsWith('https://')||config.host.startsWith('http://'))){
-    let newConfig: Config = {
+  if (
+    !(config.host.startsWith('https://') || config.host.startsWith('http://'))
+  ) {
+    return {
       ...config,
-      host: 'http://' + config.host
+      host: 'http://' + config.host,
     }
-    return newConfig;
   }
-  return config;
+  return config
 }
 
 export { sleep, removeUndefinedFromObject, addProtocolIfNotPresent }

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -153,6 +153,18 @@ describe.each([
       expect(e.type).toEqual('MeiliSearchCommunicationError')
     }
   })
+
+  test(`${permission} key: host without HTTP should not throw Invalid URL Error`, async () => {
+    const client = new MeiliSearch({ host: 'meilisearch:7700' })
+    const health = await client.isHealthy()
+    expect(health).toBe(false)
+  })
+
+  test(`${permission} key: host without HTTP and port should not throw Invalid URL Error`, async () => {
+    const client = new MeiliSearch({ host: 'meilisearch' })
+    const health = await client.isHealthy()
+    expect(health).toBe(false)
+  })
 })
 
 describe.each([


### PR DESCRIPTION
- Addresses issue #784 
- The bug was caught in docker-compose as the user is putting the hostname which is resolved by docker dns and it allows hostname to be without protocol mentioned in it (https or http)
- This is because the javascript URL() constructor does not accept url which does not follow one of the standard url pattern, which can either be '<protocol>://<host>' or '<host>:<port>'
- To fix it, we can check presence of protocol at the beginning of host and append http by default if any protocol is not present.