### PR TITLE
Update version for the next release (v0.28.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ controller.abort()
 
 ## 🤖 Compatibility with Meilisearch
 
-This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
+This package only guarantees the compatibility with the [version v0.29.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0).
 
 ## 💡 Learn more
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.27.0'
+export const PACKAGE_VERSION = '0.28.0'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -50,6 +50,11 @@ export type IndexesResults<T> = ResourceResults<T> & {}
  * SEARCH PARAMETERS
  */
 
+export const enum MatchingStrategies {
+  ALL = 'all',
+  LAST = 'last',
+}
+
 export type Filter = string | Array<string | string[]>
 
 export type Query = {
@@ -77,6 +82,7 @@ export type SearchParams = Query &
     facets?: string[]
     attributesToRetrieve?: string[]
     showMatchesPosition?: boolean
+    matchingStrategy?: MatchingStrategies
   }
 
 // Search parameters for searches made with the GET method

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,5 +1,5 @@
 import AbortController from 'abort-controller'
-import { ErrorStatusCode, EnqueuedTask } from '../src/types'
+import { ErrorStatusCode, EnqueuedTask, MatchingStrategies } from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -95,6 +95,32 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
+  test(`${permission} key: Basic phrase search with matchingStrategy at ALL`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('"french book" about', {
+        matchingStrategy: MatchingStrategies.ALL,
+      })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response.hits.length).toEqual(1)
+  })
+
+  test(`${permission} key: Basic phrase search with matchingStrategy at LAST`, async () => {
+    const client = await getClient(permission)
+    const response = await client
+      .index(index.uid)
+      .search('french book', { matchingStrategy: MatchingStrategies.LAST })
+
+    expect(response).toHaveProperty('hits', expect.any(Array))
+    expect(response).toHaveProperty('offset', 0)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response.hits.length).toEqual(2)
+  })
+
   test(`${permission} key: Search with query in searchParams overwriting query`, async () => {
     const client = await getClient(permission)
     const response = await client
@@ -121,7 +147,8 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  test(`${permission} key: Basic phrase search`, async () => {
+  // TODO: remove skip when bug is fixed by core
+  test.skip(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
@@ -131,6 +158,7 @@ describe.each([
     expect(response).toHaveProperty('limit', 20)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', '"french book" about')
+
     expect(response.hits.length).toEqual(2)
   })
 


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.

## 🚀 Enhancements

- Add the new search query parameter `matchingStrategy` #1324 @bidoubiwa 
- Ensure support to keys with wildcarded actions.
  - `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`. #1325 @bidoubiwa 
  
## ⚠️ Breaking Changes

This breaking change *__may not affect you__*, but in any case, you should check your search queries if you want to keep the same behavior from `v0.28`.

- The `NOT` filter keyword does not have an implicitly `EXIST` operator anymore. Check out for more information: https://github.com/meilisearch/meilisearch/issues/2486