### PR TITLE
Rename some task filter to their plural form for v0.30.0

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -50,9 +50,9 @@ get_all_tasks_1: |-
 get_task_1: |-
   client.getTask(1)
 get_all_tasks_filtering_1: |-
-  client.getTasks({ indexUid: ['movies'] })
+  client.getTasks({ indexUids: ['movies'] })
 get_all_tasks_filtering_2: |-
-  client.getTasks({ status: ['succeeded', 'failed'], type: ['documentAdditionOrUpdate'] })
+  client.getTasks({ statuses: ['succeeded', 'failed'], types: ['documentAdditionOrUpdate'] })
 get_all_tasks_paginating_1: |-
   client.getTasks({ limit: 2, from: 10 })
 get_all_tasks_paginating_2: |-

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -244,7 +244,7 @@ class Index<T = Record<string, any>> {
    * @returns {Promise<TasksResults>} - Promise containing all tasks
    */
   async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
-    return await this.tasks.getTasks({ ...parameters, indexUid: [this.uid] })
+    return await this.tasks.getTasks({ ...parameters, indexUids: [this.uid] })
   }
 
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -238,10 +238,10 @@ export const enum TaskTypes {
 }
 
 export type TasksQuery = {
-  indexUid?: string[]
-  uid?: number[]
-  type?: TaskTypes[]
-  status?: TaskStatus[]
+  indexUids?: string[]
+  uids?: number[]
+  types?: TaskTypes[]
+  statuses?: TaskStatus[]
   canceledBy?: number[]
   beforeEnqueuedAt?: Date
   afterEnqueuedAt?: Date
@@ -319,7 +319,7 @@ export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
     deletedTasks?: number
 
     // Query parameters used to filter the tasks
-    originalQuery?: string
+    originalFilters?: string
   }
   error: MeiliSearchErrorInfo | null
   duration: string

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -106,7 +106,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       await client.createIndex(index2.uid)
 
       const tasks = await client.getTasks({
-        type: [
+        types: [
           TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE,
           TaskTypes.DOCUMENT_DELETION,
         ],
@@ -128,7 +128,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       await client.index(index2.uid).deleteDocument(1)
 
       const tasks = await client.index(index.uid).getTasks({
-        type: [
+        types: [
           TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE,
           TaskTypes.DOCUMENT_DELETION,
         ],
@@ -165,7 +165,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       await client.waitForTask(task2.taskUid)
 
       const tasks = await client.getTasks({
-        status: [TaskStatus.TASK_SUCCEEDED, TaskStatus.TASK_FAILED],
+        statuses: [TaskStatus.TASK_SUCCEEDED, TaskStatus.TASK_FAILED],
       })
       const onlySuccesfullTasks = new Set(
         tasks.results.map((task) => task.status)
@@ -185,7 +185,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       await client.waitForTask(task3.taskUid)
 
       const tasks = await client.index(index.uid).getTasks({
-        status: [TaskStatus.TASK_SUCCEEDED, TaskStatus.TASK_FAILED],
+        statuses: [TaskStatus.TASK_SUCCEEDED, TaskStatus.TASK_FAILED],
       })
       const onlySuccesfullTasks = new Set(
         tasks.results.map((task) => task.status)
@@ -206,7 +206,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       await client.index(index3.uid).addDocuments([{ id: 1 }])
 
       const tasks = await client.getTasks({
-        indexUid: [index.uid, index2.uid],
+        indexUids: [index.uid, index2.uid],
       })
       const onlyTaskWithSameUid = new Set(
         tasks.results.map((task) => task.indexUid)
@@ -223,7 +223,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         .addDocuments([{ id: 1 }])
 
       const tasks = await client.getTasks({
-        uid: [taskUid],
+        uids: [taskUid],
       })
 
       expect(tasks.results[0].uid).toEqual(taskUid)
@@ -348,13 +348,13 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
     })
 
     // get tasks: canceledBy
-    test.skip(`${permission} key: Get all tasks with canceledBy filter`, async () => {
+    test(`${permission} key: Get all tasks with canceledBy filter`, async () => {
       const client = await getClient(permission)
       const addDocumentsTask = await client
         .index(index.uid)
         .addDocuments([{ id: 1 }])
       const enqueuedCancelationTask = await client.cancelTasks({
-        uid: [addDocumentsTask.taskUid],
+        uids: [addDocumentsTask.taskUid],
       })
       const cancelationTask = await client.waitForTask(
         enqueuedCancelationTask.taskUid
@@ -376,12 +376,12 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         .addDocuments([{ id: 1 }])
 
       const enqueuedTask = await client.cancelTasks({
-        uid: [addDocuments.taskUid],
+        uids: [addDocuments.taskUid],
       })
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('uid=')
+      expect(task.details?.originalFilters).toContain('uids=')
       expect(task.details?.matchedTasks).toBeDefined()
       expect(task.details?.canceledTasks).toBeDefined()
     })
@@ -391,12 +391,12 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const client = await getClient(permission)
 
       const enqueuedTask = await client.cancelTasks({
-        indexUid: [index.uid],
+        indexUids: [index.uid],
       })
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toEqual('indexUid=movies_test')
+      expect(task.details?.originalFilters).toEqual('indexUids=movies_test')
     })
 
     // cancel: type
@@ -404,7 +404,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const client = await getClient(permission)
 
       const enqueuedTask = await client.cancelTasks({
-        type: [
+        types: [
           TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE,
           TaskTypes.DOCUMENT_DELETION,
         ],
@@ -412,8 +412,8 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toEqual(
-        'type=documentAdditionOrUpdate%2CdocumentDeletion'
+      expect(task.details?.originalFilters).toEqual(
+        'types=documentAdditionOrUpdate%2CdocumentDeletion'
       )
     })
 
@@ -422,13 +422,13 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const client = await getClient(permission)
 
       const enqueuedTask = await client.cancelTasks({
-        status: [TaskStatus.TASK_ENQUEUED, TaskStatus.TASK_PROCESSING],
+        statuses: [TaskStatus.TASK_ENQUEUED, TaskStatus.TASK_PROCESSING],
       })
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toEqual(
-        'status=enqueued%2Cprocessing'
+      expect(task.details?.originalFilters).toEqual(
+        'statuses=enqueued%2Cprocessing'
       )
     })
 
@@ -444,7 +444,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('beforeEnqueuedAt')
+      expect(task.details?.originalFilters).toContain('beforeEnqueuedAt')
     })
 
     // cancel: afterEnqueuedAt
@@ -459,7 +459,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('afterEnqueuedAt')
+      expect(task.details?.originalFilters).toContain('afterEnqueuedAt')
     })
 
     // cancel: beforeStartedAt
@@ -474,7 +474,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('beforeStartedAt')
+      expect(task.details?.originalFilters).toContain('beforeStartedAt')
     })
 
     // cancel: afterStartedAt
@@ -489,7 +489,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('afterStartedAt')
+      expect(task.details?.originalFilters).toContain('afterStartedAt')
     })
 
     // cancel: beforeFinishedAt
@@ -504,7 +504,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('beforeFinishedAt')
+      expect(task.details?.originalFilters).toContain('beforeFinishedAt')
     })
 
     // cancel: afterFinishedAt
