### PR TITLE
Update dumps method v0.28

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -506,8 +506,6 @@ faceted_search_walkthrough_filter_1: |-
     })
 post_dump_1: |-
   client.createDump()
-get_dump_status_1: |-
-  client.getDumpStatus('20201101-110357260')
 phrase_search_1: |-
   client.index('movies')
     .search('"african american" horror')

--- a/README.md
+++ b/README.md
@@ -664,11 +664,7 @@ Using the index object:
 
 - [Trigger a dump creation process](https://docs.meilisearch.com/reference/api/dump.html#create-a-dump):
 
-`client.createDump(): Promise<Types.EnqueuedDump>`
-
-- [Get the status of a dump creation process](https://docs.meilisearch.com/reference/api/dump.html#get-dump-status):
-
-`client.getDumpStatus(dumpUid: string): Promise<Types.EnqueuedDump>`
+`client.createDump(): Promise<EnqueuedTask>`
 
 <hr>
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -18,7 +18,6 @@ import {
   Health,
   Stats,
   Version,
-  EnqueuedDump,
   ErrorStatusCode,
   Task,
   Result,
@@ -372,27 +371,19 @@ class Client {
   ///
 
   /**
-   * Triggers a dump creation process
+   * Creates a dump
    * @memberof MeiliSearch
    * @method createDump
-   * @returns {Promise<EnqueuedDump>} Promise returning object of the enqueued task
+   * @returns {Promise<EnqueuedTask>} Promise returning object of the enqueued task
    */
-  async createDump(): Promise<EnqueuedDump> {
+  async createDump(): Promise<EnqueuedTask> {
     const url = `dumps`
-    return await this.httpRequest.post<undefined, EnqueuedDump>(url)
+    return await this.httpRequest.post<undefined, EnqueuedTask>(url)
   }
 
-  /**
-   * Get the status of a dump creation process
-   * @memberof MeiliSearch
-   * @method getDumpStatus
-   * @param {string} dumpUid Dump UID
-   * @returns {Promise<EnqueuedDump>} Promise returning object of the enqueued task
-   */
-  async getDumpStatus(dumpUid: string): Promise<EnqueuedDump> {
-    const url = `dumps/${dumpUid}/status`
-    return await this.httpRequest.get<EnqueuedDump>(url)
-  }
+  ///
+  /// TOKENS
+  ///
 
   /**
    * Generate a tenant token

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -361,7 +361,7 @@ class Index<T = Record<string, any>> {
     options?: AddDocumentParams
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    return await this.httpRequest.post(url, documents, options)
+    return await this.httpRequest.put(url, documents, options)
   }
 
   /**
@@ -452,7 +452,7 @@ class Index<T = Record<string, any>> {
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents/delete-batch`
 
-    return await this.httpRequest.post(url, documentsIds)
+    return await this.httpRequest.put(url, documentsIds)
   }
 
   /**

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -361,7 +361,7 @@ class Index<T = Record<string, any>> {
     options?: AddDocumentParams
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    return await this.httpRequest.put(url, documents, options)
+    return await this.httpRequest.post(url, documents, options)
   }
 
   /**
@@ -452,7 +452,7 @@ class Index<T = Record<string, any>> {
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents/delete-batch`
 
-    return await this.httpRequest.put(url, documentsIds)
+    return await this.httpRequest.post(url, documentsIds)
   }
 
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -208,6 +208,15 @@ export type EnqueuedTask = {
   enqueuedAt: string
 }
 
+export const enum TaskTypes {
+  INDEX_CREATION = 'indexCreation',
+  INDEX_UPDATE = 'indexUpdate',
+  INDEX_DELETION = 'indexDeletion',
+  DOCUMENTS_ADDITION_OR_UPDATE = 'documentAdditionOrUpdate',
+  DOCUMENTS_DELETION = 'documentsDeletion',
+  SETTINGS_UPDATE = 'settingsUpdate',
+}
+
 export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   uid: number
   batchUid: number

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -254,13 +254,6 @@ export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   finishedAt: string
 }
 
-export type EnqueuedDump = {
-  uid: string
-  status: 'in_progress' | 'failed' | 'done'
-  startedAt: string
-  finishedAt: string
-}
-
 export type WaitOptions = {
   timeOutMs?: number
   intervalMs?: number
@@ -459,9 +452,6 @@ export const enum ErrorStatusCode {
 
   /** @see https://docs.meilisearch.com/errors/#task_not_found */
   TASK_NOT_FOUND = 'task_not_found',
-
-  /** @see https://docs.meilisearch.com/errors/#dump_already_processing */
-  DUMP_ALREADY_PROCESSING = 'dump_already_processing',
 
   /** @see https://docs.meilisearch.com/errors/#dump_process_failed */
   DUMP_PROCESS_FAILED = 'dump_process_failed',

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -208,15 +208,6 @@ export type EnqueuedTask = {
   enqueuedAt: string
 }
 
-export const enum TaskTypes {
-  INDEX_CREATION = 'indexCreation',
-  INDEX_UPDATE = 'indexUpdate',
-  INDEX_DELETION = 'indexDeletion',
-  DOCUMENTS_ADDITION_OR_UPDATE = 'documentAdditionOrUpdate',
-  DOCUMENTS_DELETION = 'documentsDeletion',
-  SETTINGS_UPDATE = 'settingsUpdate',
-}
-
 export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   uid: number
   batchUid: number

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -444,22 +444,6 @@ describe.each([{ permission: 'Public' }])(
           ErrorStatusCode.INVALID_API_KEY
         )
       })
-
-      test(`${permission} key: try to create dumps and be denir`, async () => {
-        const client = await getClient(permission)
-        await expect(client.createDump()).rejects.toHaveProperty(
-          'code',
-          ErrorStatusCode.INVALID_API_KEY
-        )
-      })
-
-      test(`${permission} key: try to create dumps and be denied`, async () => {
-        const client = await getClient(permission)
-        await expect(client.getDumpStatus('test')).rejects.toHaveProperty(
-          'code',
-          ErrorStatusCode.INVALID_API_KEY
-        )
-      })
     })
   }
 )
