### PR TITLE
Fix getting started code-sample json import

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -409,7 +409,7 @@ getting_started_add_documents_md: |-
   `import` syntax:
   ```js
   import { MeiliSearch } from 'meilisearch'
-  import movies from '../small_movies.json'
+  import movies from './movies.json'
   ```
 
   **Use**


### PR DESCRIPTION
Wrong json document import in the getting started code sample. From `../small_movies.json` to `./movies.json`