### PR TITLE
refactor: Construct date type for related keys

### DIFF
--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -266,7 +266,15 @@ class Client {
    */
   async getKeys(parameters: KeysQuery = {}): Promise<KeysResults> {
     const url = `keys`
-    return await this.httpRequest.get<KeysResults>(url, parameters)
+    const allKeys = await this.httpRequest.get<KeysResults>(url, parameters)
+
+    allKeys.results = allKeys.results.map((key) => ({
+      ...key,
+      createdAt: new Date(key.createdAt),
+      updateAt: new Date(key.updateAt),
+    }))
+
+    return allKeys
   }
 
   /**

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -266,15 +266,15 @@ class Client {
    */
   async getKeys(parameters: KeysQuery = {}): Promise<KeysResults> {
     const url = `keys`
-    const allKeys = await this.httpRequest.get<KeysResults>(url, parameters)
+    const keys = await this.httpRequest.get<KeysResults>(url, parameters)
 
-    allKeys.results = allKeys.results.map((key) => ({
+    keys.results = keys.results.map((key) => ({
       ...key,
       createdAt: new Date(key.createdAt),
       updateAt: new Date(key.updateAt),
     }))
 
-    return allKeys
+    return keys
   }
 
   /**

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -403,7 +403,11 @@ class Client {
    */
   async createDump(): Promise<EnqueuedTask> {
     const url = `dumps`
-    return await this.httpRequest.post<undefined, EnqueuedTask>(url)
+    const task = await this.httpRequest.post<undefined, EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -195,7 +195,11 @@ class Index<T = Record<string, any>> {
   ): Promise<EnqueuedTask> {
     const url = `indexes`
     const req = new HttpRequests(config)
-    return req.post(url, { ...options, uid })
+    const taskItem = await req.post(url, { ...options, uid })
+
+    taskItem.enqueuedAt = new Date(taskItem.enqueuedAt)
+
+    return taskItem
   }
 
   /**
@@ -384,7 +388,11 @@ class Index<T = Record<string, any>> {
     options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    return await this.httpRequest.post(url, documents, options)
+    const documentItem = await this.httpRequest.post(url, documents, options)
+
+    documentItem.enqueuedAt = new Date(documentItem.enqueuedAt)
+
+    return documentItem
   }
 
   /**
@@ -424,7 +432,11 @@ class Index<T = Record<string, any>> {
     options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    return await this.httpRequest.put(url, documents, options)
+    const taskItem = await this.httpRequest.put(url, documents, options)
+
+    taskItem.enqueuedAt = new Date(taskItem.enqueuedAt)
+
+    return taskItem
   }
 
   /**

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -195,11 +195,11 @@ class Index<T = Record<string, any>> {
   ): Promise<EnqueuedTask> {
     const url = `indexes`
     const req = new HttpRequests(config)
-    const taskItem = await req.post(url, { ...options, uid })
+    const task = await req.post(url, { ...options, uid })
 
-    taskItem.enqueuedAt = new Date(taskItem.enqueuedAt)
+    task.enqueuedAt = new Date(taskItem.enqueuedAt)
 
-    return taskItem
+    return task
   }
 
   /**
@@ -432,9 +432,9 @@ class Index<T = Record<string, any>> {
     options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    const taskItem = await this.httpRequest.put(url, documents, options)
+    const task = await this.httpRequest.put(url, documents, options)
 
-    taskItem.enqueuedAt = new Date(taskItem.enqueuedAt)
+    task.enqueuedAt = new Date(task.enqueuedAt)
 
     return taskItem
   }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -388,11 +388,11 @@ class Index<T = Record<string, any>> {
     options?: DocumentOptions
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    const documentItem = await this.httpRequest.post(url, documents, options)
+    const task = await this.httpRequest.post(url, documents, options)
 
-    documentItem.enqueuedAt = new Date(documentItem.enqueuedAt)
+    task.enqueuedAt = new Date(documentItem.enqueuedAt)
 
-    return documentItem
+    return task
   }
 
   /**

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -197,7 +197,7 @@ class Index<T = Record<string, any>> {
     const req = new HttpRequests(config)
     const task = await req.post(url, { ...options, uid })
 
-    task.enqueuedAt = new Date(taskItem.enqueuedAt)
+    task.enqueuedAt = new Date(task.enqueuedAt)
 
     return task
   }
@@ -211,7 +211,11 @@ class Index<T = Record<string, any>> {
    */
   async update(data: IndexOptions): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}`
-    return await this.httpRequest.patch(url, data)
+    const task = await this.httpRequest.patch(url, data)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -222,7 +226,11 @@ class Index<T = Record<string, any>> {
    */
   async delete(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}`
-    return await this.httpRequest.delete(url)
+    const task = await this.httpRequest.delete(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -390,7 +398,7 @@ class Index<T = Record<string, any>> {
     const url = `indexes/${this.uid}/documents`
     const task = await this.httpRequest.post(url, documents, options)
 
-    task.enqueuedAt = new Date(documentItem.enqueuedAt)
+    task.enqueuedAt = new Date(task.enqueuedAt)
 
     return task
   }
@@ -436,7 +444,7 @@ class Index<T = Record<string, any>> {
 
     task.enqueuedAt = new Date(task.enqueuedAt)
 
-    return taskItem
+    return task
   }
 
   /**
@@ -472,7 +480,11 @@ class Index<T = Record<string, any>> {
    */
   async deleteDocument(documentId: string | number): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents/${documentId}`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -487,7 +499,11 @@ class Index<T = Record<string, any>> {
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents/delete-batch`
 
-    return await this.httpRequest.post(url, documentsIds)
+    const task = await this.httpRequest.post(url, documentsIds)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -498,7 +514,11 @@ class Index<T = Record<string, any>> {
    */
   async deleteAllDocuments(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/documents`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -526,7 +546,11 @@ class Index<T = Record<string, any>> {
    */
   async updateSettings(settings: Settings): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings`
-    return await this.httpRequest.patch(url, settings)
+    const task = await this.httpRequest.patch(url, settings)
+
+    task.enqueued = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -537,7 +561,11 @@ class Index<T = Record<string, any>> {
    */
   async resetSettings(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -564,7 +592,11 @@ class Index<T = Record<string, any>> {
    */
   async updateSynonyms(synonyms: Synonyms): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/synonyms`
-    return await this.httpRequest.put(url, synonyms)
+    const task = await this.httpRequest.put(url, synonyms)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -575,7 +607,11 @@ class Index<T = Record<string, any>> {
    */
   async resetSynonyms(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/synonyms`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -602,7 +638,11 @@ class Index<T = Record<string, any>> {
    */
   async updateStopWords(stopWords: StopWords): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/stop-words`
-    return await this.httpRequest.put(url, stopWords)
+    const task = await this.httpRequest.put(url, stopWords)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -613,7 +653,11 @@ class Index<T = Record<string, any>> {
    */
   async resetStopWords(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/stop-words`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -640,7 +684,11 @@ class Index<T = Record<string, any>> {
    */
   async updateRankingRules(rankingRules: RankingRules): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/ranking-rules`
-    return await this.httpRequest.put(url, rankingRules)
+    const task = await this.httpRequest.put(url, rankingRules)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -651,7 +699,11 @@ class Index<T = Record<string, any>> {
    */
   async resetRankingRules(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/ranking-rules`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -680,7 +732,11 @@ class Index<T = Record<string, any>> {
     distinctAttribute: DistinctAttribute
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/distinct-attribute`
-    return await this.httpRequest.put(url, distinctAttribute)
+    const task = await this.httpRequest.put(url, distinctAttribute)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -691,7 +747,11 @@ class Index<T = Record<string, any>> {
    */
   async resetDistinctAttribute(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/distinct-attribute`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -720,7 +780,11 @@ class Index<T = Record<string, any>> {
     filterableAttributes: FilterableAttributes
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/filterable-attributes`
-    return await this.httpRequest.put(url, filterableAttributes)
+    const task = await this.httpRequest.put(url, filterableAttributes)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -731,7 +795,11 @@ class Index<T = Record<string, any>> {
    */
   async resetFilterableAttributes(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/filterable-attributes`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -760,7 +828,11 @@ class Index<T = Record<string, any>> {
     sortableAttributes: SortableAttributes
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/sortable-attributes`
-    return await this.httpRequest.put(url, sortableAttributes)
+    const task = await this.httpRequest.put(url, sortableAttributes)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -771,7 +843,11 @@ class Index<T = Record<string, any>> {
    */
   async resetSortableAttributes(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/sortable-attributes`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -800,7 +876,11 @@ class Index<T = Record<string, any>> {
     searchableAttributes: SearchableAttributes
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/searchable-attributes`
-    return await this.httpRequest.put(url, searchableAttributes)
+    const task = await this.httpRequest.put(url, searchableAttributes)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -811,7 +891,11 @@ class Index<T = Record<string, any>> {
    */
   async resetSearchableAttributes(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/searchable-attributes`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -840,7 +924,11 @@ class Index<T = Record<string, any>> {
     displayedAttributes: DisplayedAttributes
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/displayed-attributes`
-    return await this.httpRequest.put(url, displayedAttributes)
+    const task = await this.httpRequest.put(url, displayedAttributes)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -851,7 +939,11 @@ class Index<T = Record<string, any>> {
    */
   async resetDisplayedAttributes(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/displayed-attributes`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   ///
@@ -880,7 +972,11 @@ class Index<T = Record<string, any>> {
     typoTolerance: TypoTolerance
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/typo-tolerance`
-    return await this.httpRequest.patch(url, typoTolerance)
+    const task = await this.httpRequest.patch(url, typoTolerance)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 
   /**
@@ -891,7 +987,11 @@ class Index<T = Record<string, any>> {
    */
   async resetTypoTolerance(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/typo-tolerance`
-    return await this.httpRequest.delete<EnqueuedTask>(url)
+    const task = await this.httpRequest.delete<EnqueuedTask>(url)
+
+    task.enqueuedAt = new Date(task.enqueuedAt)
+
+    return task
   }
 }
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -26,7 +26,13 @@ class TaskClient {
    */
   async getTask(uid: number): Promise<Task> {
     const url = `tasks/${uid}`
-    return await this.httpRequest.get<Task>(url)
+    const taskItem = await this.httpRequest.get<Task>(url)
+
+    taskItem.startedAt = new Date(taskItem.startedAt)
+    taskItem.enqueuedAt = new Date(taskItem.enqueuedAt)
+    taskItem.finishedAt = new Date(taskItem.finishedAt)
+
+    return taskItem
   }
 
   /**
@@ -47,10 +53,19 @@ class TaskClient {
       limit: parameters.limit,
     }
 
-    return await this.httpRequest.get<Promise<TasksResults>>(
+    const taskList = await this.httpRequest.get<Promise<TasksResults>>(
       url,
       removeUndefinedFromObject(queryParams)
     )
+
+    taskList.results = taskList.results.map((task) => ({
+      ...task,
+      startedAt: new Date(task.startedAt),
+      enqueuedAt: new Date(task.enqueuedAt),
+      finishedAt: new Date(task.finishedAt),
+    }))
+
+    return taskList
   }
 
   /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -58,14 +58,14 @@ class TaskClient {
       removeUndefinedFromObject(queryParams)
     )
 
-    taskList.results = taskList.results.map((task) => ({
+    tasks.results = tasks.results.map((task) => ({
       ...task,
       startedAt: new Date(task.startedAt),
       enqueuedAt: new Date(task.enqueuedAt),
       finishedAt: new Date(task.finishedAt),
     }))
 
-    return taskList
+    return tasks
   }
 
   /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -53,7 +53,7 @@ class TaskClient {
       limit: parameters.limit,
     }
 
-    const taskList = await this.httpRequest.get<Promise<TasksResults>>(
+    const tasks = await this.httpRequest.get<Promise<TasksResults>>(
       url,
       removeUndefinedFromObject(queryParams)
     )

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -230,7 +230,7 @@ export type EnqueuedTask = {
   indexUid?: string
   status: TaskStatus
   type: TaskTypes
-  enqueuedAt: string
+  enqueuedAt: Date
 }
 
 export type Task = Omit<EnqueuedTask, 'taskUid'> & {
@@ -275,8 +275,8 @@ export type Task = Omit<EnqueuedTask, 'taskUid'> & {
   }
   error?: MeiliSearchErrorInfo
   duration: string
-  startedAt: string
-  finishedAt: string
+  startedAt: Date
+  finishedAt: Date
 }
 
 export type TasksResults = {
@@ -328,9 +328,9 @@ export type Key = {
   key: string
   actions: string[]
   indexes: string[]
-  expiresAt: string
-  createdAt: string
-  updateAt: string
+  expiresAt: Date
+  createdAt: Date
+  updateAt: Date
 }
 
 export type KeyCreation = {
@@ -339,7 +339,7 @@ export type KeyCreation = {
   description?: string
   actions: string[]
   indexes: string[]
-  expiresAt: string | null
+  expiresAt: Date | null
 }
 
 export type KeyUpdate = {

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -51,7 +51,9 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(searchKey).toHaveProperty('indexes')
       expect(searchKey).toHaveProperty('expiresAt', null)
       expect(searchKey).toHaveProperty('createdAt')
+      expect(searchKey?.createdAt).toBeInstanceOf(Date)
       expect(searchKey).toHaveProperty('updatedAt')
+      expect(searchKey?.updateAt).toBeInstanceOf(Date)
 
       const adminKey = keys.results.find(
         (key: any) => key.name === 'Default Admin API Key'
@@ -67,7 +69,9 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(adminKey).toHaveProperty('indexes')
       expect(adminKey).toHaveProperty('expiresAt', null)
       expect(adminKey).toHaveProperty('createdAt')
+      expect(searchKey?.createdAt).toBeInstanceOf(Date)
       expect(adminKey).toHaveProperty('updatedAt')
+      expect(searchKey?.updateAt).toBeInstanceOf(Date)
     })
 
     test(`${permission} key: get keys with pagination`, async () => {
@@ -123,7 +127,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         description: 'Indexing Products API key',
         actions: ['documents.add'],
         indexes: ['products'],
-        expiresAt: '2050-11-13T00:00:00Z', // Test will fail in 2050
+        expiresAt: new Date('2050-11-13T00:00:00Z'), // Test will fail in 2050
       })
 
       expect(key).toBeDefined()
@@ -138,7 +142,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         description: 'Indexing Products API key',
         actions: ['documents.add'],
         indexes: ['products'],
-        expiresAt: '2050-11-13T00:00:00Z', // Test will fail in 2050
+        expiresAt: new Date('2050-11-13T00:00:00Z'), // Test will fail in 2050
       })
 
       const updatedKey = await client.updateKey(key.key, {
@@ -161,7 +165,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
         description: 'Indexing Products API key',
         actions: ['documents.add'],
         indexes: ['products'],
-        expiresAt: '2050-11-13T00:00:00Z', // Test will fail in 2050
+        expiresAt: new Date('2050-11-13T00:00:00Z'), // Test will fail in 2050
       })
 
       const deletedKey = await client.deleteKey(key.key)

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -45,6 +45,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(enqueuedTask.status).toBeDefined()
       expect(enqueuedTask.type).toEqual(TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE)
       expect(enqueuedTask.enqueuedAt).toBeDefined()
+      expect(enqueuedTask.enqueuedAt).toBeInstanceOf(Date)
     })
 
     test(`${permission} key: Get one task`, async () => {
@@ -57,15 +58,17 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
       expect(task.indexUid).toEqual(index.uid)
       expect(task.status).toEqual(TaskStatus.TASK_SUCCEEDED)
       expect(task.type).toEqual(TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE)
-      expect(task.enqueuedAt).toBeDefined()
       expect(task.uid).toEqual(enqueuedTask.taskUid)
       expect(task).toHaveProperty('details')
       expect(task.details.indexedDocuments).toEqual(7)
       expect(task.details.receivedDocuments).toEqual(7)
       expect(task.duration).toBeDefined()
       expect(task.enqueuedAt).toBeDefined()
+      expect(task.enqueuedAt).toBeInstanceOf(Date)
       expect(task.finishedAt).toBeDefined()
+      expect(task.finishedAt).toBeInstanceOf(Date)
       expect(task.startedAt).toBeDefined()
+      expect(task.startedAt).toBeInstanceOf(Date)
     })
 
     test(`${permission} key: Get one task with index instance`, async () => {


### PR DESCRIPTION
# Pull Request

I have updated the codebase so that the keys which are technically of date type are constructed with `Date()` object before returning.
Also I have updated the Test cases.

## What does this PR do?
Fixes #1223 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
- [x] Updated the test cases to see they pass

Thank you so much for contributing to Meilisearch!
