### PR TITLE
Update .code-samples.meilisearch.yaml

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -281,7 +281,7 @@ settings_guide_ranking_rules_1: |-
     ]
   })
 settings_guide_distinct_1: |-
-  client.index('movies').updateSettings({
+  client.index('jackets').updateSettings({
     distinctAttribute: 'product_id'
   })
 settings_guide_searchable_1: |-


### PR DESCRIPTION
Make `settings_guide_distinct_1` consistent w/ this code sample in other SDKs.

See [this issue](https://github.com/meilisearch/documentation/issues/471#issuecomment-1027733637).