### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -50,30 +50,42 @@ export type Query = {
   q?: string | null
 }
 
-export type SearchParams = Pagination & {
-  filter?: Filter
-  sort?: string[]
-  facetsDistribution?: string[]
-  attributesToRetrieve?: string[]
+export type Highlight = {
   attributesToHighlight?: string[]
+  highlightPreTag?: string
+  highlightPostTag?: string
+}
+
+export type Crop = {
   attributesToCrop?: string[]
   cropLength?: number
-  matches?: boolean
+  cropMarker?: string
 }
+
+export type SearchParams = Pagination &
+  Highlight &
+  Crop & {
+    filter?: Filter
+    sort?: string[]
+    facetsDistribution?: string[]
+    attributesToRetrieve?: string[]
+    matches?: boolean
+  }
 
 export type SearchRequest = SearchParams & Query
 
 // Search parameters for searches made with the GET method
 // Are different than the parameters for the POST method
 export type SearchRequestGET = Pagination &
-  Query & {
+  Query &
+  Omit<Highlight, 'attributesToHighlight'> &
+  Omit<Crop, 'attributesToCrop'> & {
     filter?: string
     sort?: string
     facetsDistribution?: string
     attributesToRetrieve?: string
     attributesToHighlight?: string
     attributesToCrop?: string
-    cropLength?: number
     matches?: boolean
   }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -39,6 +39,10 @@ export type AddDocumentParams = {
   primaryKey?: string
 }
 
+/*
+ * SEARCH PARAMETERS
+ */
+
 export type Filter = string | Array<string | string[]>
 
 export type Pagination = {

--- a/tests/get_search_tests.ts
+++ b/tests/get_search_tests.ts
@@ -230,6 +230,47 @@ describe.each([
     expect(response.hits[0]).toHaveProperty('_matchesInfo', expect.any(Object))
   })
 
+  test(`${permission} key: search on default cropping parameters`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).searchGet('prince', {
+      attributesToCrop: ['*'],
+      cropLength: 6,
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      '…book about a prince that walks…'
+    )
+  })
+
+  test(`${permission} key: search on customized cropMarker`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).searchGet('prince', {
+      attributesToCrop: ['*'],
+      cropLength: 6,
+      cropMarker: '(ꈍᴗꈍ)',
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      '(ꈍᴗꈍ)book about a prince that walks(ꈍᴗꈍ)'
+    )
+  })
+
+  test(`${permission} key: search on customized highlight tags`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).searchGet('prince', {
+      attributesToHighlight: ['*'],
+      highlightPreTag: '(⊃｡•́‿•̀｡)⊃ ',
+      highlightPostTag: ' ⊂(´• ω •`⊂)',
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      'A french book about a (⊃｡•́‿•̀｡)⊃ prince ⊂(´• ω •`⊂) that walks on little cute planets'
+    )
+  })
+
   test(`${permission} key: search with all options and all fields`, async () => {
     const client = await getClient(permission)
     const response = await client.index(index.uid).searchGet('prince', {

--- a/tests/search_tests.ts
+++ b/tests/search_tests.ts
@@ -244,6 +244,47 @@ describe.each([
     expect(response.hits[0]).toHaveProperty('_matchesInfo', expect.any(Object))
   })
 
+  test(`${permission} key: search on default cropping parameters`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search('prince', {
+      attributesToCrop: ['*'],
+      cropLength: 6,
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      '…book about a prince that walks…'
+    )
+  })
+
+  test(`${permission} key: search on customized cropMarker`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search('prince', {
+      attributesToCrop: ['*'],
+      cropLength: 6,
+      cropMarker: '(ꈍᴗꈍ)',
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      '(ꈍᴗꈍ)book about a prince that walks(ꈍᴗꈍ)'
+    )
+  })
+
+  test(`${permission} key: search on customized highlight tags`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search('prince', {
+      attributesToHighlight: ['*'],
+      highlightPreTag: '(⊃｡•́‿•̀｡)⊃ ',
+      highlightPostTag: ' ⊂(´• ω •`⊂)',
+    })
+
+    expect(response.hits[0]._formatted).toHaveProperty(
+      'comment',
+      'A french book about a (⊃｡•́‿•̀｡)⊃ prince ⊂(´• ω •`⊂) that walks on little cute planets'
+    )
+  })
+
   test(`${permission} key: search with all options and all fields`, async () => {
     const client = await getClient(permission)
     const response = await client.index(index.uid).search('prince', {
@@ -408,6 +449,17 @@ describe.each([
       genre: { fantasy: 2 },
     })
     expect(response.hits.length).toEqual(2)
+  })
+
+  test(`${permission} key: search on index with no documents and no primary key`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(emptyIndex.uid).search('prince', {})
+    expect(response).toHaveProperty('hits', [])
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
+    expect(response).toHaveProperty('query', 'prince')
+    expect(response.hits.length).toEqual(0)
   })
 
   test(`${permission} key: search on index with no documents and no primary key`, async () => {


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced: 

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`
