### PR TITLE
Add temporarely testing CI for beta branches

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,0 +1,53 @@
+# Testing the code base against the Meilisearch pre-releases
+name: Beta tests
+
+# Will only run manualy by providing the correct docker image
+on:
+  workflow_dispatch:
+    inputs:
+      dockerImage:
+        description: 'Docker image of the beta version'
+        required: true
+        type: string
+
+jobs:
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['12', '14', '16']
+    services:
+      meilisearch:
+        image: getmeili/meilisearch:${{ inputs.dockerImage }}
+        env:
+          MEILI_MASTER_KEY: 'masterKey'
+          MEILI_NO_ANALYTICS: 'true'
+        ports:
+          - '7700:7700'
+    name: integration-tests-beta ${{ github.ref }} (Node.js ${{ matrix.node }})
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./node_modules
+          key: ${{ hashFiles('yarn.lock') }}
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn --dev
+      - name: Run tests
+        run: yarn test
+      - name: Build project
+        run: yarn build
+      - name: Run ESM env
+        run: yarn test:env:esm
+      - name: Run Node.js env
+        run: yarn test:env:nodejs
+      - name: Run node typescript env
+        run: yarn test:env:node-ts
+      - name: Run Browser env
+        run: yarn test:env:browser


### PR DESCRIPTION
Until we find a better way to fetch the correct docker image version for a certain beta feature, this CI lets us manually trigger the tests by providing the correct docker image. 