### PR TITLE
Change order of branches conditions in beta CI

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,12 +1,12 @@
 # Testing the code base against a specific Meilisearch feature
 name: Beta tests
 
-# Will only run for PRs and pushes to *-beta
+# Will only run for PRs and pushes to *-beta and not the bump betas
 on:
   push:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
   pull_request:
-    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+    branches: ['**-beta', '!bump-meilisearch-v[0-9]*.[0-9]*.[0-9]*-beta']
 
 jobs:
   meilisearch-version:


### PR DESCRIPTION
The order made that the second condition was overriding the first one. Making the tests run anyway on bump beta;s