### PR TITLE
Update settings code-sample for v0.28.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -7,14 +7,6 @@ get_all_tasks_filtering_1: |-
 get_all_tasks_filtering_2: |-
 get_all_tasks_paginating_1: |-
 get_all_tasks_paginating_2: |-
-get_pagination_settings_1: |-
-update_pagination_settings_1: |-
-reset_pagination_settings_1: |-
-get_faceting_settings_1: |-
-update_faceting_settings_1: |-
-reset_faceting_settings_1: |-
-settings_guide_faceting_1: |-
-settings_guide_pagination_1: |-
 
 get_one_index_1: |-
   client.index('movies').getRawInfo()
@@ -561,6 +553,18 @@ update_sortable_attributes_1: |-
     ])
 reset_sortable_attributes_1: |-
   client.index('books').resetSortableAttributes()
+get_pagination_settings_1: |-
+update_pagination_settings_1: |-
+  client.index('books').updateSettings({ pagination: { maxTotalHits: 100 }})
+reset_pagination_settings_1: |-
+get_faceting_settings_1: |-
+update_faceting_settings_1: |-
+  client.index('books').updateSettings({ faceting: { maxValuesPerFacet: 2 }})
+reset_faceting_settings_1: |-
+settings_guide_faceting_1: |-
+  client.index('books').updateSettings({ faceting: { maxValuesPerFacet: 5 }})
+settings_guide_pagination_1: |-
+  client.index('books').updateSettings({ pagination: { maxTotalHits: 50 }})
 search_parameter_guide_sort_1: |-
   client.index('books').search('science fiction', {
     sort: ['price:asc'],

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -90,7 +90,7 @@ PLEASE_UPDATE_ME>>>>>>>>>>>>>delete_a_key_1: |-
   client.deleteKey('d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4')
 get_settings_1: |-
   client.index('movies').getSettings()
-PLEASE_UPDATE_ME>>>>>>>>>>>>>update_settings_1: |-
+update_settings_1: |-
   client.index('movies').updateSettings({
       rankingRules: [
           'words',
@@ -135,6 +135,12 @@ PLEASE_UPDATE_ME>>>>>>>>>>>>>update_settings_1: |-
           'disableOnAttributes': [
               'title'
           ]
+      },
+      pagination: {
+          maxTotalHits: 5000
+      },
+      faceting: {
+          maxValuesPerFacet: 200
       }
   })
 reset_settings_1: |-
@@ -450,7 +456,8 @@ getting_started_update_searchable_attributes: |-
   ])
 getting_started_update_stop_words: |-
   client.index('movies').updateStopWords(['the'])
-PLEASE_UPDATE_ME>>>>>>>>>>>>>PLEASE_UPDATE_ME>>>>>>>>>>>>>getting_started_check_task_status: |-
+? PLEASE_UPDATE_ME>>>>>>>>>>>>>PLEASE_UPDATE_ME>>>>>>>>>>>>>getting_started_check_task_status
+: |-
   client.index('movies').getTask(0)
 getting_started_synonyms: |-
   client.index('movies').updateSynonyms({


### PR DESCRIPTION
As per [this issue](https://github.com/meilisearch/integration-guides/issues/208)

- ~Add  `get_pagination_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1759)~
  - for the `books` index
- [x] Add  `update_pagination_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1759)
  - for the `books` index
  - Update `"maxTotalHits": 100`
- ~Add  `reset_pagination_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1759)~
  - for the `books` index
- [x]  Update `update_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1759), [PR](https://github.com/meilisearch/documentation/pull/1761) 
  - add ` "pagination": {"maxTotalHits": 5000}` 
  - add `"faceting": { "maxValuesPerFacet": 200}` 
- ~Add `get_faceting_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1761)~
  - for the `books` index 
- [x] Add `update_faceting_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1761) 
  - for the `books` index 
  - Update: `"maxValuesPerFacet": 2`
- ~Add `reset_faceting_settings_1` [PR](https://github.com/meilisearch/documentation/pull/1761)~
  - for the `books` index 
- [x] Add `settings_guide_faceting_1` [PR](https://github.com/meilisearch/documentation/pull/1767)
  - for the `movies` index
  - sets `"maxValuesPerFacet": 5`
-  [x] Add `settings_guide_pagination_1` [PR](https://github.com/meilisearch/documentation/pull/1766)
  - for the `movies` index
  - sets `"maxTotalHits": 50` 

