### PR TITLE
Make tenant token generation code sample consistent w/ spec

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -313,8 +313,8 @@ add_movies_json_1: |-
   client.index('movies').addDocuments(movies).then((res) => console.log(res))
 documents_guide_add_movie_1: |-
   client.index('movies').addDocuments([{
-    'movie_id': '123sq178',
-    'title': 'Amelie Poulain'
+    movie_id: '123sq178',
+    title: 'Amelie Poulain'
   }])
 search_guide_1: |-
   client.index('movies').search('shifu', {
@@ -502,8 +502,8 @@ authorization_header_1: |-
   client.getKeys()
 tenant_token_guide_generate_sdk_1: |-
   const searchRules = {
-    'patient_medical_records': {
-      'filter': 'user_id = 1'
+    patient_medical_records: {
+      filter: 'user_id = 1'
     }
   }
   const apiKey = 'B5KdX2MY2jV6EXfUs6scSfmC...'

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -503,7 +503,7 @@ authorization_header_1: |-
 tenant_token_guide_generate_sdk_1: |-
   const searchRules = {
     'patient_medical_records': {
-      filter: 'user_id = 1'
+      'filter': 'user_id = 1'
     }
   }
   const apiKey = 'B5KdX2MY2jV6EXfUs6scSfmC...'


### PR DESCRIPTION
~I haven't tested this myself, so I'm not positive it's correct, but in the spec `'filter'` is always treated as a string in the `searchRules` object.~

I asked @curquiza and she told me that

```
example = {
  frites: "miam"
}
```

and

```
example = {
  "frites": "miam"
}
```

are treated as exactly the same by JavaScript. In this case the syntax without quotes would actually be preferred since the key is only a single word. It does make me wonder why `patient_medical_records` is in quotes in the same sample--might be inconsistent? But anyway, sorry to bother you and feel free to close this PR 😅 