### PR TITLE
Standardise naming convention of Private and Public keys in test to Admin and Search respectively. 

### DIFF
--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -24,8 +24,8 @@ afterAll(() => {
 
 describe.each([
   { permission: 'Master' },
-  { permission: 'Private' },
-  { permission: 'Public' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
 ])('Test on client instance', ({ permission }) => {
   beforeEach(() => {
     return clearAllIndexes(config)
@@ -149,7 +149,7 @@ describe.each([
   })
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on client w/ master and admin key',
   ({ permission }) => {
     beforeEach(() => {
@@ -408,7 +408,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on misc client methods w/ search apikey',
   ({ permission }) => {
     beforeEach(() => {

--- a/tests/displayed_attributes.test.ts
+++ b/tests/displayed_attributes.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on displayed attributes',
   ({ permission }) => {
     beforeEach(async () => {
@@ -72,7 +72,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on displayed attributes',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/distinct_attribute.test.ts
+++ b/tests/distinct_attribute.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on distinct attribute',
   ({ permission }) => {
     beforeEach(async () => {
@@ -70,7 +70,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on distinct attribute',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -24,7 +24,7 @@ afterAll(() => {
 })
 
 describe('Documents tests', () => {
-  describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+  describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     'Test on documents',
     ({ permission }) => {
       beforeEach(async () => {
@@ -477,7 +477,7 @@ describe('Documents tests', () => {
     }
   )
 
-  describe.each([{ permission: 'Public' }])(
+  describe.each([{ permission: 'Search' }])(
     'Test on documents',
     ({ permission }) => {
       beforeEach(() => {

--- a/tests/dump.test.ts
+++ b/tests/dump.test.ts
@@ -11,7 +11,7 @@ beforeEach(async () => {
   await clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on dump',
   ({ permission }) => {
     test(`${permission} key: create a new dump`, async () => {
@@ -23,7 +23,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on dump with search api key should not have access',
   ({ permission }) => {
     test(`${permission} key: try to create dump with search key and be denied`, async () => {

--- a/tests/faceting.test.ts
+++ b/tests/faceting.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on faceting',
   ({ permission }) => {
     beforeEach(async () => {
@@ -85,7 +85,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on faceting',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/filterable_attributes.test.ts
+++ b/tests/filterable_attributes.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on searchable attributes',
   ({ permission }) => {
     beforeEach(async () => {
@@ -78,7 +78,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on attributes for filtering',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -63,8 +63,8 @@ afterAll(() => {
 
 describe.each([
   { permission: 'Master' },
-  { permission: 'Private' },
-  { permission: 'Public' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
 ])('Test on GET search', ({ permission }) => {
   beforeAll(async () => {
     await clearAllIndexes(config)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,7 +19,7 @@ afterAll(async () => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on indexes w/ master and admin key',
   ({ permission }) => {
     beforeEach(() => {
@@ -393,7 +393,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on routes with search key',
   ({ permission }) => {
     beforeEach(() => {

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -16,7 +16,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on keys',
   ({ permission }) => {
     beforeEach(async () => {
@@ -87,7 +87,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
 
     test(`${permission} key: get on key`, async () => {
       const client = await getClient(permission)
-      const apiKey = await getKey('Private')
+      const apiKey = await getKey('Admin')
 
       const key = await client.getKey(apiKey)
 
@@ -203,7 +203,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on keys with search key',
   ({ permission }) => {
     test(`${permission} key: get keys denied`, async () => {

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,4 +1,4 @@
-import { ErrorStatusCode } from '../src/types'
+﻿import { ErrorStatusCode } from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on pagination',
   ({ permission }) => {
     beforeEach(async () => {
@@ -80,7 +80,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on pagination',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/ranking_rules.test.ts
+++ b/tests/ranking_rules.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on ranking rules',
   ({ permission }) => {
     beforeEach(async () => {
@@ -83,7 +83,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on ranking rules',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -61,8 +61,8 @@ const dataset = [
 
 describe.each([
   { permission: 'Master' },
-  { permission: 'Private' },
-  { permission: 'Public' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
 ])('Test on POST search', ({ permission }) => {
   beforeAll(async () => {
     await clearAllIndexes(config)
@@ -640,8 +640,8 @@ describe.each([{ permission: 'Master' }])(
 
 describe.each([
   { permission: 'Master' },
-  { permission: 'Private' },
-  { permission: 'Public' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
 ])('Test on abortable search', ({ permission }) => {
   beforeAll(async () => {
     const client = await getClient('Master')

--- a/tests/searchable_attributes.test.ts
+++ b/tests/searchable_attributes.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on searchable attributes',
   ({ permission }) => {
     beforeEach(async () => {
@@ -80,7 +80,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on searchable attributes',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -64,7 +64,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on settings',
   ({ permission }) => {
     beforeEach(async () => {
@@ -307,7 +307,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on settings',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/sortable_attributes.test.ts
+++ b/tests/sortable_attributes.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on sortable attributes',
   ({ permission }) => {
     beforeEach(async () => {
@@ -74,7 +74,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on sortable attributes',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/stop_words.test.ts
+++ b/tests/stop_words.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on stop words',
   ({ permission }) => {
     beforeEach(async () => {
@@ -73,7 +73,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on stop words',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/synonyms.test.ts
+++ b/tests/synonyms.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on synonyms',
   ({ permission }) => {
     beforeEach(async () => {
@@ -70,7 +70,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Test on synonyms',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -26,7 +26,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Tests on tasks',
   ({ permission }) => {
     beforeEach(async () => {
@@ -230,7 +230,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])('Test on tasks', ({ permission }) => {
+describe.each([{ permission: 'Search' }])('Test on tasks', ({ permission }) => {
   beforeEach(async () => {
     await clearAllIndexes(config)
   })

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Private' }])(
+describe.each([{ permission: 'Admin' }])(
   'Tests on token generation',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -82,8 +82,8 @@ afterAll(() => {
 
 describe.each([
   { permission: 'Master' },
-  { permission: 'Private' },
-  { permission: 'Public' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
 ])('Test on search', ({ permission }) => {
   beforeAll(async () => {
     const client = await getClient('Master')

--- a/tests/typo_tolerance.test.ts
+++ b/tests/typo_tolerance.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Tests on typo tolerance',
   ({ permission }) => {
     beforeEach(async () => {
@@ -89,7 +89,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
   }
 )
 
-describe.each([{ permission: 'Public' }])(
+describe.each([{ permission: 'Search' }])(
   'Tests on typo tolerance',
   ({ permission }) => {
     beforeEach(async () => {

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -53,20 +53,20 @@ async function getClient(permission: string): Promise<MeiliSearch> {
 
   if (permission === 'Search') {
     const searchKey = await getKey(permission)
-    const publicClient = new MeiliSearch({
+    const searchClient = new MeiliSearch({
       host: HOST,
       apiKey: searchKey,
     })
-    return publicClient
+    return searchClient
   }
 
   if (permission === 'Admin') {
     const adminKey = await getKey(permission)
-    const privateClient = new MeiliSearch({
+    const adminClient = new MeiliSearch({
       host: HOST,
       apiKey: adminKey,
     })
-    return privateClient
+    return adminClient
   }
 
   return masterClient

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -29,13 +29,13 @@ async function getKey(permission: string): Promise<string> {
   }
   const { results: keys } = await masterClient.getKeys()
 
-  if (permission === 'Public') {
+  if (permission === 'Search') {
     const key = keys.find((key: any) => key.name === 'Default Search API Key')
       ?.key
     return key || ''
   }
 
-  if (permission === 'Private') {
+  if (permission === 'Admin') {
     const key = keys.find((key: any) => key.name === 'Default Admin API Key')
       ?.key
     return key || ''
@@ -51,7 +51,7 @@ async function getClient(permission: string): Promise<MeiliSearch> {
     return anonymousClient
   }
 
-  if (permission === 'Public') {
+  if (permission === 'Search') {
     const searchKey = await getKey(permission)
     const publicClient = new MeiliSearch({
       host: HOST,
@@ -60,7 +60,7 @@ async function getClient(permission: string): Promise<MeiliSearch> {
     return publicClient
   }
 
-  if (permission === 'Private') {
+  if (permission === 'Admin') {
     const adminKey = await getKey(permission)
     const privateClient = new MeiliSearch({
       host: HOST,

--- a/tests/wait_for_task.test.ts
+++ b/tests/wait_for_task.test.ts
@@ -16,7 +16,7 @@ afterAll(() => {
   return clearAllIndexes(config)
 })
 
-describe.each([{ permission: 'Master' }, { permission: 'Private' }])(
+describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
   'Test on wait for task',
   ({ permission }) => {
     beforeEach(async () => {


### PR DESCRIPTION
# Pull Request
Standardise naming convention of Private and Public keys in test to Admin and Seach respectively

## Related issue
Fixes #1137 

## What does this PR do?
-Standardises the naming convention of Index and Admin Keys in the tests by updating the remaining Private and Public string constants been passed. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
