### PR TITLE
Add snapshot_creation task type for v0.30.0

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -231,6 +231,7 @@ export const enum TaskTypes {
   DOCUMENTS_ADDITION_OR_UPDATE = 'documentAdditionOrUpdate',
   DOCUMENT_DELETION = 'documentDeletion',
   SETTINGS_UPDATE = 'settingsUpdate',
+  SNAPSHOT_CREATION = 'snapshotCreation',
 }
 
 export type TasksQuery = {


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2953

- [ ] Add `snapshot_creation` task type
