### PR TITLE
Remove batch uid for v0.30.0

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -16,7 +16,6 @@ class Task {
   status: TaskObject['status']
   type: TaskObject['type']
   uid: TaskObject['uid']
-  batchUid: TaskObject['batchUid']
   details: TaskObject['details']
   error: TaskObject['error']
   duration: TaskObject['duration']
@@ -29,7 +28,6 @@ class Task {
     this.status = task.status
     this.type = task.type
     this.uid = task.uid
-    this.batchUid = task.batchUid
     this.details = task.details
     this.error = task.error
     this.duration = task.duration

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -252,7 +252,6 @@ export type EnqueuedTaskObject = {
 
 export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
   uid: number
-  batchUid: number
   details: {
     // Number of documents sent
     receivedDocuments?: number


### PR DESCRIPTION
### Remove `batchUid` from `Task` type (from 0.29)

- issue: https://github.com/meilisearch/meilisearch/issues/2582
- spec: https://github.com/meilisearch/specifications/pull/162

- [x] removed mention of batchUid