@@ -519,7 +519,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_CANCELATION)
-      expect(task.details?.originalQuery).toContain('afterFinishedAt')
+      expect(task.details?.originalFilters).toContain('afterFinishedAt')
     })
 
     // delete: uid
@@ -530,7 +530,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         .addDocuments([{ id: 1 }])
 
       const deleteTask = await client.deleteTasks({
-        uid: [addDocuments.taskUid],
+        uids: [addDocuments.taskUid],
       })
       const task = await client.waitForTask(deleteTask.taskUid)
 
@@ -550,7 +550,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         .addDocuments([{ id: 1 }])
 
       const enqueuedTask = await client.deleteTasks({
-        indexUid: [index.uid],
+        indexUids: [index.uid],
       })
       const deleteTask = await client.waitForTask(enqueuedTask.taskUid)
 
@@ -566,7 +566,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const client = await getClient(permission)
 
       const enqueuedTask = await client.deleteTasks({
-        type: [
+        types: [
           TaskTypes.DOCUMENTS_ADDITION_OR_UPDATE,
           TaskTypes.DOCUMENT_DELETION,
         ],
@@ -574,8 +574,8 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const deleteTask = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(deleteTask.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(deleteTask.details?.originalQuery).toEqual(
-        'type=documentAdditionOrUpdate%2CdocumentDeletion'
+      expect(deleteTask.details?.originalFilters).toEqual(
+        'types=documentAdditionOrUpdate%2CdocumentDeletion'
       )
     })
 
@@ -584,13 +584,13 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const client = await getClient(permission)
 
       const enqueuedTask = await client.deleteTasks({
-        status: [TaskStatus.TASK_ENQUEUED, TaskStatus.TASK_PROCESSING],
+        statuses: [TaskStatus.TASK_ENQUEUED, TaskStatus.TASK_PROCESSING],
       })
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toEqual(
-        'status=enqueued%2Cprocessing'
+      expect(task.details?.originalFilters).toEqual(
+        'statuses=enqueued%2Cprocessing'
       )
     })
 
@@ -606,7 +606,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('beforeEnqueuedAt')
+      expect(task.details?.originalFilters).toContain('beforeEnqueuedAt')
     })
 
     // delete: afterEnqueuedAt
