### PR TITLE
Add new get tasks query parameters for v0.30 of Meilisearch

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,8 +235,16 @@ export const enum TaskTypes {
 
 export type TasksQuery = {
   indexUid?: string[]
+  uid?: number[]
   type?: TaskTypes[]
   status?: TaskStatus[]
+  canceledBy?: string[]
+  beforeEnqueuedAt?: Date
+  afterEnqueuedAt?: Date
+  beforeStartedAt?: Date
+  afterStartedAt?: Date
+  beforeFinishedAt?: Date
+  afterFinishedAt?: Date
   limit?: number
   from?: number
 }


### PR DESCRIPTION
Add the cancel task api, see [spec](https://github.com/meilisearch/specifications/pull/195)

TODO: 


in TasksQuery:
  - [x] Add `uid`
  - [x] Add `canceledBy`
  - [x] Add `beforeEnqueuedAt`
  - [x] Add `afterEnqueuedAt`
  - [x] Add `afterStatedAd`
  - [x] Add `beforeFinishedAt`
  - [x] Add `afterFinishedAt`

in `Task` and `TaskObject`
  - [ ] Add `canceledBy`

in `Task.details`:
  - [ ] Add `matchedTasks`
  - [ ] Add `canceledTasks`
  - [ ] Add `originalQuery`

in `TaskTypes`:
  - [ ] Add `taskCancelation`

in `TaskStatus`:
  - [ ] add `canceled`

in `errors`:
  - [ ] Add `invalid_task_uid`
  - [ ] Add `invalid_task_date`
  - [ ] Add `invalid_task_canceled_by`
  - [ ] Add `missing_task_filters`

in `actions` of token:
  - [ ] Add `tasks.cancel` (if defined)
