### PR TITLE
Update version for the next release (v0.27.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.26.0'
+export const PACKAGE_VERSION = '0.27.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥 Breaking changes

- `client.updateKey(key: string, options: KeyPayload): Promise<Key>` now can just update the `description` and/or the name. #1266
- The type `EnqueuedTask` now returns an `taskUid` instead of an `uid`
- `client.getTasks(...)` and `index.getTasks()` now returns a  TasksResults type containing the following fields: `results`, `limit`, `from`, `next`  #1269 
- `index.search` changes in the response parameters: #1263
    - `nbHits` replaced with `estimatedTotalHits`
    - `exhaustiveNbHits` is deleted
    - `exhaustiveFacetsCount` is deleted
- `index.search` changes in the request parameters:  #1263
    -  `matches` renamed `showMatchesPosition`
    -  `_matchesInfo` response parameter is renamed `_matchesPosition`
    - `facetsDistribution` request parameter is renamed `facets`.
    -  `facetsDistribution` response parameter is renamed `facetDistribution`.
- The `Index` type and returned `IndexObject` does not contain a `name` field anymore
- `client.getIndexes` and `client.getRawIndexes` now returns an `IndexesResults` type containing the following fields: `results`, `limit`, `offset`, `total` #1269
- `index.getDocuments` and `client.getDocuments` now returns an `DocumentsResults` type containing the following fields: `results`, `limit`, `offset`, `total` #1269
- `index.getDocuments` query parameter `attributesToRetrieve` is now called `fields` #1264
- `client.getDumpStatus` has been removed #1267
- `client.createDump()` now returns an `EnqueuedTask` #1267
- `client.generateTenantToken(apiKeyUid, searchRules, options)` has now a mandatory `apiKeyUid` parameter which should contain the uid of a specific API key. #1268  


## 🚀 Enhancements

- `client.getKeys(parameters: KeysQuery  = {})` now accepts pagination parameters: `limit`, `offset` #1269 
- `client.getKey(keyOrUid: string)` can now also find keys based on their key uid. #1266 
- `client.createKey(options: KeyCreation)` lets you specify a custom uid (optionally) to create a new Key #1269
- The returned `Key` now has an additional `name` and `uid` string fields. #1266 
- The `indexUid` field in both `EnqueuedTask` and `Task` can be null #1259 
- `client.getTasks(parameters: TasksQuery = {})` and   `index.getTasks(parameters: TasksQuery)` now accepts pagination parameters: `limit`, `from`, `next` and filters parameters: `type`, `status`, `indexUid` (same for `index.getTasks`) #1269 
- `client.getIndexes` and `client.getRawIndexes` now accepts pagination parameters: `limit`, `offset` #1269 
- `index.getDocuments` now accepts pagination parameters: `limit`, `offset` #1269 
- `new MeiliSearch({ host, apiKey, headers, clientAgents })` now accept a new parameter `clientAgents` that should contain the agent from which the library is used. #1272

Thanks again to @bidoubiwa ! 🎉