@@ -621,7 +621,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('afterEnqueuedAt')
+      expect(task.details?.originalFilters).toContain('afterEnqueuedAt')
     })
 
     // delete: beforeStartedAt
@@ -636,7 +636,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('beforeStartedAt')
+      expect(task.details?.originalFilters).toContain('beforeStartedAt')
     })
 
     // delete: afterStartedAt
@@ -651,7 +651,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('afterStartedAt')
+      expect(task.details?.originalFilters).toContain('afterStartedAt')
     })
 
     // delete: beforeFinishedAt
@@ -666,7 +666,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('beforeFinishedAt')
+      expect(task.details?.originalFilters).toContain('beforeFinishedAt')
     })
 
     // delete: afterFinishedAt
@@ -681,7 +681,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const task = await client.waitForTask(enqueuedTask.taskUid)
 
       expect(task.type).toEqual(TaskTypes.TASK_DELETION)
-      expect(task.details?.originalQuery).toContain('afterFinishedAt')
+      expect(task.details?.originalFilters).toContain('afterFinishedAt')
     })
 
     test(`${permission} key: Get all indexes tasks with index instance`, async () => {
@@ -756,7 +756,7 @@ describe.each([
   })
 
   test(`Test on getTasks route`, async () => {
-    const route = `tasks?indexUid=movies_test`
+    const route = `tasks?indexUids=movies_test`
     const client = new MeiliSearch({ host })
     const strippedHost = trailing ? host.slice(0, -1) : host
 

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -365,7 +365,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       })
       const tasksUids = tasks.results.map((t) => t.uid)
 
-      expect(tasksUids.includes(addDocumentsTask.taskUid)).toBeTruthy()
+      expect(tasksUids[0]).toEqual(addDocumentsTask.taskUid)
     })
 
     // cancel: uid

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -353,9 +353,12 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const addDocumentsTask = await client
         .index(index.uid)
         .addDocuments([{ id: 1 }])
+
+      // Cancel the task
       const enqueuedCancelationTask = await client.cancelTasks({
         uids: [addDocumentsTask.taskUid],
       })
+      // wait for the task to be fully canceled
       const cancelationTask = await client.waitForTask(
         enqueuedCancelationTask.taskUid
       )


### PR DESCRIPTION
V0.30.0rc1
- TasksQuery: 
   - [x] `indexUid` renamed to `indexUids`
   - [x] `type` renamed to  `types`
   - [x] `status` renamed to `statuses`
   - [x] `uid` renamed to `uids`
- Task details:
  - [x] rename `originalQuery` detail to `OriginalFilters`
