### PR TITLE
Use optional chaining instead of ternary operators in `searchGet` method

### DIFF
--- a/src/lib/indexes.ts
+++ b/src/lib/indexes.ts
@@ -116,19 +116,11 @@ class Index<T = Record<string, any>> {
       q: query,
       ...options,
       filter: parseFilter(options?.filter),
-      sort: options?.sort ? options.sort.join(',') : undefined,
-      facetsDistribution: options?.facetsDistribution
-        ? options.facetsDistribution.join(',')
-        : undefined,
-      attributesToRetrieve: options?.attributesToRetrieve
-        ? options.attributesToRetrieve.join(',')
-        : undefined,
-      attributesToCrop: options?.attributesToCrop
-        ? options.attributesToCrop.join(',')
-        : undefined,
-      attributesToHighlight: options?.attributesToHighlight
-        ? options.attributesToHighlight.join(',')
-        : undefined,
+      sort: options?.sort?.join(','),
+      facetsDistribution: options?.facetsDistribution?.join(','),
+      attributesToRetrieve: options?.attributesToRetrieve?.join(','),
+      attributesToCrop: options?.attributesToCrop?.join(','),
+      attributesToHighlight: options?.attributesToHighlight?.join(','),
     }
 
     return await this.httpRequest.get<SearchResponse<T>>(


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This removes unnecessary ternary operators in the `searchGet` method

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
