### PR TITLE
Fix tests failing because of bad task handling

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -316,8 +316,8 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
 
     test(`${permission} key: delete index using client`, async () => {
       const client = await getClient(permission)
-      const { taskUid } = await client.deleteIndex(indexPk.uid)
       await client.createIndex(indexPk.uid)
+      const { taskUid } = await client.deleteIndex(indexPk.uid)
       await client.waitForTask(taskUid)
 
       const { results } = await client.getIndexes()

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -10,6 +10,10 @@ beforeEach(async () => {
   await clearAllIndexes(config)
 })
 
+afterAll(() => {
+  return clearAllIndexes(config)
+})
+
 describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   'Test on keys',
   ({ permission }) => {

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -16,7 +16,7 @@ const TOKEN_TYP = 'JWT'
 const UID = 'movies_test'
 
 afterAll(() => {
-  clearAllIndexes(config)
+  return clearAllIndexes(config)
 })
 
 describe.each([{ permission: 'Private' }])(


### PR DESCRIPTION
Some tests were failing sometimes because of a bad handling on awaiting tasks and clearing the indexes