### PR TITLE
Fix type for TypoTolerance

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -163,7 +163,7 @@ export type TypoTolerance = {
   enabled?: boolean | null
   disabledOnAttributes?: string[] | null
   disableOnWords?: string[] | null
-  minWordSizeForTypos?: {
+  minWordLengthForTypo?: {
     oneTypo?: number | null
     twoTypos?: number | null
   }


### PR DESCRIPTION
Fix typescript error by changing key ```minWordSizeForTypos``` in ```minWordLengthForTypo```