@@ -542,22 +526,6 @@ describe.each([{ permission: 'No' }])(
       test(`${permission} key: try to get /stats information and be denied`, async () => {
         const client = await getClient(permission)
         await expect(client.getStats()).rejects.toHaveProperty(
-          'code',
-          ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
-        )
-      })
-
-      test(`${permission} key: try to create dumps and be denir`, async () => {
-        const client = await getClient(permission)
-        await expect(client.createDump()).rejects.toHaveProperty(
-          'code',
-          ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
-        )
-      })
-
-      test(`${permission} key: try to create dumps and be denied`, async () => {
-        const client = await getClient(permission)
-        await expect(client.getDumpStatus('test')).rejects.toHaveProperty(
           'code',
           ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
         )
@@ -680,32 +648,6 @@ describe.each([
     const client = new MeiliSearch({ host })
     const strippedHost = trailing ? host.slice(0, -1) : host
     await expect(client.getVersion()).rejects.toHaveProperty(
-      'message',
-      `request to ${strippedHost}/${route} failed, reason: connect ECONNREFUSED ${BAD_HOST.replace(
-        'http://',
-        ''
-      )}`
-    )
-  })
-
-  test(`Test createDump route`, async () => {
-    const route = `dumps`
-    const client = new MeiliSearch({ host })
-    const strippedHost = trailing ? host.slice(0, -1) : host
-    await expect(client.createDump()).rejects.toHaveProperty(
-      'message',
-      `request to ${strippedHost}/${route} failed, reason: connect ECONNREFUSED ${BAD_HOST.replace(
-        'http://',
-        ''
-      )}`
-    )
-  })
-
-  test(`Test getDumpStatus route`, async () => {
-    const route = `dumps/1/status`
-    const client = new MeiliSearch({ host })
-    const strippedHost = trailing ? host.slice(0, -1) : host
-    await expect(client.getDumpStatus('1')).rejects.toHaveProperty(
       'message',
       `request to ${strippedHost}/${route} failed, reason: connect ECONNREFUSED ${BAD_HOST.replace(
         'http://',

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -87,6 +87,7 @@ const clearAllIndexes = async (config: Config): Promise<void> => {
     const { taskUid } = await client.index(indexUid).delete()
     taskIds.push(taskUid)
   }
+
   await client.waitForTasks(taskIds)
 }
 

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -1,9 +1,5 @@
-import { MeiliSearch, MeiliSearchTimeOutError, Index } from '../../src'
-import { Config, EnqueuedDump } from '../../src/types'
-
-async function sleep(ms: number): Promise<void> {
-  return await new Promise((resolve) => setTimeout(resolve, ms))
-}
+import { MeiliSearch, Index } from '../../src'
+import { Config } from '../../src/types'
 
 // testing
 const MASTER_KEY = 'masterKey'
@@ -88,25 +84,6 @@ const clearAllIndexes = async (config: Config): Promise<void> => {
     taskIds.push(taskUid)
   }
   await client.waitForTasks(taskIds)
-}
-
-async function waitForDumpProcessing(
-  dumpId: string,
-  client: MeiliSearch,
-  {
-    timeOutMs = 5000,
-    intervalMs = 50,
-  }: { timeOutMs?: number; intervalMs?: number } = {}
-): Promise<EnqueuedDump> {
-  const startingTime = Date.now()
-  while (Date.now() - startingTime < timeOutMs) {
-    const response = await client.getDumpStatus(dumpId)
-    if (response.status !== 'in_progress') return response
-    await sleep(intervalMs)
-  }
-  throw new MeiliSearchTimeOutError(
-    `timeout of ${timeOutMs}ms has exceeded on process ${dumpId} when waiting for the dump creation process to be done.`
-  )
 }
 
 function decode64(buff: string) {
@@ -196,7 +173,6 @@ export {
   MASTER_KEY,
   MeiliSearch,
   Index,
-  waitForDumpProcessing,
   getClient,
   getKey,
   decode64,

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -87,7 +87,6 @@ const clearAllIndexes = async (config: Config): Promise<void> => {
     const { taskUid } = await client.index(indexUid).delete()
     taskIds.push(taskUid)
   }
-
   await client.waitForTasks(taskIds)
 }
 


### PR DESCRIPTION
## Changes related to the `dumps` resources

Related to:
issue: https://github.com/meilisearch/meilisearch/issues/2371

All the changes:
- [x] Remove code sample `get_dump_status_1`
- [x] Remove method get dump status.
- [x] A dump creation now responds with a `task` object from type `dumpCreation`.
- [x] The error `dump_already_processing` don't need to be handled.

## Additional

I removed the tests from `client.tests.ts` related to dumps as they were a duplicate of the ones present in `dumps.tests.ts`