### PR TITLE
Remove nodemon from dependabot watched dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,4 @@ updates:
       - dependency-name: "babel-eslint"
       - dependency-name: "*prettier*"
       - dependency-name: "lint-staged"
-      - dependency-name: "nodemon"      
+      - dependency-name: "nodemon"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
       - dependency-name: "babel-eslint"
       - dependency-name: "*prettier*"
       - dependency-name: "lint-staged"
+      - dependency-name: "nodemon"      


### PR DESCRIPTION
Nodemon is a dev dependency that does not impact the code base or the builds