### PR TITLE
Update code-samples with getRawIndexes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -6,7 +6,7 @@
 get_one_index_1: |-
   client.index('movies').getRawInfo()
 list_all_indexes_1: |-
-  client.getIndexes()
+  client.getRawIndexes()
 create_an_index_1: |-
   client.createIndex('movies', { primaryKey: 'id' })
 update_an_index_1: |-


### PR DESCRIPTION
As per [the documentation](https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes), the example should return a list of indexes in an object format and not in a list of instances