### PR TITLE
Add a validator on the provided host

### DIFF
--- a/src/lib/meilisearch.ts
+++ b/src/lib/meilisearch.ts
@@ -24,7 +24,6 @@ import {
   Result,
 } from '../types'
 import { HttpRequests } from './http-requests'
-import { addProtocolIfNotPresent } from './utils'
 import { TaskClient } from './task'
 
 class MeiliSearch {
@@ -37,8 +36,6 @@ class MeiliSearch {
    * @param {Config} config Configuration object
    */
   constructor(config: Config) {
-    config.host = addProtocolIfNotPresent(config.host)
-    config.host = HttpRequests.addTrailingSlash(config.host)
     this.config = config
     this.httpRequest = new HttpRequests(config)
     this.tasks = new TaskClient(config)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,4 +20,16 @@ function addProtocolIfNotPresent(host: string): string {
   return host
 }
 
-export { sleep, removeUndefinedFromObject, addProtocolIfNotPresent }
+function addTrailingSlash(url: string): string {
+  if (!url.endsWith('/')) {
+    url += '/'
+  }
+  return url
+}
+
+export {
+  sleep,
+  removeUndefinedFromObject,
+  addProtocolIfNotPresent,
+  addTrailingSlash,
+}

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -150,12 +150,6 @@ describe.each([
       new MeiliSearch({ host: '' })
     }).toThrow('The provided host is not valid.')
   })
-
-  test(`${permission} key: Empty string host should throw an error`, () => {
-    expect(() => {
-      new MeiliSearch({ host: null })
-    }).toThrow('The provided host is not valid.')
-  })
 })
 
 describe.each([{ permission: 'Master' }, { permission: 'Private' }])(

--- a/tests/client_tests.ts
+++ b/tests/client_tests.ts
@@ -144,6 +144,18 @@ describe.each([
     const health = await client.isHealthy()
     expect(health).toBe(false)
   })
+
+  test(`${permission} key: Empty string host should throw an error`, () => {
+    expect(() => {
+      new MeiliSearch({ host: '' })
+    }).toThrow('The provided host is not valid.')
+  })
+
+  test(`${permission} key: Empty string host should throw an error`, () => {
+    expect(() => {
+      new MeiliSearch({ host: null })
+    }).toThrow('The provided host is not valid.')
+  })
 })
 
 describe.each([{ permission: 'Master' }, { permission: 'Private' }])(

--- a/tests/unit_tests.ts
+++ b/tests/unit_tests.ts
@@ -18,6 +18,5 @@ test(`Client handles host URL with domain and path and no trailing slash`, () =>
   const client = new MeiliSearch({
     host: customHost,
   })
-  expect(client.config.host).toBe(customHost + '/')
   expect(client.httpRequest.url.href).toBe(customHost + '/')
 })


### PR DESCRIPTION
the previous error was very unclear on what the problem was, in another repo I had to create a wrapper around the error. So I might just change it here: 

before: 
```
TypeError [ERR_INVALID_URL]: Invalid URL: http://
    at onParseError (internal/url.js:259:9)
    at new URL (internal/url.js:335:5)
   // ....
  input: 'http://',
  code: 'ERR_INVALID_URL'
}
```

after: 
```
Error [MeiliSearchError]: The provided host is not valid.
    at new HttpRequests (/meilisearch-js/dist/bundles/meilisearch.umd.js:320:17)
    at new MeiliSearch (/meilisearch-js/dist/bundles/meilisearch.umd.js:2336:28)
   // ....
  type: 'MeiliSearchError'
}
```