### PR TITLE
Export Task and EnqueuedTask

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export * from './types'
 export * from './errors'
 export * from './indexes'
+export * from './enqueued-task'
+export * from './task'
 import { MeiliSearch } from './clients/node-client'
 
 export { MeiliSearch }


### PR DESCRIPTION
As per #1343 Task and EnqueuedTask became classes but are not exported publically.  See issue #1373 

In this PR, the new classes Task and EnqueuedTask are exported and importable by users of the package