### PR TITLE
fix: TypoTolerance type has a wrong key name

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -160,7 +160,7 @@ export type Synonyms = {
 } | null
 export type TypoTolerance = {
   enabled?: boolean | null
-  disabledOnAttributes?: string[] | null
+  disableOnAttributes?: string[] | null
   disableOnWords?: string[] | null
   minWordSizeForTypos?: {
     oneTypo?: number | null


### PR DESCRIPTION
wrong name 'disabledOnAttributes' rename to correct name 'disableOnAttributes'

# Pull Request

## What does this PR do?
Fixes #1275 
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [✔] Does this PR fix an existing issue?
- [✔] Have you read the contributing guidelines?
- [✔] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
