### PR TITLE
Add tests on keys action for v0.29.1

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -50,6 +50,11 @@ export type IndexesResults<T> = ResourceResults<T> & {}
  * SEARCH PARAMETERS
  */
 
+export const enum MatchingStrategies {
+  ALL = 'all',
+  LAST = 'last',
+}
+
 export type Filter = string | Array<string | string[]>
 
 export type Query = {
@@ -77,6 +82,7 @@ export type SearchParams = Query &
     facets?: string[]
     attributesToRetrieve?: string[]
     showMatchesPosition?: boolean
+    matchingStrategy?: MatchingStrategies
   }
 
 // Search parameters for searches made with the GET method

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,5 +1,5 @@
 import AbortController from 'abort-controller'
-import { ErrorStatusCode, EnqueuedTask } from '../src/types'
+import { ErrorStatusCode, EnqueuedTask, MatchingStrategies } from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -95,6 +95,32 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
+  test(`${permission} key: Basic phrase search with matchingStrategy at ALL`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('"french book" about', {
+        matchingStrategy: MatchingStrategies.ALL,
+      })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response.hits.length).toEqual(1)
+  })
+
+  test(`${permission} key: Basic phrase search with matchingStrategy at LAST`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('french book', { matchingStrategy: MatchingStrategies.LAST })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response.hits.length).toEqual(2)
+  })
+
   test(`${permission} key: Search with query in searchParams overwriting query`, async () => {
     const client = await getClient(permission)
     const response = await client
@@ -121,7 +147,8 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  test(`${permission} key: Basic phrase search`, async () => {
+  // TODO: remove skip when bug is fixed by core
+  test.skip(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
@@ -131,6 +158,7 @@ describe.each([
     expect(response).toHaveProperty('limit', 20)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', '"french book" about')
+
     expect(response.hits.length).toEqual(2)
   })
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -147,8 +147,7 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  // TODO: remove skip when bug is fixed by core
-  test.skip(`${permission} key: Basic phrase search`, async () => {
+  test(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)


### PR DESCRIPTION
## Create an API key with the `action` with `*` for `indexes`, `settings`, `tasks`, `dumps`, `stats`

Related to:
- issue: https://github.com/meilisearch/meilisearch/issues/2578

This change enables the creation of keys with only one string as `action` that represents all the actions for a resource, e.g. `indexes.*` can do everything related to `indexes`.

- Add or replace some `test` cases to use this new compressed version.

# Release body

## 🚀 Enhancements

- `actions` field during `key` creation now accepts wildcards on actions. For example: `indexes.*` provides rights to create/get/delete/update indexes.
