### PR TITLE
Add tasks filters for v0.30

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -11,12 +11,12 @@ import {
 
 import { addTrailingSlash, addProtocolIfNotPresent } from './utils'
 
-function stringifyQueryParams<T extends object, U extends object>(
-  parameters: T
-): U {
+type queryParams<T> = { [key in keyof T]: string }
+
+function toQueryParams<T extends object>(parameters: T): queryParams<T> {
   const params = Object.keys(parameters) as Array<keyof T>
 
-  const queryParams = params.reduce<U>((acc, key) => {
+  const queryParams = params.reduce<queryParams<T>>((acc, key) => {
     const value = parameters[key]
     if (value === undefined) {
       return acc
@@ -26,7 +26,7 @@ function stringifyQueryParams<T extends object, U extends object>(
       return { ...acc, [key]: value.toISOString() }
     }
     return { ...acc, [key]: value }
-  }, {} as U)
+  }, {} as queryParams<T>)
   return queryParams
 }
 
@@ -238,4 +238,4 @@ class HttpRequests {
   }
 }
 
-export { HttpRequests, stringifyQueryParams }
+export { HttpRequests, toQueryParams }

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -11,6 +11,25 @@ import {
 
 import { addTrailingSlash, addProtocolIfNotPresent } from './utils'
 
+function stringifyQueryParams<T extends object, U extends object>(
+  parameters: T
+): U {
+  const params = Object.keys(parameters) as Array<keyof T>
+
+  const queryParams = params.reduce<U>((acc, key) => {
+    const value = parameters[key]
+    if (value === undefined) {
+      return acc
+    } else if (Array.isArray(value)) {
+      return { ...acc, [key]: value.join(',') }
+    } else if (value instanceof Date) {
+      return { ...acc, [key]: value.toISOString() }
+    }
+    return { ...acc, [key]: value }
+  }, {} as U)
+  return queryParams
+}
+
 function constructHostURL(host: string): string {
   try {
     host = addProtocolIfNotPresent(host)
@@ -219,4 +238,4 @@ class HttpRequests {
   }
 }
 
-export { HttpRequests }
+export { HttpRequests, stringifyQueryParams }

--- a/src/task.ts
+++ b/src/task.ts
@@ -8,8 +8,25 @@ import {
   TaskObject,
   TasksResultsObject,
 } from './types'
-import { HttpRequests } from './http-requests'
-import { removeUndefinedFromObject, sleep } from './utils'
+import { HttpRequests, stringifyQueryParams } from './http-requests'
+import { sleep } from './utils'
+import { EnqueuedTask } from './enqueued-task'
+
+type TasksRequest = {
+  indexUid?: string
+  uid?: string
+  type?: string
+  status?: string
+  canceledBy?: string
+  beforeEnqueuedAt?: string
+  afterEnqueuedAt?: string
+  beforeStartedAt?: string
+  afterStartedAt?: string
+  beforeFinishedAt?: string
+  afterFinishedAt?: string
+  limit?: number
+  from?: number
+}
 
 class Task {
   indexUid: TaskObject['indexUid']
@@ -69,37 +86,10 @@ class TaskClient {
    */
   async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     const url = `tasks`
-    const {
-      beforeEnqueuedAt,
-      afterEnqueuedAt,
-      beforeStartedAt,
-      afterStartedAt,
-      beforeFinishedAt,
-      afterFinishedAt,
-      uid,
-      indexUid,
-      type,
-      status,
-    } = parameters
-
-    const queryParams = {
-      uid: uid?.join(','),
-      indexUid: indexUid?.join(','),
-      type: type?.join(','),
-      status: status?.join(','),
-      beforeEnqueuedAt: beforeEnqueuedAt && beforeEnqueuedAt.toISOString(),
-      afterEnqueuedAt: afterEnqueuedAt && afterEnqueuedAt.toISOString(),
-      beforeStartedAt: beforeStartedAt && beforeStartedAt.toISOString(),
-      afterStartedAt: afterStartedAt && afterStartedAt.toISOString(),
-      beforeFinishedAt: beforeFinishedAt && beforeFinishedAt.toISOString(),
-      afterFinishedAt: afterFinishedAt && afterFinishedAt.toISOString(),
-      from: parameters.from,
-      limit: parameters.limit,
-    }
 
     const tasks = await this.httpRequest.get<Promise<TasksResultsObject>>(
       url,
-      removeUndefinedFromObject(queryParams)
+      stringifyQueryParams<TasksQuery, TasksRequest>(parameters)
     )
 
     return {

--- a/src/task.ts
+++ b/src/task.ts
@@ -69,7 +69,12 @@ class TaskClient {
    */
   async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     const url = `tasks`
-    const { beforeEnqueuedAt, afterEnqueuedAt } = parameters
+    const {
+      beforeEnqueuedAt,
+      afterEnqueuedAt,
+      beforeStartedAt,
+      afterStartedAt,
+    } = parameters
 
     const queryParams = {
       indexUid: parameters?.indexUid?.join(','),
@@ -77,6 +82,8 @@ class TaskClient {
       status: parameters?.status?.join(','),
       beforeEnqueuedAt: beforeEnqueuedAt && beforeEnqueuedAt.toISOString(),
       afterEnqueuedAt: afterEnqueuedAt && afterEnqueuedAt.toISOString(),
+      beforeStartedAt: beforeStartedAt && beforeStartedAt.toISOString(),
+      afterStartedAt: afterStartedAt && afterStartedAt.toISOString(),
       // afterEnqueuedAt?: parameters?.,
       // beforeStartedAt?: parameters?.,
       // afterStartedAt?: parameters?.,

--- a/src/task.ts
+++ b/src/task.ts
@@ -74,6 +74,8 @@ class TaskClient {
       afterEnqueuedAt,
       beforeStartedAt,
       afterStartedAt,
+      beforeFinishedAt,
+      afterFinishedAt,
     } = parameters
 
     const queryParams = {
@@ -84,11 +86,8 @@ class TaskClient {
       afterEnqueuedAt: afterEnqueuedAt && afterEnqueuedAt.toISOString(),
       beforeStartedAt: beforeStartedAt && beforeStartedAt.toISOString(),
       afterStartedAt: afterStartedAt && afterStartedAt.toISOString(),
-      // afterEnqueuedAt?: parameters?.,
-      // beforeStartedAt?: parameters?.,
-      // afterStartedAt?: parameters?.,
-      // beforeFinishedAt?: parameters?.,
-      // afterFinishedAt?: parameters?.,
+      beforeFinishedAt: beforeFinishedAt && beforeFinishedAt.toISOString(),
+      afterFinishedAt: afterFinishedAt && afterFinishedAt.toISOString(),
       from: parameters.from,
       limit: parameters.limit,
     }

--- a/src/task.ts
+++ b/src/task.ts
@@ -10,7 +10,6 @@ import {
 } from './types'
 import { HttpRequests, toQueryParams } from './http-requests'
 import { sleep } from './utils'
-import { EnqueuedTask } from './enqueued-task'
 
 class Task {
   indexUid: TaskObject['indexUid']

--- a/src/task.ts
+++ b/src/task.ts
@@ -79,6 +79,7 @@ class TaskClient {
     } = parameters
 
     const queryParams = {
+      uid: parameters?.uid?.join(','),
       indexUid: parameters?.indexUid?.join(','),
       type: parameters?.type?.join(','),
       status: parameters?.status?.join(','),

--- a/src/task.ts
+++ b/src/task.ts
@@ -69,11 +69,19 @@ class TaskClient {
    */
   async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
     const url = `tasks`
+    const { beforeEnqueuedAt, afterEnqueuedAt } = parameters
 
     const queryParams = {
       indexUid: parameters?.indexUid?.join(','),
       type: parameters?.type?.join(','),
       status: parameters?.status?.join(','),
+      beforeEnqueuedAt: beforeEnqueuedAt && beforeEnqueuedAt.toISOString(),
+      afterEnqueuedAt: afterEnqueuedAt && afterEnqueuedAt.toISOString(),
+      // afterEnqueuedAt?: parameters?.,
+      // beforeStartedAt?: parameters?.,
+      // afterStartedAt?: parameters?.,
+      // beforeFinishedAt?: parameters?.,
+      // afterFinishedAt?: parameters?.,
       from: parameters.from,
       limit: parameters.limit,
     }

--- a/src/task.ts
+++ b/src/task.ts
@@ -8,25 +8,9 @@ import {
   TaskObject,
   TasksResultsObject,
 } from './types'
-import { HttpRequests, stringifyQueryParams } from './http-requests'
+import { HttpRequests, toQueryParams } from './http-requests'
 import { sleep } from './utils'
 import { EnqueuedTask } from './enqueued-task'
-
-type TasksRequest = {
-  indexUid?: string
-  uid?: string
-  type?: string
-  status?: string
-  canceledBy?: string
-  beforeEnqueuedAt?: string
-  afterEnqueuedAt?: string
-  beforeStartedAt?: string
-  afterStartedAt?: string
-  beforeFinishedAt?: string
-  afterFinishedAt?: string
-  limit?: number
-  from?: number
-}
 
 class Task {
   indexUid: TaskObject['indexUid']
@@ -89,7 +73,7 @@ class TaskClient {
 
     const tasks = await this.httpRequest.get<Promise<TasksResultsObject>>(
       url,
-      stringifyQueryParams<TasksQuery, TasksRequest>(parameters)
+      toQueryParams<TasksQuery>(parameters)
     )
 
     return {

--- a/src/task.ts
+++ b/src/task.ts
@@ -76,13 +76,17 @@ class TaskClient {
       afterStartedAt,
       beforeFinishedAt,
       afterFinishedAt,
+      uid,
+      indexUid,
+      type,
+      status,
     } = parameters
 
     const queryParams = {
-      uid: parameters?.uid?.join(','),
-      indexUid: parameters?.indexUid?.join(','),
-      type: parameters?.type?.join(','),
-      status: parameters?.status?.join(','),
+      uid: uid?.join(','),
+      indexUid: indexUid?.join(','),
+      type: type?.join(','),
+      status: status?.join(','),
       beforeEnqueuedAt: beforeEnqueuedAt && beforeEnqueuedAt.toISOString(),
       afterEnqueuedAt: afterEnqueuedAt && afterEnqueuedAt.toISOString(),
       beforeStartedAt: beforeStartedAt && beforeStartedAt.toISOString(),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -520,6 +520,15 @@ export const enum ErrorStatusCode {
 
   /** @see https://docs.meilisearch.com/errors/#dump_not_found */
   DUMP_NOT_FOUND = 'dump_not_found',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_task_uid */
+  INVALID_TASK_UID = 'invalid_task_uid',
+
+  /** @see https://docs.meilisearch.com/errors/#invalid_task_date */
+  INVALID_TASK_DATE = 'invalid_task_date',
+
+  /** @see https://docs.meilisearch.com/errors/#missing_task_filters */
+  MISSING_TASK_FILTERS = 'missing_task_filters',
 }
 
 export type TokenIndexRules = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,8 +235,15 @@ export const enum TaskTypes {
 
 export type TasksQuery = {
   indexUid?: string[]
+  uid?: number[]
   type?: TaskTypes[]
   status?: TaskStatus[]
+  beforeEnqueuedAt?: Date
+  afterEnqueuedAt?: Date
+  beforeStartedAt?: Date
+  afterStartedAt?: Date
+  beforeFinishedAt?: Date
+  afterFinishedAt?: Date
   limit?: number
   from?: number
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -235,15 +235,8 @@ export const enum TaskTypes {
 
 export type TasksQuery = {
   indexUid?: string[]
-  uid?: number[]
   type?: TaskTypes[]
   status?: TaskStatus[]
-  beforeEnqueuedAt?: Date
-  afterEnqueuedAt?: Date
-  beforeStartedAt?: Date
-  afterStartedAt?: Date
-  beforeFinishedAt?: Date
-  afterFinishedAt?: Date
   limit?: number
   from?: number
 }

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -91,11 +91,12 @@ describe.each([
 
   test(`${permission} key: Basic search`, async () => {
     const client = await getClient(permission)
+
     const response = await client.index(index.uid).searchGet('prince', {})
+
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
     expect(response.hits.length).toEqual(2)
@@ -129,27 +130,13 @@ describe.each([
     const response = await client.index(index.uid).searchGet('prince', {
       attributesToRetrieve: ['*'],
     })
-    expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(2)
-  })
+    const hit = response.hits[0]
 
-  test(`${permission} key: search with array options`, async () => {
-    const client = await getClient(permission)
-    const response = await client.index(index.uid).searchGet('prince', {
-      attributesToRetrieve: ['*'],
-    })
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(2)
+    expect(Object.keys(hit).join(',')).toEqual(
+      Object.keys(dataset[1]).join(',')
+    )
   })
 
   test(`${permission} key: search with options`, async () => {
@@ -195,12 +182,6 @@ describe.each([
       showMatchesPosition: true,
     })
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response).toHaveProperty('query', 'prince')
-    expect(response.hits.length).toEqual(1)
     expect(response.hits[0]).toHaveProperty('_matchesPosition', {
       comment: [{ start: 22, length: 6 }],
       title: [{ start: 9, length: 6 }],
@@ -415,7 +396,7 @@ describe.each([
       genre: { fantasy: 2 },
     })
     expect(response.hits.length).toEqual(2)
-    expect(response.totalHits).toEqual(2)
+    expect(response.estimatedTotalHits).toEqual(2)
   })
 
   test(`${permission} key: search with multiple filter and empty string query (placeholder)`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -634,7 +634,7 @@ describe.each([
     const response = await client.index(index.uid).search('', {
       hitsPerPage: 1,
       page: 1,
-      limit: 1,
+      offset: 1,
     })
 
     expect(response.hits.length).toEqual(1)

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -151,16 +151,14 @@ describe.each([
     expect(response.hits.length).toEqual(2)
   })
 
-  // TODO: remove skip when bug is fixed by core
-  test.skip(`${permission} key: Basic phrase search`, async () => {
+  test(`${permission} key: Basic phrase search`, async () => {
     const client = await getClient(permission)
     const response = await client
       .index(index.uid)
       .search('"french book" about', {})
     expect(response).toHaveProperty('hits', expect.any(Array))
-    expect(response).toHaveProperty('hitsPerPage', 20)
-    expect(response).toHaveProperty('page', 1)
-    expect(response).toHaveProperty('totalPages', 1)
+    expect(response).toHaveProperty('limit', 20)
+    expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', '"french book" about')
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -545,6 +545,20 @@ describe.each([
     expect(response.totalHits).toEqual(7)
   })
 
+  test(`${permission} key: search with pagination parameters: hitsPerPage at 0`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('', {
+      hitsPerPage: 0,
+    })
+
+    expect(response.hits.length).toEqual(0)
+    expect(response.hitsPerPage).toEqual(0)
+    expect(response.page).toEqual(1)
+    expect(response.totalPages).toEqual(0)
+    expect(response.totalHits).toEqual(7)
+  })
+
   test(`${permission} key: search with pagination parameters: hitsPerPage at 1 and page at 0`, async () => {
     const client = await getClient(permission)
 
@@ -557,6 +571,20 @@ describe.each([
     expect(response.hitsPerPage).toEqual(1)
     expect(response.page).toEqual(0)
     expect(response.totalPages).toEqual(7)
+    expect(response.totalHits).toEqual(7)
+  })
+
+  test(`${permission} key: search with pagination parameters: page at 0`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('', {
+      page: 0,
+    })
+
+    expect(response.hits.length).toEqual(0)
+    expect(response.hitsPerPage).toEqual(20)
+    expect(response.page).toEqual(0)
+    expect(response.totalPages).toEqual(1)
     expect(response.totalHits).toEqual(7)
   })
 

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -83,6 +83,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(task.uid).toEqual(enqueuedTask.taskUid)
     })
 
+    // get tasks
     test(`${permission} key: Get all tasks`, async () => {
       const client = await getClient(permission)
       const enqueuedTask = await client
@@ -96,6 +97,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasks.results[0].uid).toEqual(enqueuedTask.taskUid)
     })
 
+    // get tasks: type
     test(`${permission} key: Get all tasks with type filter`, async () => {
       const client = await getClient(permission)
       await client.index(index.uid).addDocuments([{ id: 1 }])
@@ -115,6 +117,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(onlyDocumentAddition.size).toEqual(2)
     })
 
+    // get tasks: type
     test(`${permission} key: Get all tasks with type filter on an index`, async () => {
       const client = await getClient(permission)
       await client.deleteIndex(index2.uid)
@@ -136,6 +139,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(onlyDocumentAddition.size).toEqual(2)
     })
 
+    // get tasks: pagination
     test(`${permission} key: Get all tasks with pagination`, async () => {
       const client = await getClient(permission)
       const task1 = await client.index(index.uid).addDocuments([{ id: 1 }])
@@ -151,6 +155,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasks.next).toEqual(0)
     })
 
+    // get tasks: status
     test(`${permission} key: Get all tasks with status filter`, async () => {
       const client = await getClient(permission)
       const task1 = await client.index(index.uid).addDocuments([{ id: 1 }])
@@ -168,6 +173,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(onlySuccesfullTasks.size).toEqual(2)
     })
 
+    // get tasks: status
     test(`${permission} key: Get all tasks with status filter on an index`, async () => {
       const client = await getClient(permission)
       const task1 = await client.index(index.uid).addDocuments([{ id: 1 }])
@@ -191,6 +197,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(onlyTaskWithSameUid.size).toEqual(1)
     })
 
+    // get tasks: indexUid
     test(`${permission} key: Get all tasks with indexUid filter`, async () => {
       const client = await getClient(permission)
       await client.index(index.uid).addDocuments([{ id: 1 }])
@@ -207,7 +214,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(onlyTaskWithSameUid.size).toEqual(2)
     })
 
-    // uid
+    // get tasks: uid
     test(`${permission} key: Get all tasks with uid filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client
@@ -221,7 +228,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasks.results[0].uid).toEqual(taskUid)
     })
 
-    // beforeEnqueuedAt
+    // get tasks: beforeEnqueuedAt
     test(`${permission} key: Get all tasks with beforeEnqueuedAt filter`, async () => {
       const client = await getClient(permission)
       const currentTimeStamp = Date.now()
@@ -240,7 +247,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasksUids.includes(taskUid)).toBeFalsy()
     })
 
-    // afterEnqueuedAt
+    // get tasks: afterEnqueuedAt
     test(`${permission} key: Get all tasks with afterEnqueuedAt filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client
@@ -259,7 +266,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasksUids.includes(taskUid)).toBeFalsy()
     })
 
-    // beforeStartedAt
+    // get tasks: beforeStartedAt
     test(`${permission} key: Get all tasks with beforeStartedAt filter`, async () => {
       const client = await getClient(permission)
       const currentTimeStamp = Date.now()
@@ -279,7 +286,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasksUids.includes(taskUid)).toBeFalsy()
     })
 
-    // afterStartedAt
+    // get tasks: afterStartedAt
     test(`${permission} key: Get all tasks with afterStartedAt filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client
@@ -299,7 +306,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasksUids.includes(taskUid)).toBeFalsy()
     })
 
-    // beforeFinishedAt
+    // get tasks: beforeFinishedAt
     test(`${permission} key: Get all tasks with beforeFinishedAt filter`, async () => {
       const client = await getClient(permission)
       const currentTimeStamp = Date.now()
@@ -319,7 +326,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(tasksUids.includes(taskUid)).toBeFalsy()
     })
 
-    // afterFinishedAt
+    // get tasks: afterFinishedAt
     test(`${permission} key: Get all tasks with afterFinishedAt filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -225,7 +225,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // beforeEnqueuedAt
-    test.only(`${permission} key: Get all tasks with beforeEnqueuedAt filter`, async () => {
+    test(`${permission} key: Get all tasks with beforeEnqueuedAt filter`, async () => {
       const client = await getClient(permission)
       const currentTimeStamp = Date.now()
       const currentTime = new Date(currentTimeStamp)
@@ -244,7 +244,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // afterEnqueuedAt
-    test.only(`${permission} key: Get all tasks with afterEnqueuedAt filter`, async () => {
+    test(`${permission} key: Get all tasks with afterEnqueuedAt filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client
         .index(index.uid)
@@ -263,7 +263,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // beforeStartedAt
-    test.only(`${permission} key: Get all tasks with beforeStartedAt filter`, async () => {
+    test(`${permission} key: Get all tasks with beforeStartedAt filter`, async () => {
       const client = await getClient(permission)
       const currentTimeStamp = Date.now()
       const currentTime = new Date(currentTimeStamp)
@@ -272,7 +272,6 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const { taskUid } = await client
         .index(index.uid)
         .addDocuments([{ id: 1 }])
-
       await client.index(index.uid).waitForTask(taskUid) // ensures the tasks has a `startedAt` value
 
       const tasks = await client.getTasks({
@@ -284,7 +283,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // afterStartedAt
-    test.only(`${permission} key: Get all tasks with afterStartedAt filter`, async () => {
+    test(`${permission} key: Get all tasks with afterStartedAt filter`, async () => {
       const client = await getClient(permission)
       const { taskUid } = await client
         .index(index.uid)
@@ -297,6 +296,46 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const tasks = await client.getTasks({
         afterStartedAt: currentTime,
+      })
+      const tasksUids = tasks.results.map((t) => t.uid)
+
+      expect(tasksUids.includes(taskUid)).toBeFalsy()
+    })
+
+    // beforeFinishedAt
+    test(`${permission} key: Get all tasks with beforeFinishedAt filter`, async () => {
+      const client = await getClient(permission)
+      const currentTimeStamp = Date.now()
+      const currentTime = new Date(currentTimeStamp)
+      await sleep(1) // in ms
+
+      const { taskUid } = await client
+        .index(index.uid)
+        .addDocuments([{ id: 1 }])
+      await client.index(index.uid).waitForTask(taskUid) // ensures the tasks has a `finishedAt` value
+
+      const tasks = await client.getTasks({
+        beforeFinishedAt: currentTime,
+      })
+      const tasksUids = tasks.results.map((t) => t.uid)
+
+      expect(tasksUids.includes(taskUid)).toBeFalsy()
+    })
+
+    // afterFinishedAt
+    test(`${permission} key: Get all tasks with afterFinishedAt filter`, async () => {
+      const client = await getClient(permission)
+      const { taskUid } = await client
+        .index(index.uid)
+        .addDocuments([{ id: 1 }])
+      await client.index(index.uid).waitForTask(taskUid) // ensures the tasks has a `finishedAt` value
+      await sleep(1) // in ms
+
+      const currentTimeStamp = Date.now()
+      const currentTime = new Date(currentTimeStamp)
+
+      const tasks = await client.getTasks({
+        afterFinishedAt: currentTime,
       })
       const tasksUids = tasks.results.map((t) => t.uid)
 

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -208,20 +208,17 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // uid
-    test(`${permission} key: Get all tasks with indexUid filter`, async () => {
+    test(`${permission} key: Get all tasks with uid filter`, async () => {
       const client = await getClient(permission)
-      await client.index(index.uid).addDocuments([{ id: 1 }])
-      await client.index(index2.uid).addDocuments([{ id: 1 }])
-      await client.index(index3.uid).addDocuments([{ id: 1 }])
+      const { taskUid } = await client
+        .index(index.uid)
+        .addDocuments([{ id: 1 }])
 
       const tasks = await client.getTasks({
-        indexUid: [index.uid, index2.uid],
+        uid: [taskUid],
       })
-      const onlyTaskWithSameUid = new Set(
-        tasks.results.map((task) => task.indexUid)
-      )
 
-      expect(onlyTaskWithSameUid.size).toEqual(2)
+      expect(tasks.results[0].uid).toEqual(taskUid)
     })
 
     // beforeEnqueuedAt

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -246,7 +246,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const { taskUid } = await client
         .index(index.uid)
         .addDocuments([{ id: 1 }])
-      await sleep(1) // in ms
+      await sleep(2) // in ms
 
       const currentTimeStamp = Date.now()
       const currentTime = new Date(currentTimeStamp)

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -110,9 +110,8 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index<Movie>(index.uid).search('prince', {})
     expect(response.hits.length === 2).toBeTruthy()
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 2).toBeTruthy()
+    expect(response.limit === 20).toBeTruthy()
+    expect(response.offset === 0).toBeTruthy()
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response.query === 'prince').toBeTruthy()
   })
@@ -168,11 +167,6 @@ describe.each([
       showMatchesPosition: true,
     })
     expect(response.hits.length === 1).toBeTruthy()
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 1).toBeTruthy()
-    expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
-    expect(response.query === 'prince').toBeTruthy()
     expect(response.hits[0]?._matchesPosition?.comment).toEqual([
       { start: 22, length: 6 },
     ])
@@ -355,9 +349,7 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index(emptyIndex.uid).search('prince', {})
 
-    expect(response.page === 1).toBeTruthy()
-    expect(response.hitsPerPage === 20).toBeTruthy()
-    expect(response.totalHits === 0).toBeTruthy()
+    expect(response.hits.length === 0).toBeTruthy()
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response.query === 'prince').toBeTruthy()
   })
@@ -372,9 +364,10 @@ describe.each([
     })
 
     expect(response.hits.length).toEqual(1)
-    expect(response.limit === 1).toBeTruthy()
-    expect(response.offset === 0).toBeTruthy()
-    expect(response.estimatedTotalHits).toEqual(7)
+    expect(response.hitsPerPage === 1).toBeTruthy()
+    expect(response.page === 1).toBeTruthy()
+    expect(response.totalPages === 7).toBeTruthy()
+    expect(response.totalHits === 7).toBeTruthy()
   })
 
   test(`${permission} key: Try to Search on deleted index and fail`, async () => {


### PR DESCRIPTION
Add new filters on the `get /tasks` route.

Present in this [spec](https://github.com/meilisearch/specifications/pull/195)

TODO: 
V0.30.0rc1
- TasksQuery: 
   - [ ] `indexUid` renamed to `indexUids`
   - [ ] `type` renamed to  `types`
   - [ ] `status` renamed to `statuses`
   - [ ] `uid` renamed to `uids`
- Errors: 
  - [ ] `invalid_task_type` renamed to `invalid_task_types_filter`
  - [ ] `invalid_task_status` renamed to `invalid_task_statuses`

V0.30.0rc0
in TasksQuery:
  - [x] Add `uid`
  - [x] Add `beforeEnqueuedAt`
  - [x] Add `afterEnqueuedAt`
  - [x] Add `beforeStartedAt`
  - [x] Add `afterStatedAt`
  - [x] Add `beforeFinishedAt`
  - [x] Add `afterFinishedAt`
in `errors`:
  - [x] Add `invalid_task_uid`
  - [x] Add `invalid_task_date`
  - [x] Add `missing_task_filters`

Tests:
  - [x] `uid`
  - [x] `beforeEnqueuedAt`
  - [x] `afterEnqueuedAt`
  - [x] `beforeStartedAt`
  - [x] `afterStatedAt`
  - [x] `beforeFinishedAt`
  - [x] `afterFinishedAt`
  - [x] `invalid_task_uid`
  - [x] `invalid_task_date`
  - [x] `missing_task_filter`

