### PR TITLE
Change naming of updateDocumentInBatch to Batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Or using the index object:
 
 - [Add or replace multiple documents in batches](https://docs.meilisearch.com/reference/api/documents.html#add-or-replace-documents):
 
-`index.addDocumentsInBatch(documents: Document<T>[], batchSize = 1000): Promise<EnqueuedUpdate[]>`
+`index.addDocumentsInBatches(documents: Document<T>[], batchSize = 1000): Promise<EnqueuedUpdate[]>`
 
 - [Add or update multiple documents](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents):
 
@@ -410,7 +410,7 @@ Or using the index object:
 
 - [Add or update multiple documents in batches](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents):
 
-`index.updateDocumentsInBatch(documents: Document<T>[], batchSize = 1000): Promise<EnqueuedUpdate[]>`
+`index.updateDocumentsInBatches(documents: Document<T>[], batchSize = 1000): Promise<EnqueuedUpdate[]>`
 
 - [Get Documents](https://docs.meilisearch.com/reference/api/documents.html#get-documents):
 

--- a/src/lib/indexes.ts
+++ b/src/lib/indexes.ts
@@ -319,9 +319,9 @@ class Index<T = Record<string, any>> {
   /**
    * Add or replace multiples documents to an index in batches
    * @memberof Index
-   * @method addDocumentsInBatch
+   * @method addDocumentsInBatches
    */
-  async addDocumentsInBatch(
+  async addDocumentsInBatches(
     documents: Array<Document<T>>,
     batchSize = 1000,
     options?: AddDocumentParams
@@ -353,7 +353,7 @@ class Index<T = Record<string, any>> {
    * @memberof Index
    * @method updateDocuments
    */
-  async updateDocumentsInBatch(
+  async updateDocumentsInBatches(
     documents: Array<Document<T>>,
     batchSize = 1000,
     options?: AddDocumentParams

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -74,7 +74,7 @@ describe.each([
   test(`${permission} key: Add documents to uid with primary key in batch`, async () => {
     const response: EnqueuedUpdate[] = await client
       .index(indexPk.uid)
-      .addDocumentsInBatch(dataset, 4)
+      .addDocumentsInBatches(dataset, 4)
     expect(response).toBeInstanceOf(Array)
     expect(response).toHaveLength(2)
     expect(response[0]).toHaveProperty('updateId', expect.any(Number))
@@ -227,7 +227,7 @@ describe.each([
   test(`${permission} key: Update document from index that has a primary key in batch`, async () => {
     const response: EnqueuedUpdate[] = await client
       .index(indexPk.uid)
-      .updateDocumentsInBatch(dataset, 2)
+      .updateDocumentsInBatches(dataset, 2)
     expect(response).toBeInstanceOf(Array)
     expect(response).toHaveLength(4)
     expect(response[0]).toHaveProperty('updateId', expect.any(Number))


### PR DESCRIPTION
Fixes naming error introduced in: #1039

