### PR TITLE
Make updateDocuments accept partial documents in typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,11 +385,11 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Add or update multiple documents](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents):
 
-`index.updateDocuments(documents: Document<T>[]): Promise<EnqueuedTask>`
+`index.updateDocuments(documents: Array<Document<Partial<T>>>): Promise<EnqueuedTask>`
 
 - [Add or update multiple documents in batches](https://docs.meilisearch.com/reference/api/documents.html#add-or-update-documents):
 
-`index.updateDocumentsInBatches(documents: Document<T>[], batchSize = 1000): Promise<EnqueuedTask[]>`
+`index.updateDocumentsInBatches(documents: Array<Document<Partial<T>>>, batchSize = 1000): Promise<EnqueuedTask[]>`
 
 - [Get Documents](https://docs.meilisearch.com/reference/api/documents.html#get-documents):
 

--- a/src/lib/indexes.ts
+++ b/src/lib/indexes.ts
@@ -394,12 +394,12 @@ class Index<T = Record<string, any>> {
    * Add or update multiples documents to an index
    * @memberof Index
    * @method updateDocuments
-   * @param {Array<Document<T>>} documents Array of Document objects to add/update
+   * @param {Array<Document<Partial<T>>>} documents Array of Document objects to add/update
    * @param {AddDocumentParams} options? Query parameters
    * @returns {Promise<EnqueuedTask>} Promise containing object of the enqueued update
    */
   async updateDocuments(
-    documents: Array<Document<T>>,
+    documents: Array<Document<Partial<T>>>,
     options?: AddDocumentParams
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
@@ -417,7 +417,7 @@ class Index<T = Record<string, any>> {
    * @returns {Promise<EnqueuedTasks>} Promise containing array of enqueued update objects for each batch
    */
   async updateDocumentsInBatches(
-    documents: Array<Document<T>>,
+    documents: Array<Document<Partial<T>>>,
     batchSize = 1000,
     options?: AddDocumentParams
   ): Promise<EnqueuedTask[]> {

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -184,7 +184,7 @@ describe('Documents tests', () => {
         expect(response).toHaveProperty('title', title)
       })
 
-      test(`${permission} key: Partial update a document`, async () => {
+      test(`${permission} key: Partial update of a document`, async () => {
         const client = await getClient(permission)
         const id = 456
         const documents: EnqueuedTask = await client
@@ -215,7 +215,7 @@ describe('Documents tests', () => {
         }
       })
 
-      test(`${permission} key: Update partial document in batch`, async () => {
+      test(`${permission} key: Partial update of a document in batch`, async () => {
         const client = await getClient(permission)
         const partialDocument = { id: 1 }
 

--- a/tests/documents_tests.ts
+++ b/tests/documents_tests.ts
@@ -11,6 +11,7 @@ import {
   MeiliSearch,
   getClient,
   dataset,
+  Book,
 } from './meilisearch-test-utils'
 
 const indexNoPk = {
@@ -183,6 +184,20 @@ describe('Documents tests', () => {
         expect(response).toHaveProperty('title', title)
       })
 
+      test(`${permission} key: Partial update a document`, async () => {
+        const client = await getClient(permission)
+        const id = 456
+        const documents: EnqueuedTask = await client
+          .index<Book>(indexPk.uid)
+          .updateDocuments([{ id }])
+        await client.index(indexPk.uid).waitForTask(documents.uid)
+
+        const response = await client.index(indexPk.uid).getDocument(id)
+
+        expect(response).toHaveProperty('id', id)
+        expect(response).not.toHaveProperty('title')
+      })
+
       test(`${permission} key: Update document from index that has a primary key in batch`, async () => {
         const client = await getClient(permission)
         const tasks = await client
@@ -195,6 +210,28 @@ describe('Documents tests', () => {
           const task = await client
             .index(indexPk.uid)
             .waitForTask(EnqueuedTask.uid)
+          expect(task.status).toBe(TaskStatus.TASK_SUCCEEDED)
+          expect(task.type).toBe('documentPartial')
+        }
+      })
+
+      test(`${permission} key: Update partial document in batch`, async () => {
+        const client = await getClient(permission)
+        const partialDocument = { id: 1 }
+
+        const tasks = await client
+          .index<Book>(indexPk.uid)
+          .updateDocumentsInBatches([partialDocument], 2)
+
+        expect(tasks).toBeInstanceOf(Array)
+        expect(tasks).toHaveLength(1)
+        expect(tasks[0]).toHaveProperty('uid', expect.any(Number))
+
+        for (const EnqueuedTask of tasks) {
+          const task = await client
+            .index(indexPk.uid)
+            .waitForTask(EnqueuedTask.uid)
+
           expect(task.status).toBe(TaskStatus.TASK_SUCCEEDED)
           expect(task.type).toBe('documentPartial')
         }

--- a/tests/meilisearch-test-utils.ts
+++ b/tests/meilisearch-test-utils.ts
@@ -127,6 +127,12 @@ const dataset = [
   { id: 42, title: "The Hitchhiker's Guide to the Galaxy" },
 ]
 
+export type Book = {
+  id: number
+  title: string
+  comment: string
+}
+
 export {
   clearAllIndexes,
   config,


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #1187

In a typed environment, when using the `updateDocuments` method, you should be able to provide only some parts of the document that you want to update. 
Unfortunately, the typing was asking for the whole document. This PR changes the type to `partial`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
