### PR TITLE
Update waitForTasks return format to not use resource result

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,11 +437,10 @@ If you want to know more about the development workflow or want to contribute, p
   `index.waitForTask(uid: number, { timeOutMs?: number, intervalMs?: number }): Promise<Task>`
 
 - Wait for multiple tasks:
-
-  `client.waitForTasks(uids: number[], { timeOutMs?: number, intervalMs?: number }): Promise<Result<Task[]>>`
+  `client.waitForTasks(uids: number[], { timeOutMs?: number, intervalMs?: number }): Promise<Task[]>`
 
   With an index instance:
-  `index.waitForTasks(uids: number[], { timeOutMs?: number, intervalMs?: number }): Promise<Result<Task[]>>`
+  `index.waitForTasks(uids: number[], { timeOutMs?: number, intervalMs?: number }): Promise<Task[]>`
 
 ### Indexes <!-- omit in toc -->
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -204,12 +204,12 @@ class Client {
    * @param {number[]} taskUids - Tasks identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Result<Task[]>>} - Promise returning an array of tasks
+   * @returns {Promise<Task[]>} - Promise returning an array of tasks
    */
   async waitForTasks(
     taskUids: number[],
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Result<Task[]>> {
+  ): Promise<Task[]> {
     return await this.tasks.waitForTasks(taskUids, {
       timeOutMs,
       intervalMs,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -255,12 +255,12 @@ class Index<T = Record<string, any>> {
    * @param {number[]} taskUids - Tasks identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Result<Task[]>>} - Promise containing an array of tasks
+   * @returns {Promise<Task[]>} - Promise containing an array of tasks
    */
   async waitForTasks(
     taskUids: number[],
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Result<Task[]>> {
+  ): Promise<Task[]> {
     return await this.tasks.waitForTasks(taskUids, {
       timeOutMs,
       intervalMs,

--- a/src/task.ts
+++ b/src/task.ts
@@ -83,12 +83,12 @@ class TaskClient {
    * @param {number[]} taskUids Tasks identifier list
    * @param {WaitOptions} options Wait options
    *
-   * @returns {Promise<Result<Task[]>>} Promise returning a list of tasks after they have been processed
+   * @returns {Promise<Task[]>} Promise returning a list of tasks after they have been processed
    */
   async waitForTasks(
     taskUids: number[],
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Result<Task[]>> {
+  ): Promise<Task[]> {
     const tasks: Task[] = []
     for (const taskUid of taskUids) {
       const task = await this.waitForTask(taskUid, {
@@ -97,7 +97,7 @@ class TaskClient {
       })
       tasks.push(task)
     }
-    return { results: tasks }
+    return tasks
   }
 }
 

--- a/tests/wait_for_task.test.ts
+++ b/tests/wait_for_task.test.ts
@@ -89,8 +89,8 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         .index(index.uid)
         .addDocuments(dataset)
 
-      const update = await client.waitForTasks([task1, task2])
-      const [update1, update2] = update.results
+      const tasks = await client.waitForTasks([task1, task2])
+      const [update1, update2] = tasks
 
       expect(update1).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
       expect(update2).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
@@ -105,11 +105,11 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         .index(index.uid)
         .addDocuments(dataset)
 
-      const update = await client.waitForTasks([task1, task2], {
+      const tasks = await client.waitForTasks([task1, task2], {
         timeOutMs: 6000,
         intervalMs: 100,
       })
-      const [update1, update2] = update.results
+      const [update1, update2] = tasks
 
       expect(update1).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
       expect(update2).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
@@ -124,11 +124,11 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         .index(index.uid)
         .addDocuments(dataset)
 
-      const update = await client.waitForTasks([task1, task2], {
+      const tasks = await client.waitForTasks([task1, task2], {
         timeOutMs: 6000,
         intervalMs: 0,
       })
-      const [update1, update2] = update.results
+      const [update1, update2] = tasks
 
       expect(update1).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
       expect(update2).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
@@ -159,8 +159,8 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         .index(index.uid)
         .addDocuments(dataset)
 
-      const update = await client.index(index.uid).waitForTasks([task1, task2])
-      const [update1, update2] = update.results
+      const tasks = await client.index(index.uid).waitForTasks([task1, task2])
+      const [update1, update2] = tasks
 
       expect(update1).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)
       expect(update2).toHaveProperty('status', TaskStatus.TASK_SUCCEEDED)


### PR DESCRIPTION
Update the response of waitForTasks that was using the Result type to prepare for the consistent pagination system #1269 