### PR TITLE
Unskip formatted tests failing due to unexpected meilisearch change

### DIFF
--- a/tests/typed_search_tests.ts
+++ b/tests/typed_search_tests.ts
@@ -167,8 +167,7 @@ describe.each([
     ])
   })
 
-  // TODO: enable again on rc1
-  test.skip(`${permission} key: Search with all options but not all fields`, async () => {
+  test(`${permission} key: Search with all options but not all fields`, async () => {
     const client = await getClient(permission)
     const response = await client.index<Movie>(index.uid).search('prince', {
       limit: 5,


### PR DESCRIPTION
An unexpected change in the pre-release of Meilisearch made a test fail. 
Since of the latest RC this has been fixed and thus the tested on skiped

https://github.com/meilisearch/meilisearch/issues/2318