### PR TITLE
Allow query in search options

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -81,7 +81,7 @@ class Index<T = Record<string, any>> {
 
     return await this.httpRequest.post(
       url,
-      removeUndefinedFromObject({ ...options, q: query }),
+      removeUndefinedFromObject({ q: query, ...options }),
       undefined,
       config
     )

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -66,7 +66,8 @@ export type Crop = {
   cropMarker?: string
 }
 
-export type SearchParams = Pagination &
+export type SearchParams = Query &
+  Pagination &
   Highlight &
   Crop & {
     filter?: Filter
@@ -75,8 +76,6 @@ export type SearchParams = Pagination &
     attributesToRetrieve?: string[]
     matches?: boolean
   }
-
-export type SearchRequest = SearchParams & Query
 
 // Search parameters for searches made with the GET method
 // Are different than the parameters for the POST method

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -93,6 +93,32 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
+  test(`${permission} key: Search with query in searchParams overwriting query`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('other', { q: 'prince' })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
+    expect(response).toHaveProperty('query', 'prince')
+    expect(response.hits.length).toEqual(2)
+  })
+
+  test(`${permission} key: Search with query in searchParams overwriting null query`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search(null, { q: 'prince' })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
+    expect(response).toHaveProperty('query', 'prince')
+    expect(response.hits.length).toEqual(2)
+  })
+
   test(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -113,6 +113,15 @@ describe.each([
     expect(response.query === 'prince').toBeTruthy()
   })
 
+  test(`${permission} key: Search with query in searchParams`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('other', { q: 'prince' }) // ensures `q` is a valid field in SearchParams type
+
+    expect(response).toHaveProperty('query', 'prince')
+  })
+
   test(`${permission} key: Search with options`, async () => {
     const client = await getClient(permission)
     const response = await client


### PR DESCRIPTION
Fixes: #1198 
closes: #1212


Currently when using the search method: 

```ts
index('xxx').search(query: string, options: SearchParams = {}, config?: Partial<Request>)
```

the `options` parameter complying to the SearchParams type does not accept the `q` parameter in typescript. Which has made a few user having to make a work-around annoying:

```js
const query = params.q
delete params.q
await index.client(query, params)
```

Initially having the `query` as a first parameter has been chosen to make a search without options more simple ([algolia does the same](https://www.algolia.com/doc/api-reference/api-methods/search/#examples)).
Nonetheless, the most common use case would use the second `options` parameter. 

In `not typescript` the user can add `q` to the searchParams. The `q` is overwritten by the first search parameter.

We have three choices to consider: 
### 1. Remove the query parameter

```ts
index('xxx').search(options: SearchParams = {}, config?: Partial<Request>)
```

example: 
```js
index.search({ q: "test" })
```


### 2. Allow query in options but does not overwrite the first params

**current behavior**

the first parameter not be overwritten by the searchParams: 

example: 
```js
index.search("hello", { q: "world" }) // query requested will be `hello`
```

This means that if a user wants to use the option object, they have to still specify the query as the first parameter to avoid a `null` or `undedined` to overwrite the `q` in the options object: 


```js
const options = { q = "hello" }
index.search(options.q, options) // query is hello
index.search(null, options) // query is null
```

### 3. Allow query in options and overwrites first params

the first parameter would be overwritten by the searchParams: 

example: 
```js
index.search("hello",  { q: "world" }) // query requested will be `world`
```

This one lets the user ignore the first parameter

```js
index.search(null, { q: "world" }) // query requested will be `world`
```