### PR TITLE
Feature prototype: define strategy on optional words during search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.27.0",
+  "version": "0.27.0-optional-words-beta.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.27.0-optional-words-beta.0",
+  "version": "0.27.0-optional-words-beta.1",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.27.0-optional-words-beta.0'
+export const PACKAGE_VERSION = '0.27.0-optional-words-beta.1'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -71,6 +71,7 @@ export type Crop = {
 export const enum OptionalWords {
   NONE = 'none',
   LAST = 'last',
+  ANY = 'any',
 }
 
 export type SearchParams = Query &

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -68,6 +68,11 @@ export type Crop = {
   cropMarker?: string
 }
 
+export const enum OptionalWords {
+  NONE = 'none',
+  LAST = 'last',
+}
+
 export type SearchParams = Query &
   Pagination &
   Highlight &
@@ -77,6 +82,7 @@ export type SearchParams = Query &
     facets?: string[]
     attributesToRetrieve?: string[]
     showMatchesPosition?: boolean
+    optionalWords?: OptionalWords
   }
 
 // Search parameters for searches made with the GET method

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -121,8 +121,7 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  // TODO: un skip when fixed
-  test.skip(`${permission} key: Basic phrase search`, async () => {
+  test(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
@@ -136,20 +135,18 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  // TODO: un skip when fixed
-  test.skip(`${permission} key: Basic phrase searchwith optionalWords at none`, async () => {
+  test(`${permission} key: Basic phrase searchwith optionalWords at none`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
       .search('"french book" about', { optionalWords: OptionalWords.NONE })
 
-    console.log(response.hits)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('limit', 20)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', '"french book" about')
-    expect(response.hits.length).toEqual(2)
+    expect(response.hits.length).toEqual(1)
   })
 
   test(`${permission} key: search with options`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -149,6 +149,20 @@ describe.each([
     expect(response.hits.length).toEqual(1)
   })
 
+  test(`${permission} key: Basic phrase searchwith optionalWords at any`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('french book', { optionalWords: OptionalWords.ANY })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
+    expect(response).toHaveProperty('query', 'french book')
+    expect(response.hits.length).toEqual(6)
+  })
+
   test(`${permission} key: search with options`, async () => {
     const client = await getClient(permission)
     const response = await client

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -130,12 +130,10 @@ describe.each([
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('limit', 20)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', '"french book" about')
     expect(response.hits.length).toEqual(2)
   })
 
-  test(`${permission} key: Basic phrase searchwith optionalWords at none`, async () => {
+  test(`${permission} key: Basic phrase search with optionalWords at NONE`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
@@ -144,12 +142,10 @@ describe.each([
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('limit', 20)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', '"french book" about')
     expect(response.hits.length).toEqual(1)
   })
 
-  test(`${permission} key: Basic phrase searchwith optionalWords at any`, async () => {
+  test(`${permission} key: Basic phrase search with optionalWords at ANY`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
@@ -158,8 +154,6 @@ describe.each([
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('limit', 20)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', 'french book')
     expect(response.hits.length).toEqual(6)
   })
 
@@ -636,7 +630,7 @@ describe.each([{ permission: 'Master' }])(
       })
     })
 
-    test(`${permission} key: search with optional words to none`, async () => {
+    test(`${permission} key: search with optionalWords as NONE`, async () => {
       const client = await getClient(permission)
 
       const response = await client.index(index.uid).search('Another french', {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,5 +1,5 @@
 import AbortController from 'abort-controller'
-import { ErrorStatusCode, EnqueuedTask } from '../src/types'
+import { ErrorStatusCode, EnqueuedTask, OptionalWords } from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -121,11 +121,29 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  test(`${permission} key: Basic phrase search`, async () => {
+  // TODO: un skip when fixed
+  test.skip(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
       .search('"french book" about', {})
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
+    expect(response).toHaveProperty('query', '"french book" about')
+    expect(response.hits.length).toEqual(2)
+  })
+
+  // TODO: un skip when fixed
+  test.skip(`${permission} key: Basic phrase searchwith optionalWords at none`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('"french book" about', { optionalWords: OptionalWords.NONE })
+
+    console.log(response.hits)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('limit', 20)
@@ -603,6 +621,23 @@ describe.each([{ permission: 'Master' }])(
         info: {
           comment: 'The best book',
           reviewNb: 1000,
+        },
+      })
+    })
+
+    test(`${permission} key: search with optional words to none`, async () => {
+      const client = await getClient(permission)
+
+      const response = await client.index(index.uid).search('Another french', {
+        optionalWords: OptionalWords.NONE,
+      })
+
+      expect(response.hits[0]).toEqual({
+        id: 3,
+        title: 'Le Rouge et le Noir',
+        info: {
+          comment: 'Another french book',
+          reviewNb: 700,
         },
       })
     })


### PR DESCRIPTION
Introduces `optionalWords` search parameter.
It lets you decide the search strategy for words matching during a search.

See https://github.com/meilisearch/meilisearch/pull/2636