### PR TITLE
Create new publish CI for beta versions

### DIFF
--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -12,13 +12,11 @@ if [ $is_pre_release = false ]; then
   echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
   if [ $? != 0 ]; then
     echo "Error: Your tag: $current_tag is wrongly formatted."
-    echo "Please refer to the contributing guide for help."
+    echo 'Please refer to the contributing guide for help.'
     exit 1
   fi
   exit 0
-fi
-
-if [ $is_pre_release = true ]; then
+elif [ $is_pre_release = true ]; then
   # Works with the format vX.X.X-xxx-beta.X
   # none or multiple -xxx are valid
   #
@@ -30,8 +28,10 @@ if [ $is_pre_release = true ]; then
 
   if [ $? != 0 ]; then
     echo "Error: Your beta tag: $current_tag is wrongly formatted."
-    echo "Please refer to the contributing guide for help."
+    echo 'Please refer to the contributing guide for help.'
     exit 1
   fi
   exit 0
 fi
+
+exit 0

--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -2,13 +2,17 @@
 
 # Checking if current tag matches the required formating
 is_pre_release=$1
-
 current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
 
 if [ $is_pre_release = false ]; then
+  # Works with the format vX.X.X
+  #
+  # Example of correct format:
+  # v0.1.0
   echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
   if [ $? != 0 ]; then
-    echo "Your tag is badly formatted for a none pre-release"
+    echo "Error: Your tag: $current_tag is wrongly formatted."
+    echo "Please refer to the contributing guide for help."
     exit 1
   fi
   exit 0
@@ -18,14 +22,15 @@ if [ $is_pre_release = true ]; then
   # Works with the format vX.X.X-xxx-beta.X
   # none or multiple -xxx are valid
   #
-  # Exemple of correct format
-  # vX.X.X-beta.0
-  # vX.X.X-xxx-beta.0
-  # vX.X.X-xxx-xxx-beta.0
+  # Examples of correct format:
+  # v0.1.0-beta.0
+  # v0.1.0-xxx-beta.0
+  # v0.1.0-xxx-xxx-beta.0
   echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
 
   if [ $? != 0 ]; then
-    echo "Your pre release tag: $current_tag is badly formatted. Please refer to contributing guide"
+    echo "Error: Your beta tag: $current_tag is wrongly formatted."
+    echo "Please refer to the contributing guide for help."
     exit 1
   fi
   exit 0

--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Checking if current tag matches the required formating
+is_pre_release=$1
+
+current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
+
+if [ $is_pre_release = false ]; then
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
+  if [ $? != 0 ]; then
+    echo "Your tag is badly formatted for a none pre-release"
+    exit 1
+  fi
+  exit 0
+fi
+
+if [ $is_pre_release = true ]; then
+  # Works with the format vX.X.X-xxx-beta.X
+  # none or multiple -xxx are valid
+  #
+  # Exemple of correct format
+  # vX.X.X-beta.0
+  # vX.X.X-xxx-beta.0
+  # vX.X.X-xxx-xxx-beta.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
+
+  if [ $? != 0 ]; then
+    echo "Your pre release tag: $current_tag is badly formatted. Please refer to contributing guide"
+    exit 1
+  fi
+  exit 0
+fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,17 +14,19 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
+      - name: Check tag format
+        run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
       - name: Install dependencies
         run: yarn install
       - name: Build meilisearch-js
         run: yarn build
       - name: Publish with latest tag
-        if: "!github.event.release.prerelease"
+        if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
         run: npm publish .
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish with beta tag
-        if: "github.event.release.prerelease"
-        run: npm publish . --tag beta
+        if: "github.event.release.prerelease && contains(github.ref, 'beta')"
+        run: npm publish . --tag beta --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,16 +135,25 @@ GitHub Actions will be triggered and push the package to [npm](https://www.npmjs
 
 Here are the steps to release a beta version of this package:
 
-- Create a new branch originating the branch containing the "beta" changes. For example, if during the Meilisearch pre-release, create a branch originating `bump-meilisearch-v*.*.*`.<br>
-`vX.X.X` is the next version of the package, NOT the version of Meilisearch!
+- Create a new branch containing the "beta" changes with the following format `xxx-beta` where `xxx` explains the context.
 
-```bash
-git checkout bump-meilisearch-v*.*.*
-git pull origin bump-meilisearch-v*.*.*
-git checkout -b vX.X.X-beta.0
-```
+  For example:
+    - When implementing a beta feature create a branch `my-feature-beta` where you implement the feature.
+      ```bash
+        git checkout -b my-feature-beta
+      ```
+    - During the Meilisearch pre-release create a branch originating from `bump-meilisearch-v*.*.*` named `meilisearch-v*.*.*-beta`. <br>
+    `v*.*.*` is the next version of the package, NOT the version of Meilisearch!
 
-- Change the version in `package.json` with `X.X.X-beta.0` and commit it to the `vX.X.X-beta.0` branch
+      ```bash
+      git checkout bump-meilisearch-v*.*.*
+      git pull origin bump-meilisearch-v*.*.*
+      git checkout -b bump-meilisearch-v*.*.*-beta
+      ```
+
+- Change the version in `package.json` with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
+  - `v*.*.*-my-feature-beta.0`
+  - `v*.*.*-beta.0`
 
 - Go to the [GitHub interface for releasing](https://github.com/meilisearch/meilisearch-js/releases): on this page, click on `Draft a new release`.
 
@@ -159,8 +168,7 @@ git checkout -b vX.X.X-beta.0
 GitHub Actions will be triggered and push the beta version to [npm](https://www.npmjs.com/package/meilisearch).
 
 💡 If you need to release a new beta for the same version (i.e. `vX.X.X-beta.1`):
-- merge the change into `bump-meilisearch-v*.*.*`
-- rebase the `vX.X.X-beta.0` branch
+- merge the change into your beta branch
 - change the version name in `package.json`
 - creata a pre-release via the GitHub interface
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,11 +138,11 @@ Here are the steps to release a beta version of this package:
 - Create a new branch containing the "beta" changes with the following format `xxx-beta` where `xxx` explains the context.
 
   For example:
-    - When implementing a beta feature create a branch `my-feature-beta` where you implement the feature.
+    - When implementing a beta feature, create a branch `my-feature-beta` where you implement the feature.
       ```bash
         git checkout -b my-feature-beta
       ```
-    - During the Meilisearch pre-release create a branch originating from `bump-meilisearch-v*.*.*` named `meilisearch-v*.*.*-beta`. <br>
+    - During the Meilisearch pre-release, create a branch originating from `bump-meilisearch-v*.*.*` named `meilisearch-v*.*.*-beta`. <br>
     `v*.*.*` is the next version of the package, NOT the version of Meilisearch!
 
       ```bash


### PR DESCRIPTION
To be able to create beta releases on different subjects: `bumps`, `features`, etc.. we needed to provide a better suited CI.

This CI also checks if the tag well formated to ensure we do not publish a version that does not follow the naming convention.

The workflow has been tested on a private directory and seems to work correctly

⚠️ the `--dry-run` tag on the beta `npm publish . --tag beta --dry-run` is voluntarily added. The idea is to make a try run to ensure that it does what it is suppose to do! 

