### PR TITLE
Add pagination feature for v0.30.0

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,8 +235,15 @@ export const enum TaskTypes {
 
 export type TasksQuery = {
   indexUid?: string[]
+  uid?: number[]
   type?: TaskTypes[]
   status?: TaskStatus[]
+  beforeEnqueuedAt?: Date
+  afterEnqueuedAt?: Date
+  beforeStartedAt?: Date
+  afterStartedAt?: Date
+  beforeFinishedAt?: Date
+  afterFinishedAt?: Date
   limit?: number
   from?: number
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,15 +235,8 @@ export const enum TaskTypes {
 
 export type TasksQuery = {
   indexUid?: string[]
-  uid?: number[]
   type?: TaskTypes[]
   status?: TaskStatus[]
-  beforeEnqueuedAt?: Date
-  afterEnqueuedAt?: Date
-  beforeStartedAt?: Date
-  afterStartedAt?: Date
-  beforeFinishedAt?: Date
-  afterFinishedAt?: Date
   limit?: number
   from?: number
 }

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -91,11 +91,12 @@ describe.each([
 
   test(`${permission} key: Basic search`, async () => {
     const client = await getClient(permission)
+
     const response = await client.index(index.uid).searchGet('prince', {})
+
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
     expect(response.hits.length).toEqual(2)
@@ -129,27 +130,13 @@ describe.each([
     const response = await client.index(index.uid).searchGet('prince', {
       attributesToRetrieve: ['*'],
     })
-    expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(2)
-  })
+    const hit = response.hits[0]
 
-  test(`${permission} key: search with array options`, async () => {
-    const client = await getClient(permission)
-    const response = await client.index(index.uid).searchGet('prince', {
-      attributesToRetrieve: ['*'],
-    })
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(2)
+    expect(Object.keys(hit).join(',')).toEqual(
+      Object.keys(dataset[1]).join(',')
+    )
   })
 
   test(`${permission} key: search with options`, async () => {
@@ -195,12 +182,6 @@ describe.each([
       showMatchesPosition: true,
     })
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(1)
     expect(response.hits[0]).toHaveProperty('_matchesPosition', {
       comment: [{ start: 22, length: 6 }],
       title: [{ start: 9, length: 6 }],
@@ -415,7 +396,7 @@ describe.each([
       genre: { fantasy: 2 },
     })
     expect(response.hits.length).toEqual(2)
-    expect(response.totalHits).toEqual(2)
+    expect(response.estimatedTotalHits).toEqual(2)
   })
 
   test(`${permission} key: search with multiple filter and empty string query (placeholder)`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -235,10 +235,12 @@ describe.each([
 
   test(`${permission} key: search with limit and offset`, async () => {
     const client = await getClient(permission)
+
     const response = await client.index(index.uid).search('prince', {
       limit: 1,
       offset: 1,
     })
+
     expect(response).toHaveProperty('hits', [
       {
         id: 4,

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -634,7 +634,7 @@ describe.each([
     const response = await client.index(index.uid).search('', {
       hitsPerPage: 1,
       page: 1,
-      limit: 1,
+      offset: 1,
     })
 
     expect(response.hits.length).toEqual(1)

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -151,16 +151,14 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  // TODO: remove skip when bug is fixed by core
-  test.skip(`${permission} key: Basic phrase search`, async () => {
+  test(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
       .search('"french book" about', {})
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', '"french book" about')
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -545,6 +545,20 @@ describe.each([
     expect(response.totalHits).toEqual(7)
   })
 
+  test(`${permission} key: search with pagination parameters: hitsPerPage at 0`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('', {
+      hitsPerPage: 0,
+    })
+
+    expect(response.hits.length).toEqual(0)
+    expect(response.hitsPerPage).toEqual(0)
+    expect(response.page).toEqual(1)
+    expect(response.totalPages).toEqual(0)
+    expect(response.totalHits).toEqual(7)
+  })
+
   test(`${permission} key: search with pagination parameters: hitsPerPage at 1 and page at 0`, async () => {
     const client = await getClient(permission)
 
@@ -557,6 +571,20 @@ describe.each([
     expect(response.hitsPerPage).toEqual(1)
     expect(response.page).toEqual(0)
     expect(response.totalPages).toEqual(7)
+    expect(response.totalHits).toEqual(7)
+  })
+
+  test(`${permission} key: search with pagination parameters: page at 0`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('', {
+      page: 0,
+    })
+
+    expect(response.hits.length).toEqual(0)
+    expect(response.hitsPerPage).toEqual(20)
+    expect(response.page).toEqual(0)
+    expect(response.totalPages).toEqual(1)
     expect(response.totalHits).toEqual(7)
   })
 

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -110,9 +110,8 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index<Movie>(index.uid).search('prince', {})
     expect(response.hits.length === 2).toBeTruthy()
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 2).toBeTruthy()
+    expect(response.limit === 20).toBeTruthy()
+    expect(response.offset === 0).toBeTruthy()
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response.query === 'prince').toBeTruthy()
   })
@@ -168,11 +167,6 @@ describe.each([
       showMatchesPosition: true,
     })
     expect(response.hits.length === 1).toBeTruthy()
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 1).toBeTruthy()
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response.query === 'prince').toBeTruthy()
     expect(response.hits[0]?._matchesPosition?.comment).toEqual([
       { start: 22, length: 6 },
     ])
@@ -355,9 +349,7 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index(emptyIndex.uid).search('prince', {})
 
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 0).toBeTruthy()
+    expect(response.hits.length === 0).toBeTruthy()
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response.query === 'prince').toBeTruthy()
   })
@@ -372,9 +364,10 @@ describe.each([
     })
 
     expect(response.hits.length).toEqual(1)
-    expect(response.limit === 1).toBeTruthy()
-    expect(response.offset === 0).toBeTruthy()
-    expect(response.estimatedTotalHits).toEqual(7)
+    expect(response.hitsPerPage === 1).toBeTruthy()
+    expect(response.page === 1).toBeTruthy()
+    expect(response.totalPages === 7).toBeTruthy()
+    expect(response.totalHits === 7).toBeTruthy()
   })
 
   test(`${permission} key: Try to Search on deleted index and fail`, async () => {


### PR DESCRIPTION
Adds the new page selection component 


TODO: 

- [x] add two new search parameters: `page` and `hitsPerPage`
- [x] add 4 new search responses: `page`, `hitsPerPage`, `totalHits`, `totalPages`

Response: 
- [x] Limit is now optional
- [x] offset is now optional
- [x] estimatedTotalHits is now optional
- [x] new `page` is optional
- [x] new `hitsPerPage` is optional
- [x] new `totalPages` is optional
- [x] new `totalHits` is optional

Tests
- [x] add tests in search.test.ts
- [x] add tests in typed-search.test.ts
