### PR TITLE
Create beta version for meilisearch v0.29.0

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,12 +1,12 @@
 # Testing the code base against a specific Meilisearch feature
 name: Beta tests
 
-# Will only run for PRs and pushes to *-beta
+# Will only run for PRs and pushes to *-beta and not the bump betas
 on:
   push:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta', '**-beta']
   pull_request:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta', '**-beta']
 
 jobs:
   meilisearch-version:

--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,12 +1,12 @@
 # Testing the code base against a specific Meilisearch feature
 name: Beta tests
 
-# Will only run for PRs and pushes to *-beta and not the bump betas
+# Will only run for PRs and pushes to *-beta
 on:
   push:
-    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
   pull_request:
-    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
 
 jobs:
   meilisearch-version:

--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -4,9 +4,9 @@ name: Beta tests
 # Will only run for PRs and pushes to *-beta and not the bump betas
 on:
   push:
-    branches: ['!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
   pull_request:
-    branches: ['!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
 
 jobs:
   meilisearch-version:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.27.0",
+  "version": "0.27.0-beta.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.27.0-beta.0",
+  "version": "0.28.0-beta.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.27.0'
+export const PACKAGE_VERSION = '0.27.0-beta.0'

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.27.0-beta.0'
+export const PACKAGE_VERSION = '0.28.0-beta.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.1 :tada:
Check out the changelog of [Meilisearch v0.29.1](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0rc1) for more information on the changes.

## 🚀 Enhancements

- New search query parameter `matchingStrategy` #1324
- The `actions` field when creating a key now accepts wildcards on specific actions. For example: indexes.* provides rights to create/get/delete/update indexes https://github.com/meilisearch/meilisearch/issues/2560
- Changes in filters and behavior of the NOT keyword https://github.com/meilisearch/meilisearch/issues/2486