### PR TITLE
Add keys parameter in missing routes v0.28.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,11 +629,11 @@ Using the index object:
 
 - [Update a key](https://docs.meilisearch.com/reference/api/keys.html#update-a-key):
 
-`client.updateKey(key: string, options: KeyUpdate): Promise<Key>`
+`client.updateKey(keyOrUid: string, options: KeyUpdate): Promise<Key>`
 
 - [Delete a key](https://docs.meilisearch.com/reference/api/keys.html#delete-a-key):
 
-`client.deleteKey(key: string): Promise<void>`
+`client.deleteKey(keyOrUid: string): Promise<void>`
 
 ### isHealthy <!-- omit in toc -->
 

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -300,12 +300,12 @@ class Client {
    * @memberof MeiliSearch
    * @method updateKey
    *
-   * @param {string} key - Key
+   * @param {string} keyOrUid - Key
    * @param {KeyUpdate} options - Key options
    * @returns {Promise<Key>} Promise returning an object with keys
    */
-  async updateKey(key: string, options: KeyUpdate): Promise<Key> {
-    const url = `keys/${key}`
+  async updateKey(keyOrUid: string, options: KeyUpdate): Promise<Key> {
+    const url = `keys/${keyOrUid}`
     return await this.httpRequest.patch(url, options)
   }
 
@@ -314,11 +314,11 @@ class Client {
    * @memberof MeiliSearch
    * @method deleteKey
    *
-   * @param {string} key - Key
+   * @param {string} keyOrUid - Key
    * @returns {Promise<Void>}
    */
-  async deleteKey(key: string): Promise<void> {
-    const url = `keys/${key}`
+  async deleteKey(keyOrUid: string): Promise<void> {
+    const url = `keys/${keyOrUid}`
     return await this.httpRequest.delete<any>(url)
   }
 


### PR DESCRIPTION
- `deleteKey` and `updateKey` are also able to be recognizable by either the `uid` or the `key`.