### PR TITLE
Add pagination system on resources for v0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get Documents](https://docs.meilisearch.com/reference/api/documents.html#get-documents):
 
-`index.getDocuments(params: DocumentsQuery): Promise<Result<Documents<T>>>`
+`index.getDocuments(parameters: DocumentsQuery = {}): Promise<Result<Documents<T>>>`
 
 - [Get one document](https://docs.meilisearch.com/reference/api/documents.html#get-one-document):
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get Documents](https://docs.meilisearch.com/reference/api/documents.html#get-documents):
 
-`index.getDocuments(params: DocumentsParams): Promise<Result<Documents<T>>>`
+`index.getDocuments(params: DocumentsQuery): Promise<Result<Documents<T>>>`
 
 - [Get one document](https://docs.meilisearch.com/reference/api/documents.html#get-one-document):
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all tasks](https://docs.meilisearch.com/reference/api/tasks.html#get-all-tasks)
 
-  `client.getTasks(parameters: TaskParams): Promise<TasksResults>`
+  `client.getTasks(parameters: TasksQuery): Promise<TasksResults>`
 
 - [Get one task](https://docs.meilisearch.com/reference/api/tasks.html#get-task)
 
@@ -423,7 +423,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all tasks of an index](https://docs.meilisearch.com/reference/api/tasks.html#get-all-tasks-by-index)
 
-  `index.getTasks(parameters: TaskParams): Promise<TasksResults>`
+  `index.getTasks(parameters: TasksQuery): Promise<TasksResults>`
 
 - [Get one task of an index](https://docs.meilisearch.com/reference/api/tasks.html#get-task)
 

--- a/README.md
+++ b/README.md
@@ -446,11 +446,11 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all indexes as Index instances](https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes):
 
-`client.getIndexes(): Promise<Result<Index[]>>`
+`client.getIndexes(parameters: IndexesQuery): Promise<IndexesResults<Index[]>>`
 
 - [Get all indexes](https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes):
 
-`client.getRawIndexes(): Promise<Result<IndexResponse[]>>`
+`client.getRawIndexes(parameters: IndexesQuery): Promise<Result<IndexObject[]>>`
 
 - [Create a new index](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index):
 
@@ -464,10 +464,10 @@ If you want to know more about the development workflow or want to contribute, p
 `client.getIndex<T>(uid: string): Promise<Index<T>>`
 
 - [Get the raw index JSON response from Meilisearch](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index):
-`client.getRawIndex(uid: string): Promise<IndexResponse>`
+`client.getRawIndex(uid: string): Promise<IndexObject>`
 
 - [Get an object with information about the index](https://docs.meilisearch.com/reference/api/indexes.html#get-one-index):
-`index.getRawInfo(): Promise<IndexResponse>`
+`index.getRawInfo(): Promise<IndexObject>`
 
 - [Update Index](https://docs.meilisearch.com/reference/api/indexes.html#update-an-index):
 
@@ -617,7 +617,7 @@ Using the index object:
 
 - [Get keys](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys):
 
-`client.getKeys(): Promise<Result<Key[]>>`
+`client.getKeys(parameters: KeysQuery): Promise<KeysResults>`
 
 - [Get one key](https://docs.meilisearch.com/reference/api/keys.html#get-one-key):
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get Documents](https://docs.meilisearch.com/reference/api/documents.html#get-documents):
 
-`index.getDocuments(parameters: DocumentsQuery = {}): Promise<Result<Documents<T>>>`
+`index.getDocuments(parameters: DocumentsQuery = {}): Promise<DocumentsResults<T>>>`
 
 - [Get one document](https://docs.meilisearch.com/reference/api/documents.html#get-one-document):
 
@@ -415,7 +415,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all tasks](https://docs.meilisearch.com/reference/api/tasks.html#get-all-tasks)
 
-  `client.getTasks(): Promise<Result<Task[]>>`
+  `client.getTasks(parameters: TaskParams): Promise<TasksResults>`
 
 - [Get one task](https://docs.meilisearch.com/reference/api/tasks.html#get-task)
 
@@ -423,7 +423,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all tasks of an index](https://docs.meilisearch.com/reference/api/tasks.html#get-all-tasks-by-index)
 
-  `index.getTasks(): Promise<Result<Task[]>>`
+  `index.getTasks(parameters: TaskParams): Promise<TasksResults>`
 
 - [Get one task of an index](https://docs.meilisearch.com/reference/api/tasks.html#get-task)
 
@@ -450,7 +450,7 @@ If you want to know more about the development workflow or want to contribute, p
 
 - [Get all indexes](https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes):
 
-`client.getRawIndexes(parameters: IndexesQuery): Promise<Result<IndexObject[]>>`
+`client.getRawIndexes(parameters: IndexesQuery): Promise<IndexesResults<IndexObject[]>>`
 
 - [Create a new index](https://docs.meilisearch.com/reference/api/indexes.html#create-an-index):
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -12,7 +12,7 @@ import {
   KeyCreation,
   Config,
   IndexOptions,
-  IndexResponse,
+  IndexObject,
   EnqueuedTask,
   Key,
   Health,
@@ -26,6 +26,10 @@ import {
   TaskParams,
   WaitOptions,
   KeyUpdate,
+  IndexesQuery,
+  IndexesResults,
+  KeysQuery,
+  KeysResults,
 } from '../types'
 import { HttpRequests } from '../http-requests'
 import { TaskClient } from '../task'
@@ -76,9 +80,9 @@ class Client {
    * @memberof MeiliSearch
    * @method getRawIndex
    * @param {string} indexUid The index UID
-   * @returns {Promise<IndexResponse>} Promise returning index information
+   * @returns {Promise<IndexObject>} Promise returning index information
    */
-  async getRawIndex(indexUid: string): Promise<IndexResponse> {
+  async getRawIndex(indexUid: string): Promise<IndexObject> {
     return new Index(this.config, indexUid).getRawInfo()
   }
 
@@ -86,11 +90,12 @@ class Client {
    * Get all the indexes as Index instances.
    * @memberof MeiliSearch
    * @method getIndexes
+   * @param {IndexesQuery} parameters - Parameters to browse the indexes
    *
-   * @returns {Promise<Result<Index[]>>} Promise returning array of raw index information
+   * @returns {Promise<IndexesResults<Index[]>>} Promise returning array of raw index information
    */
-  async getIndexes(): Promise<Result<Index[]>> {
-    const rawIndexes = await this.getRawIndexes()
+  async getIndexes(parameters: IndexesQuery): Promise<IndexesResults<Index[]>> {
+    const rawIndexes = await this.getRawIndexes(parameters)
     const indexes: Index[] = rawIndexes.results.map(
       (index) => new Index(this.config, index.uid, index.primaryKey)
     )
@@ -101,12 +106,18 @@ class Client {
    * Get all the indexes in their raw value (no Index instances).
    * @memberof MeiliSearch
    * @method getRawIndexes
+   * @param {IndexesQuery} parameters - Parameters to browse the indexes
    *
-   * @returns {Promise<Result<IndexResponse[]>>} Promise returning array of raw index information
+   * @returns {Promise<IndexesResults<IndexObject[]>>} Promise returning array of raw index information
    */
-  async getRawIndexes(): Promise<Result<IndexResponse[]>> {
+  async getRawIndexes(
+    parameters: IndexesQuery
+  ): Promise<IndexesResults<IndexObject[]>> {
     const url = `indexes`
-    return await this.httpRequest.get<Result<IndexResponse[]>>(url)
+    return await this.httpRequest.get<IndexesResults<IndexObject[]>>(
+      url,
+      parameters
+    )
   }
 
   /**
@@ -245,11 +256,13 @@ class Client {
    * Get all API keys
    * @memberof MeiliSearch
    * @method getKeys
-   * @returns {Promise<Keys>} Promise returning an object with keys
+   * @param {KeysQuery} parameters - Parameters to browse the indexes
+   *
+   * @returns {Promise<KeysResults>} Promise returning an object with keys
    */
-  async getKeys(): Promise<Result<Key[]>> {
+  async getKeys(parameters: KeysQuery): Promise<KeysResults> {
     const url = `keys`
-    return await this.httpRequest.get<Result<Key[]>>(url)
+    return await this.httpRequest.get<KeysResults>(url, parameters)
   }
 
   /**

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -22,7 +22,7 @@ import {
   Task,
   TokenSearchRules,
   TokenOptions,
-  TaskParams,
+  TasksQuery,
   WaitOptions,
   KeyUpdate,
   IndexesQuery,
@@ -196,7 +196,7 @@ class Client {
    *
    * @returns {Promise<TasksResults>} - Promise returning all tasks
    */
-  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
+  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     return await this.tasks.getTasks(parameters)
   }
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -20,7 +20,6 @@ import {
   Version,
   ErrorStatusCode,
   Task,
-  Result,
   TokenSearchRules,
   TokenOptions,
   TaskParams,
@@ -30,6 +29,7 @@ import {
   IndexesResults,
   KeysQuery,
   KeysResults,
+  TasksResults,
 } from '../types'
 import { HttpRequests } from '../http-requests'
 import { TaskClient } from '../task'
@@ -192,10 +192,12 @@ class Client {
    * Get the list of all client tasks
    * @memberof MeiliSearch
    * @method getTasks
-   * @returns {Promise<Result<Task[]>>} - Promise returning all tasks
+   * @param {TasksQuery} parameters - Parameters to browse the tasks
+   *
+   * @returns {Promise<TasksResults>} - Promise returning all tasks
    */
-  async getTasks(params?: TaskParams): Promise<Result<Task[]>> {
-    return await this.tasks.getTasks(params)
+  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
+    return await this.tasks.getTasks(parameters)
   }
 
   /**
@@ -203,7 +205,7 @@ class Client {
    * @memberof MeiliSearch
    * @method getTask
    * @param {number} taskUid - Task identifier
-   * @returns {Promise<Task>} - Promise returning a task
+   * @returns {Promise<TasksResults>} - Promise returning a task
    */
   async getTask(taskUid: number): Promise<Task> {
     return await this.tasks.getTask(taskUid)

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -90,7 +90,7 @@ class Client {
    * Get all the indexes as Index instances.
    * @memberof MeiliSearch
    * @method getIndexes
-   * @param {IndexesQuery} parameters - Parameters to browse the indexes
+   * @param {IndexesQuery} [parameters={}] - Parameters to browse the indexes
    *
    * @returns {Promise<IndexesResults<Index[]>>} Promise returning array of raw index information
    */
@@ -108,7 +108,7 @@ class Client {
    * Get all the indexes in their raw value (no Index instances).
    * @memberof MeiliSearch
    * @method getRawIndexes
-   * @param {IndexesQuery} parameters - Parameters to browse the indexes
+   * @param {IndexesQuery} [parameters={}] - Parameters to browse the indexes
    *
    * @returns {Promise<IndexesResults<IndexObject[]>>} Promise returning array of raw index information
    */
@@ -192,7 +192,7 @@ class Client {
    * Get the list of all client tasks
    * @memberof MeiliSearch
    * @method getTasks
-   * @param {TasksQuery} parameters - Parameters to browse the tasks
+   * @param {TasksQuery} [parameters={}] - Parameters to browse the tasks
    *
    * @returns {Promise<TasksResults>} - Promise returning all tasks
    */
@@ -260,7 +260,7 @@ class Client {
    * Get all API keys
    * @memberof MeiliSearch
    * @method getKeys
-   * @param {KeysQuery} parameters - Parameters to browse the indexes
+   * @param {KeysQuery} [parameters={}] - Parameters to browse the indexes
    *
    * @returns {Promise<KeysResults>} Promise returning an object with keys
    */

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -94,7 +94,9 @@ class Client {
    *
    * @returns {Promise<IndexesResults<Index[]>>} Promise returning array of raw index information
    */
-  async getIndexes(parameters: IndexesQuery): Promise<IndexesResults<Index[]>> {
+  async getIndexes(
+    parameters: IndexesQuery = {}
+  ): Promise<IndexesResults<Index[]>> {
     const rawIndexes = await this.getRawIndexes(parameters)
     const indexes: Index[] = rawIndexes.results.map(
       (index) => new Index(this.config, index.uid, index.primaryKey)
@@ -111,7 +113,7 @@ class Client {
    * @returns {Promise<IndexesResults<IndexObject[]>>} Promise returning array of raw index information
    */
   async getRawIndexes(
-    parameters: IndexesQuery
+    parameters: IndexesQuery = {}
   ): Promise<IndexesResults<IndexObject[]>> {
     const url = `indexes`
     return await this.httpRequest.get<IndexesResults<IndexObject[]>>(
@@ -260,7 +262,7 @@ class Client {
    *
    * @returns {Promise<KeysResults>} Promise returning an object with keys
    */
-  async getKeys(parameters: KeysQuery): Promise<KeysResults> {
+  async getKeys(parameters: KeysQuery = {}): Promise<KeysResults> {
     const url = `keys`
     return await this.httpRequest.get<KeysResults>(url, parameters)
   }

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -205,7 +205,7 @@ class Client {
    * @memberof MeiliSearch
    * @method getTask
    * @param {number} taskUid - Task identifier
-   * @returns {Promise<TasksResults>} - Promise returning a task
+   * @returns {Promise<Task>} - Promise returning a task
    */
   async getTask(taskUid: number): Promise<Task> {
     return await this.tasks.getTask(taskUid)

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -229,7 +229,7 @@ class Index<T = Record<string, any>> {
    *
    * @memberof Indexes
    * @method getTasks
-   * @param {TasksQuery} parameters - Parameters to browse the tasks
+   * @param {TasksQuery} [parameters={}] - Parameters to browse the tasks
    *
    * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
@@ -313,7 +313,7 @@ class Index<T = Record<string, any>> {
    * @memberof Index
    * @method getDocuments
    * @template T
-   * @param {DocumentsQuery<T>} parameters? Parameters to browse the documents
+   * @param {DocumentsQuery<T>} [parameters={}] Parameters to browse the documents
    * @returns {Promise<DocumentsResults<T>>>} Promise containing Document responses
    */
   async getDocuments<T = Record<string, any>>(

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -35,7 +35,7 @@ import {
   TypoTolerance,
   WaitOptions,
   DocumentsResults,
-  TaskParams,
+  TasksQuery,
   TasksResults,
 } from './types'
 import { removeUndefinedFromObject } from './utils'
@@ -233,7 +233,7 @@ class Index<T = Record<string, any>> {
    *
    * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
-  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
+  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     return await this.tasks.getTasks({ ...parameters, indexUid: [this.uid] })
   }
 

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -33,9 +33,10 @@ import {
   SearchableAttributes,
   DisplayedAttributes,
   TypoTolerance,
-  Result,
   WaitOptions,
   DocumentsResults,
+  TaskParams,
+  TasksResults,
 } from './types'
 import { removeUndefinedFromObject } from './utils'
 import { HttpRequests } from './http-requests'
@@ -228,11 +229,12 @@ class Index<T = Record<string, any>> {
    *
    * @memberof Indexes
    * @method getTasks
+   * @param {TasksQuery} parameters - Parameters to browse the tasks
    *
-   * @returns {Promise<Result<Task[]>>} - Promise containing all tasks
+   * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
-  async getTasks(): Promise<Result<Task[]>> {
-    return await this.tasks.getTasks({ indexUid: [this.uid] })
+  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
+    return await this.tasks.getTasks({ ...parameters, indexUid: [this.uid] })
   }
 
   /**

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -16,12 +16,12 @@ import {
   SearchParams,
   Filter,
   SearchRequestGET,
-  IndexResponse,
+  IndexObject,
   IndexOptions,
   IndexStats,
   DocumentsQuery,
   Document,
-  AddDocumentParams,
+  DocumentOptions,
   EnqueuedTask,
   Settings,
   Synonyms,
@@ -142,11 +142,12 @@ class Index<T = Record<string, any>> {
    * Get index information.
    * @memberof Index
    * @method getRawInfo
-   * @returns {Promise<IndexResponse>} Promise containing index information
+   *
+   * @returns {Promise<IndexObject>} Promise containing index information
    */
-  async getRawInfo(): Promise<IndexResponse> {
+  async getRawInfo(): Promise<IndexObject> {
     const url = `indexes/${this.uid}`
-    const res = await this.httpRequest.get<IndexResponse>(url)
+    const res = await this.httpRequest.get<IndexObject>(url)
     this.primaryKey = res.primaryKey
     this.updatedAt = new Date(res.updatedAt)
     this.createdAt = new Date(res.createdAt)
@@ -310,17 +311,17 @@ class Index<T = Record<string, any>> {
    * @memberof Index
    * @method getDocuments
    * @template T
-   * @param {DocumentsQuery<T>} options? Options to browse the documents
+   * @param {DocumentsQuery<T>} parameters? Parameters to browse the documents
    * @returns {Promise<DocumentsResults<T>>>} Promise containing Document responses
    */
   async getDocuments<T = Record<string, any>>(
-    options?: DocumentsQuery<T>
+    parameters?: DocumentsQuery<T>
   ): Promise<DocumentsResults<T>> {
     const url = `indexes/${this.uid}/documents`
 
     const fields = (() => {
-      if (Array.isArray(options?.fields)) {
-        return options?.fields?.join(',')
+      if (Array.isArray(parameters?.fields)) {
+        return parameters?.fields?.join(',')
       }
       return undefined
     })()
@@ -328,7 +329,7 @@ class Index<T = Record<string, any>> {
     return await this.httpRequest.get<Promise<DocumentsResults<T>>>(
       url,
       removeUndefinedFromObject({
-        ...options,
+        ...parameters,
         fields,
       })
     )
@@ -353,12 +354,13 @@ class Index<T = Record<string, any>> {
    * @method addDocuments
    * @template T
    * @param {Array<Document<T>>} documents Array of Document objects to add/replace
-   * @param {AddDocumentParams} options? Query parameters
+   * @param {DocumentOptions} options? Options on document addition
+   *
    * @returns {Promise<EnqueuedTask>} Promise containing object of the enqueued task
    */
   async addDocuments(
     documents: Array<Document<T>>,
-    options?: AddDocumentParams
+    options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
     return await this.httpRequest.post(url, documents, options)
@@ -371,13 +373,13 @@ class Index<T = Record<string, any>> {
    * @template T
    * @param {Array<Document<T>>} documents Array of Document objects to add/replace
    * @param {number} batchSize Size of the batch
-   * @param {AddDocumentParams} options? Query parameters
+   * @param {DocumentOptions} options? Options on document addition
    * @returns {Promise<EnqueuedTasks>} Promise containing array of enqueued task objects for each batch
    */
   async addDocumentsInBatches(
     documents: Array<Document<T>>,
     batchSize = 1000,
-    options?: AddDocumentParams
+    options?: DocumentOptions
   ): Promise<EnqueuedTask[]> {
     const updates = []
     for (let i = 0; i < documents.length; i += batchSize) {
@@ -393,12 +395,12 @@ class Index<T = Record<string, any>> {
    * @memberof Index
    * @method updateDocuments
    * @param {Array<Document<Partial<T>>>} documents Array of Document objects to add/update
-   * @param {AddDocumentParams} options? Query parameters
+   * @param {DocumentOptions} options? Options on document update
    * @returns {Promise<EnqueuedTask>} Promise containing object of the enqueued task
    */
   async updateDocuments(
     documents: Array<Document<Partial<T>>>,
-    options?: AddDocumentParams
+    options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
     return await this.httpRequest.put(url, documents, options)
@@ -411,13 +413,13 @@ class Index<T = Record<string, any>> {
    * @template T
    * @param {Array<Document<T>>} documents Array of Document objects to add/update
    * @param {number} batchSize Size of the batch
-   * @param {AddDocumentParams} options? Query parameters
+   * @param {DocumentOptions} options? Options on document update
    * @returns {Promise<EnqueuedTasks>} Promise containing array of enqueued task objects for each batch
    */
   async updateDocumentsInBatches(
     documents: Array<Document<Partial<T>>>,
     batchSize = 1000,
-    options?: AddDocumentParams
+    options?: DocumentOptions
   ): Promise<EnqueuedTask[]> {
     const updates = []
     for (let i = 0; i < documents.length; i += batchSize) {

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -19,8 +19,7 @@ import {
   IndexResponse,
   IndexOptions,
   IndexStats,
-  DocumentsParams,
-  Documents,
+  DocumentsQuery,
   Document,
   AddDocumentParams,
   EnqueuedTask,
@@ -36,6 +35,7 @@ import {
   TypoTolerance,
   Result,
   WaitOptions,
+  DocumentsResults,
 } from './types'
 import { removeUndefinedFromObject } from './utils'
 import { HttpRequests } from './http-requests'
@@ -310,12 +310,12 @@ class Index<T = Record<string, any>> {
    * @memberof Index
    * @method getDocuments
    * @template T
-   * @param {DocumentsParams<T>} options? Options to browse the documents
-   * @returns {Promise<Result<Documents<T>>>} Promise containing Document responses
+   * @param {DocumentsQuery<T>} options? Options to browse the documents
+   * @returns {Promise<DocumentsResults<T>>>} Promise containing Document responses
    */
   async getDocuments<T = Record<string, any>>(
-    options?: DocumentsParams<T>
-  ): Promise<Result<Documents<T>>> {
+    options?: DocumentsQuery<T>
+  ): Promise<DocumentsResults<T>> {
     const url = `indexes/${this.uid}/documents`
 
     const fields = (() => {
@@ -325,7 +325,7 @@ class Index<T = Record<string, any>> {
       return undefined
     })()
 
-    return await this.httpRequest.get<Promise<Result<Documents<T>>>>(
+    return await this.httpRequest.get<Promise<DocumentsResults<T>>>(
       url,
       removeUndefinedFromObject({
         ...options,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -315,7 +315,7 @@ class Index<T = Record<string, any>> {
    * @returns {Promise<DocumentsResults<T>>>} Promise containing Document responses
    */
   async getDocuments<T = Record<string, any>>(
-    parameters?: DocumentsQuery<T>
+    parameters: DocumentsQuery<T> = {}
   ): Promise<DocumentsResults<T>> {
     const url = `indexes/${this.uid}/documents`
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -4,7 +4,7 @@ import {
   Task,
   WaitOptions,
   TaskStatus,
-  TaskParams,
+  TasksQuery,
   TasksResults,
 } from './types'
 import { HttpRequests } from './http-requests'
@@ -32,11 +32,11 @@ class TaskClient {
   /**
    * Get tasks
    *
-   * @param  {TaskParams} [parameters={}] - Parameters to browse the tasks
+   * @param  {TasksQuery} [parameters={}] - Parameters to browse the tasks
    *
    * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
-  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
+  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     const url = `tasks`
 
     const queryParams = {

--- a/src/task.ts
+++ b/src/task.ts
@@ -32,7 +32,7 @@ class TaskClient {
   /**
    * Get tasks
    *
-   * @param  {TaskParams} parameters - Parameters to browse the tasks
+   * @param  {TaskParams} [parameters={}] - Parameters to browse the tasks
    *
    * @returns {Promise<TasksResults>} - Promise containing all tasks
    */

--- a/src/task.ts
+++ b/src/task.ts
@@ -28,6 +28,7 @@ class TaskClient {
     const url = `tasks/${uid}`
     return await this.httpRequest.get<Task>(url)
   }
+
   /**
    * Get tasks
    *
@@ -42,7 +43,10 @@ class TaskClient {
       indexUid: parameters?.indexUid?.join(','),
       type: parameters?.type?.join(','),
       status: parameters?.status?.join(','),
+      from: parameters.from,
+      limit: parameters.limit,
     }
+
     return await this.httpRequest.get<Promise<TasksResults>>(
       url,
       removeUndefinedFromObject(queryParams)

--- a/src/task.ts
+++ b/src/task.ts
@@ -4,8 +4,8 @@ import {
   Task,
   WaitOptions,
   TaskStatus,
-  Result,
   TaskParams,
+  TasksResults,
 } from './types'
 import { HttpRequests } from './http-requests'
 import { removeUndefinedFromObject, sleep } from './utils'
@@ -31,19 +31,19 @@ class TaskClient {
   /**
    * Get tasks
    *
-   * @param  {TaskParams} params - query parameters
+   * @param  {TaskParams} parameters - Parameters to browse the tasks
    *
-   * @returns { Promise<Result<Task[]>> }
+   * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
-  async getTasks(params: TaskParams = {}): Promise<Result<Task[]>> {
+  async getTasks(parameters: TaskParams = {}): Promise<TasksResults> {
     const url = `tasks`
 
     const queryParams = {
-      indexUid: params?.indexUid?.join(','),
-      type: params?.type?.join(','),
-      status: params?.status?.join(','),
+      indexUid: parameters?.indexUid?.join(','),
+      type: parameters?.type?.join(','),
+      status: parameters?.status?.join(','),
     }
-    return await this.httpRequest.get<Result<Task[]>>(
+    return await this.httpRequest.get<Promise<TasksResults>>(
       url,
       removeUndefinedFromObject(queryParams)
     )

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -203,6 +203,8 @@ export type TaskParams = {
   indexUid?: string[]
   type?: TaskTypes[]
   status?: TaskStatus[]
+  limit?: number
+  from?: number
 }
 
 export type EnqueuedTask = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,12 +10,23 @@ export type Config = {
   headers?: object
 }
 
-export type Result<T> = {
+///
+/// Resources
+///
+
+export type ResourceQuery = Pagination & {}
+
+export type Result<T> = Pagination & {
   results: T
+  total: number
+}
+export type ResourceResults<T> = Pagination & {
+  results: T
+  total: number
 }
 
 ///
-/// Request specific interfaces
+/// Indexes
 ///
 
 export type IndexRequest = {
@@ -101,16 +112,12 @@ export type _matchesInfo<T> = Partial<
   Record<keyof T, Array<{ start: number; length: number }>>
 >
 
-export type document = {
-  [field: string]: any
-}
-
-export type Hit<T = document> = T & {
+export type Hit<T = Record<string, any>> = T & {
   _formatted?: Partial<T>
   _matchesPosition?: _matchesInfo<T>
 }
 
-export type Hits<T = document> = Array<Hit<T>>
+export type Hits<T = Record<string, any>> = Array<Hit<T>>
 
 export type SearchResponse<T = Record<string, any>> = {
   hits: Hits<T>
@@ -129,14 +136,18 @@ export type FieldDistribution = {
 /*
  ** Documents
  */
-// TODO: This is going to be updated in the PR about pagination in resource routes
-export type DocumentsParams<T = Record<string, any>> = Pagination & {
+
+export type DocumentsQuery<T = Record<string, any>> = Pagination & {
   fields?: Array<Extract<keyof T, string>> | Extract<keyof T, string>
 }
-export type Document<T = Record<string, any>> = T
 
-// TODO: This is going to be updated in the PR about pagination in resource routes
 export type Documents<T = Record<string, any>> = Array<Document<T>>
+
+export type DocumentsResults<T = Record<string, any>> = ResourceResults<
+  Documents<T>
+> & {}
+
+export type Document<T = Record<string, any>> = T
 
 /*
  ** Settings

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -264,6 +264,15 @@ export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   finishedAt: string
 }
 
+export type TasksParams = {}
+
+export type TasksResults = {
+  results: Task[]
+  limit: number
+  from: number
+  next: number
+}
+
 export type WaitOptions = {
   timeOutMs?: number
   intervalMs?: number

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,6 +20,7 @@ export type Result<T> = Pagination & {
   results: T
   total: number
 }
+
 export type ResourceResults<T> = Pagination & {
   results: T
   total: number
@@ -29,25 +30,20 @@ export type ResourceResults<T> = Pagination & {
 /// Indexes
 ///
 
-export type IndexRequest = {
-  uid: string
-  primaryKey?: string
-}
-
 export type IndexOptions = {
   primaryKey?: string
 }
 
-export type IndexResponse = {
+export type IndexObject = {
   uid: string
   primaryKey?: string
   createdAt: Date
   updatedAt: Date
 }
 
-export type AddDocumentParams = {
-  primaryKey?: string
-}
+export type IndexesQuery = ResourceQuery & {}
+
+export type IndexesResults<T> = ResourceResults<T> & {}
 
 /*
  * SEARCH PARAMETERS
@@ -137,17 +133,20 @@ export type FieldDistribution = {
  ** Documents
  */
 
-export type DocumentsQuery<T = Record<string, any>> = Pagination & {
+export type DocumentOptions = {
+  primaryKey?: string
+}
+
+export type DocumentsQuery<T = Record<string, any>> = ResourceQuery & {
   fields?: Array<Extract<keyof T, string>> | Extract<keyof T, string>
 }
 
+export type Document<T = Record<string, any>> = T
 export type Documents<T = Record<string, any>> = Array<Document<T>>
 
 export type DocumentsResults<T = Record<string, any>> = ResourceResults<
   Documents<T>
 > & {}
-
-export type Document<T = Record<string, any>> = T
 
 /*
  ** Settings
@@ -325,6 +324,10 @@ export type KeyUpdate = {
   name?: string
   description?: string
 }
+
+export type KeysQuery = ResourceQuery & {}
+
+export type KeysResults = ResourceResults<Key[]> & {}
 
 /*
  ** version

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,12 +14,12 @@ export type Config = {
 /// Resources
 ///
 
-export type ResourceQuery = Pagination & {}
-
-export type Result<T> = Pagination & {
-  results: T
-  total: number
+export type Pagination = {
+  offset?: number
+  limit?: number
 }
+
+export type ResourceQuery = Pagination & {}
 
 export type ResourceResults<T> = Pagination & {
   results: T
@@ -50,11 +50,6 @@ export type IndexesResults<T> = ResourceResults<T> & {}
  */
 
 export type Filter = string | Array<string | string[]>
-
-export type Pagination = {
-  offset?: number
-  limit?: number
-}
 
 export type Query = {
   q?: string | null
@@ -263,8 +258,6 @@ export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   startedAt: string
   finishedAt: string
 }
-
-export type TasksParams = {}
 
 export type TasksResults = {
   results: Task[]

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -199,7 +199,7 @@ export const enum TaskTypes {
   SETTINGS_UPDATE = 'settingsUpdate',
 }
 
-export type TaskParams = {
+export type TasksQuery = {
   indexUid?: string[]
   type?: TaskTypes[]
   status?: TaskStatus[]

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -60,7 +60,7 @@ describe('Documents tests', () => {
       test(`${permission} key: Get documents with string fields`, async () => {
         const client = await getClient(permission)
 
-        const documents = await client.index(indexNoPk.uid).getDocuments({
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>({
           fields: 'id',
         })
 
@@ -72,7 +72,7 @@ describe('Documents tests', () => {
       test(`${permission} key: Get documents with array fields`, async () => {
         const client = await getClient(permission)
 
-        const documents = await client.index(indexNoPk.uid).getDocuments({
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>({
           fields: ['id'],
         })
 
@@ -88,7 +88,7 @@ describe('Documents tests', () => {
           .addDocuments(dataset)
         await client.index(indexNoPk.uid).waitForTask(taskUid)
 
-        const documents = await client.index(indexNoPk.uid).getDocuments({
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>({
           fields: 'id',
         })
 
@@ -102,7 +102,7 @@ describe('Documents tests', () => {
           .addDocuments(dataset)
         await client.index(indexPk.uid).waitForTask(taskUid)
 
-        const documents = await client.index(indexPk.uid).getDocuments()
+        const documents = await client.index(indexPk.uid).getDocuments<Book>()
         expect(documents.results.length).toEqual(dataset.length)
       })
 
@@ -232,7 +232,7 @@ describe('Documents tests', () => {
           .updateDocuments([{ id, title }])
         await client.index(indexNoPk.uid).waitForTask(task.taskUid)
         const document = await client.index(indexNoPk.uid).getDocument(id)
-        const documents = await client.index(indexNoPk.uid).getDocuments()
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>()
 
         expect(document).toHaveProperty('id', id)
         expect(document).toHaveProperty('title', title)
@@ -253,7 +253,7 @@ describe('Documents tests', () => {
         await client.index(indexPk.uid).waitForTask(task.taskUid)
 
         const document = await client.index(indexPk.uid).getDocument(id)
-        const documents = await client.index(indexPk.uid).getDocuments()
+        const documents = await client.index(indexPk.uid).getDocuments<Book>()
 
         expect(document).toHaveProperty('id', id)
         expect(document).toHaveProperty('title', title)
@@ -270,7 +270,7 @@ describe('Documents tests', () => {
 
         const task = await client.index(indexNoPk.uid).deleteDocument(id)
         await client.index(indexNoPk.uid).waitForTask(task.taskUid)
-        const documents = await client.index(indexNoPk.uid).getDocuments()
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>()
 
         expect(documents.results.length).toEqual(dataset.length)
       })
@@ -285,7 +285,7 @@ describe('Documents tests', () => {
         const id = 9
         const task = await client.index(indexPk.uid).deleteDocument(id)
         await client.index(indexPk.uid).waitForTask(task.taskUid)
-        const response = await client.index(indexPk.uid).getDocuments()
+        const response = await client.index(indexPk.uid).getDocuments<Book>()
 
         expect(response.results.length).toEqual(dataset.length)
       })
@@ -301,7 +301,7 @@ describe('Documents tests', () => {
         const task = await client.index(indexNoPk.uid).deleteDocuments(ids)
         await client.index(indexNoPk.uid).waitForTask(task.taskUid)
 
-        const documents = await client.index(indexNoPk.uid).getDocuments()
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>()
         const returnedIds = documents.results.map((x) => x.id)
 
         expect(documents.results.length).toEqual(dataset.length - 2)
@@ -319,7 +319,7 @@ describe('Documents tests', () => {
         const ids = [1, 2]
         const task = await client.index(indexPk.uid).deleteDocuments(ids)
         await client.index(indexPk.uid).waitForTask(task.taskUid)
-        const documents = await client.index(indexPk.uid).getDocuments()
+        const documents = await client.index(indexPk.uid).getDocuments<Book>()
         const returnedIds = documents.results.map((x) => x.id)
 
         expect(documents.results.length).toEqual(dataset.length - 2)
@@ -332,7 +332,7 @@ describe('Documents tests', () => {
         const task = await client.index(indexNoPk.uid).deleteAllDocuments()
         await client.index(indexNoPk.uid).waitForTask(task.taskUid)
 
-        const documents = await client.index(indexNoPk.uid).getDocuments()
+        const documents = await client.index(indexNoPk.uid).getDocuments<Book>()
         expect(documents.results.length).toEqual(0)
       })
 
@@ -341,7 +341,7 @@ describe('Documents tests', () => {
         const task = await client.index(indexPk.uid).deleteAllDocuments()
         await client.index(indexPk.uid).waitForTask(task.taskUid)
 
-        const documents = await client.index(indexPk.uid).getDocuments()
+        const documents = await client.index(indexPk.uid).getDocuments<Book>()
         expect(documents.results.length).toEqual(0)
       })
 
@@ -442,7 +442,7 @@ describe('Documents tests', () => {
       test(`${permission} key: Try to get documents and be denied`, async () => {
         const client = await getClient(permission)
         await expect(
-          client.index(indexPk.uid).getDocuments()
+          client.index(indexPk.uid).getDocuments<Book>()
         ).rejects.toHaveProperty('code', ErrorStatusCode.INVALID_API_KEY)
       })
 
@@ -499,7 +499,7 @@ describe('Documents tests', () => {
       test(`${permission} key: Try to get documents and be denied`, async () => {
         const client = await getClient(permission)
         await expect(
-          client.index(indexPk.uid).getDocuments()
+          client.index(indexPk.uid).getDocuments<Book>()
         ).rejects.toHaveProperty(
           'code',
           ErrorStatusCode.MISSING_AUTHORIZATION_HEADER
@@ -563,7 +563,7 @@ describe('Documents tests', () => {
       const client = new MeiliSearch({ host })
       const strippedHost = trailing ? host.slice(0, -1) : host
       await expect(
-        client.index(indexPk.uid).getDocuments()
+        client.index(indexPk.uid).getDocuments<Book>()
       ).rejects.toHaveProperty(
         'message',
         `request to ${strippedHost}/${route} failed, reason: connect ECONNREFUSED ${BAD_HOST.replace(

--- a/tests/env/typescript-browser/src/index.ts
+++ b/tests/env/typescript-browser/src/index.ts
@@ -1,4 +1,4 @@
-import { IndexResponse, MeiliSearch } from '../../../../'
+import { IndexObject, MeiliSearch } from '../../../../'
 
 const config = {
   host: 'http://127.0.0.1:7700',
@@ -15,7 +15,7 @@ function greeter(person: string) {
 ;(async () => {
   const indexes = await client.getRawIndexes()
   console.log({ indexes }, 'hello')
-  const uids = indexes.map((index: IndexResponse) => index.uid)
+  const uids = indexes.map((index: IndexObject) => index.uid)
   document.body.innerHTML = `${greeter(
     user
   )} this is the list of all your indexes: \n ${uids.join(', ')}`

--- a/tests/env/typescript-browser/src/index.ts
+++ b/tests/env/typescript-browser/src/index.ts
@@ -15,7 +15,7 @@ function greeter(person: string) {
 ;(async () => {
   const indexes = await client.getRawIndexes()
   console.log({ indexes }, 'hello')
-  const uids = indexes.map((index: IndexObject) => index.uid)
+  const uids = indexes.results.map((index: IndexObject) => index.uid)
   document.body.innerHTML = `${greeter(
     user
   )} this is the list of all your indexes: \n ${uids.join(', ')}`

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -31,7 +31,7 @@ const indexUid = "movies"
 
   const index = client.index(indexUid)
   const indexes = await client.getRawIndexes()
-  indexes.map((index: IndexObject) => {
+  indexes.results.map((index: IndexObject) => {
     console.log(index.uid)
     // console.log(index.something) -> ERROR
   })
@@ -42,7 +42,7 @@ const indexUid = "movies"
     attributesToHighlight: ['title'],
     // test: true -> ERROR Test does not exist on type SearchParams
   }
-  indexes.map((index: IndexObject) => index.uid)
+  indexes.results.map((index: IndexObject) => index.uid)
   const res: SearchResponse<Movie> = await index.search(
     'avenger',
     searchParams

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -3,7 +3,7 @@
 import {
   // @ts-ignore
   MeiliSearch,
-  IndexResponse,
+  IndexObject,
   SearchResponse,
   Hits,
   Hit,
@@ -31,7 +31,7 @@ const indexUid = "movies"
 
   const index = client.index(indexUid)
   const indexes = await client.getRawIndexes()
-  indexes.map((index: IndexResponse) => {
+  indexes.map((index: IndexObject) => {
     console.log(index.uid)
     // console.log(index.something) -> ERROR
   })
@@ -42,7 +42,7 @@ const indexUid = "movies"
     attributesToHighlight: ['title'],
     // test: true -> ERROR Test does not exist on type SearchParams
   }
-  indexes.map((index: IndexResponse) => index.uid)
+  indexes.map((index: IndexObject) => index.uid)
   const res: SearchResponse<Movie> = await index.search(
     'avenger',
     searchParams

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -213,6 +213,31 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(response).toHaveProperty('primaryKey', null)
     })
 
+    test(`${permission} key: get all indexes`, async () => {
+      const client = await getClient(permission)
+      const task1 = await client.createIndex(indexNoPk.uid)
+      const task2 = await client.createIndex(indexPk.uid)
+      await client.waitForTask(task1.taskUid)
+      await client.waitForTask(task2.taskUid)
+
+      const indexes = await client.getIndexes()
+
+      expect(indexes.results.length).toEqual(2)
+    })
+
+    test(`${permission} key: get all indexes with filters`, async () => {
+      const client = await getClient(permission)
+      const task1 = await client.createIndex(indexNoPk.uid)
+      const task2 = await client.createIndex(indexPk.uid)
+      await client.waitForTask(task1.taskUid)
+      await client.waitForTask(task2.taskUid)
+
+      const indexes = await client.getIndexes({ limit: 1, offset: 1 })
+
+      expect(indexes.results.length).toEqual(1)
+      expect(indexes.results[0].uid).toEqual(indexPk.uid)
+    })
+
     test(`${permission} key: update primary key on an index that has no primary key already`, async () => {
       const client = await getClient(permission)
       const { taskUid: createTask } = await client.createIndex(indexNoPk.uid)

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -66,6 +66,15 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(adminKey).toHaveProperty('updatedAt')
     })
 
+    test(`${permission} key: get keys with pagination`, async () => {
+      const client = await getClient(permission)
+      const keys = await client.getKeys({ limit: 1, offset: 2 })
+
+      expect(keys.limit).toEqual(1)
+      expect(keys.offset).toEqual(2)
+      expect(keys.total).toEqual(2)
+    })
+
     test(`${permission} key: get on key`, async () => {
       const client = await getClient(permission)
       const apiKey = await getKey('Private')

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -31,9 +31,9 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
 
     test(`${permission} key: get keys`, async () => {
       const client = await getClient(permission)
-      const { results: keys } = await client.getKeys()
+      const keys = await client.getKeys()
 
-      const searchKey = keys.find(
+      const searchKey = keys.results.find(
         (key: any) => key.name === 'Default Search API Key'
       )
 
@@ -49,7 +49,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(searchKey).toHaveProperty('createdAt')
       expect(searchKey).toHaveProperty('updatedAt')
 
-      const adminKey = keys.find(
+      const adminKey = keys.results.find(
         (key: any) => key.name === 'Default Admin API Key'
       )
 

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -132,6 +132,21 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(onlyDocumentAddition.size).toEqual(2)
     })
 
+    test(`${permission} key: Get all tasks with pagination`, async () => {
+      const client = await getClient(permission)
+      const task1 = await client.index(index.uid).addDocuments([{ id: 1 }])
+      const task2 = await client.index(index.uid).addDocuments([{ id: 1 }])
+      await client.waitForTask(task1.taskUid)
+      await client.waitForTask(task2.taskUid)
+
+      const tasks = await client.getTasks({ from: 1, limit: 1 })
+
+      expect(tasks.results.length).toEqual(1)
+      expect(tasks.from).toEqual(1)
+      expect(tasks.limit).toEqual(1)
+      expect(tasks.next).toEqual(0)
+    })
+
     test(`${permission} key: Get all tasks with status filter`, async () => {
       const client = await getClient(permission)
       const task1 = await client.index(index.uid).addDocuments([{ id: 1 }])


### PR DESCRIPTION
Add pagination system on the following resources: `keys`, `indexes`, `documents`

- [x] GET /keys has pagination metadata, added limit (default: 20), offset (default: 0), total.
- [x] GET /indexes has pagination metadata, added limit (default: 20), offset (default: 0), total.
- [x] GET /documents has pagination metadata, added limit (default: 20), offset (default: 0), total.

