### PR TITLE
Update wrong naming inside typotolerance setting

### DIFF
--- a/tests/settings_tests.ts
+++ b/tests/settings_tests.ts
@@ -43,7 +43,7 @@ const defaultSettings = {
   synonyms: {},
   typoTolerance: {
     enabled: true,
-    minWordLengthForTypo: {
+    minWordSizeForTypos: {
       oneTypo: 5,
       twoTypos: 9,
     },
@@ -116,7 +116,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         synonyms: { harry: ['potter'] },
         typoTolerance: {
           enabled: false,
-          minWordLengthForTypo: {
+          minWordSizeForTypos: {
             oneTypo: 1,
             twoTypos: 100,
           },
@@ -151,7 +151,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         synonyms: null,
         typoTolerance: {
           enabled: null,
-          minWordLengthForTypo: {
+          minWordSizeForTypos: {
             oneTypo: null,
             twoTypos: null,
           },

--- a/tests/typo_tolerance_tests.ts
+++ b/tests/typo_tolerance_tests.ts
@@ -14,7 +14,7 @@ const index = {
 
 const defaultTypoTolerance = {
   enabled: true,
-  minWordLengthForTypo: {
+  minWordSizeForTypos: {
     oneTypo: 5,
     twoTypos: 9,
   },
@@ -50,7 +50,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       const client = await getClient(permission)
       const newTypoTolerance = {
         enabled: false,
-        minWordLengthForTypo: {
+        minWordSizeForTypos: {
           oneTypo: 1,
           twoTypos: 2,
         },


### PR DESCRIPTION
The setting `minWordLengthForTypo` inside the `typoTolerance` setting was wrongly named. 
In this PR it is updated to the correct settings name: `minWordSizeForTypos`


https://github.com/meilisearch/meilisearch/pull/2326