### PR TITLE
attributes: constrain type to the keys of the record type in the index

### DIFF
--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -37,7 +37,7 @@ import { EnqueuedTask } from '../enqueued-task'
 class Client {
   config: Config
   httpRequest: HttpRequests
-  tasks: TaskClient
+  tasks: TaskClient<any>
 
   /**
    * Creates new MeiliSearch instance
@@ -194,9 +194,9 @@ class Client {
    * @method getTasks
    * @param {TasksQuery} [parameters={}] - Parameters to browse the tasks
    *
-   * @returns {Promise<TasksResults>} - Promise returning all tasks
+   * @returns {Promise<TasksResults<any>>} - Promise returning all tasks
    */
-  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
+  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults<any>> {
     return await this.tasks.getTasks(parameters)
   }
 
@@ -205,9 +205,9 @@ class Client {
    * @memberof MeiliSearch
    * @method getTask
    * @param {number} taskUid - Task identifier
-   * @returns {Promise<Task>} - Promise returning a task
+   * @returns {Promise<Task<any>>} - Promise returning a task
    */
-  async getTask(taskUid: number): Promise<Task> {
+  async getTask(taskUid: number): Promise<Task<any>> {
     return await this.tasks.getTask(taskUid)
   }
 
@@ -219,12 +219,12 @@ class Client {
    * @param {number[]} taskUids - Tasks identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Task[]>} - Promise returning an array of tasks
+   * @returns {Promise<Task<any>[]>} - Promise returning an array of tasks
    */
   async waitForTasks(
     taskUids: number[],
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Task[]> {
+  ): Promise<Task<any>[]> {
     return await this.tasks.waitForTasks(taskUids, {
       timeOutMs,
       intervalMs,
@@ -240,12 +240,12 @@ class Client {
    * @param {number} taskUid - Task identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Task>} - Promise returning an array of tasks
+   * @returns {Promise<Task<any>>} - Promise returning an array of tasks
    */
   async waitForTask(
     taskUid: number,
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Task> {
+  ): Promise<Task<any>> {
     return await this.tasks.waitForTask(taskUid, {
       timeOutMs,
       intervalMs,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -50,7 +50,7 @@ class Index<T = Record<string, any>> {
   createdAt: Date | undefined
   updatedAt: Date | undefined
   httpRequest: HttpRequests
-  tasks: TaskClient
+  tasks: TaskClient<T>
 
   /**
    * @param {Config} config Request configuration options
@@ -241,9 +241,9 @@ class Index<T = Record<string, any>> {
    * @method getTasks
    * @param {TasksQuery} [parameters={}] - Parameters to browse the tasks
    *
-   * @returns {Promise<TasksResults>} - Promise containing all tasks
+   * @returns {Promise<TasksResults<T>>} - Promise containing all tasks
    */
-  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults> {
+  async getTasks(parameters: TasksQuery = {}): Promise<TasksResults<T>> {
     return await this.tasks.getTasks({ ...parameters, indexUid: [this.uid] })
   }
 
@@ -254,9 +254,9 @@ class Index<T = Record<string, any>> {
    * @method getTask
    * @param {number} taskUid - Task identifier
    *
-   * @returns {Promise<Task>} - Promise containing a task
+   * @returns {Promise<Task<T>>} - Promise containing a task
    */
-  async getTask(taskUid: number): Promise<Task> {
+  async getTask(taskUid: number): Promise<Task<T>> {
     return await this.tasks.getTask(taskUid)
   }
 
@@ -268,12 +268,12 @@ class Index<T = Record<string, any>> {
    * @param {number[]} taskUids - Tasks identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Task[]>} - Promise containing an array of tasks
+   * @returns {Promise<Task<T>[]>} - Promise containing an array of tasks
    */
   async waitForTasks(
     taskUids: number[],
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Task[]> {
+  ): Promise<Task<T>[]> {
     return await this.tasks.waitForTasks(taskUids, {
       timeOutMs,
       intervalMs,
@@ -288,12 +288,12 @@ class Index<T = Record<string, any>> {
    * @param {number} taskUid - Task identifier
    * @param {WaitOptions} waitOptions - Options on timeout and interval
    *
-   * @returns {Promise<Task>} - Promise containing an array of tasks
+   * @returns {Promise<Task<T>>} - Promise containing an array of tasks
    */
   async waitForTask(
     taskUid: number,
     { timeOutMs = 5000, intervalMs = 50 }: WaitOptions = {}
-  ): Promise<Task> {
+  ): Promise<Task<T>> {
     return await this.tasks.waitForTask(taskUid, {
       timeOutMs,
       intervalMs,
@@ -520,11 +520,11 @@ class Index<T = Record<string, any>> {
    * Retrieve all settings
    * @memberof Index
    * @method getSettings
-   * @returns {Promise<Settings>} Promise containing Settings object
+   * @returns {Promise<Settings<T>>} Promise containing Settings object
    */
-  async getSettings(): Promise<Settings> {
+  async getSettings(): Promise<Settings<T>> {
     const url = `indexes/${this.uid}/settings`
-    return await this.httpRequest.get<Settings>(url)
+    return await this.httpRequest.get<Settings<T>>(url)
   }
 
   /**
@@ -532,10 +532,10 @@ class Index<T = Record<string, any>> {
    * Any parameters not provided will be left unchanged.
    * @memberof Index
    * @method updateSettings
-   * @param {Settings} settings Object containing parameters with their updated values
+   * @param {Settings<T>} settings Object containing parameters with their updated values
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
-  async updateSettings(settings: Settings): Promise<EnqueuedTask> {
+  async updateSettings(settings: Settings<T>): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings`
     const task = await this.httpRequest.patch(url, settings)
 
@@ -753,11 +753,11 @@ class Index<T = Record<string, any>> {
    * Update the distinct-attribute.
    * @memberof Index
    * @method updateDistinctAttribute
-   * @param {DistinctAttribute} distinctAttribute Field name of the distinct-attribute
+   * @param {DistinctAttribute<T>} distinctAttribute Field name of the distinct-attribute
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
   async updateDistinctAttribute(
-    distinctAttribute: DistinctAttribute
+    distinctAttribute: DistinctAttribute<T>
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/distinct-attribute`
     const task = await this.httpRequest.put(url, distinctAttribute)
@@ -799,11 +799,11 @@ class Index<T = Record<string, any>> {
    * Update the filterable-attributes.
    * @memberof Index
    * @method updateFilterableAttributes
-   * @param {FilterableAttributes} filterableAttributes Array of strings containing the attributes that can be used as filters at query time
+   * @param {FilterableAttributes<T>} filterableAttributes Array of strings containing the attributes that can be used as filters at query time
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
   async updateFilterableAttributes(
-    filterableAttributes: FilterableAttributes
+    filterableAttributes: FilterableAttributes<T>
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/filterable-attributes`
     const task = await this.httpRequest.put(url, filterableAttributes)
@@ -845,11 +845,11 @@ class Index<T = Record<string, any>> {
    * Update the sortable-attributes.
    * @memberof Index
    * @method updateSortableAttributes
-   * @param {SortableAttributes} sortableAttributes Array of strings containing the attributes that can be used to sort search results at query time
+   * @param {SortableAttributes<T>} sortableAttributes Array of strings containing the attributes that can be used to sort search results at query time
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
   async updateSortableAttributes(
-    sortableAttributes: SortableAttributes
+    sortableAttributes: SortableAttributes<T>
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/sortable-attributes`
     const task = await this.httpRequest.put(url, sortableAttributes)
@@ -891,11 +891,11 @@ class Index<T = Record<string, any>> {
    * Update the searchable-attributes.
    * @memberof Index
    * @method updateSearchableAttributes
-   * @param {SearchableAttributes} searchableAttributes Array of strings that contains searchable attributes sorted by order of importance(most to least important)
+   * @param {SearchableAttributes<T>} searchableAttributes Array of strings that contains searchable attributes sorted by order of importance(most to least important)
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
   async updateSearchableAttributes(
-    searchableAttributes: SearchableAttributes
+    searchableAttributes: SearchableAttributes<T>
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/searchable-attributes`
     const task = await this.httpRequest.put(url, searchableAttributes)
@@ -937,11 +937,11 @@ class Index<T = Record<string, any>> {
    * Update the displayed-attributes.
    * @memberof Index
    * @method updateDisplayedAttributes
-   * @param {DisplayedAttributes} displayedAttributes Array of strings that contains attributes of an index to display
+   * @param {DisplayedAttributes<T>} displayedAttributes Array of strings that contains attributes of an index to display
    * @returns {Promise<EnqueuedTask>} Promise containing an EnqueuedTask
    */
   async updateDisplayedAttributes(
-    displayedAttributes: DisplayedAttributes
+    displayedAttributes: DisplayedAttributes<T>
   ): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/displayed-attributes`
     const task = await this.httpRequest.put(url, displayedAttributes)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -166,11 +166,11 @@ export type DocumentsResults<T = Record<string, any>> = ResourceResults<
  ** Settings
  */
 
-export type FilterableAttributes = string[] | null
-export type DistinctAttribute = string | null
-export type SearchableAttributes = string[] | null
-export type SortableAttributes = string[] | null
-export type DisplayedAttributes = string[] | null
+export type FilterableAttributes<T = Record<string, any>> = (keyof T)[] | null
+export type DistinctAttribute<T = Record<string, any>> = keyof T | null
+export type SearchableAttributes<T = Record<string, any>> = (keyof T)[] | null
+export type SortableAttributes<T = Record<string, any>> = (keyof T)[] | null
+export type DisplayedAttributes<T = Record<string, any>> = (keyof T)[] | null
 export type RankingRules = string[] | null
 export type StopWords = string[] | null
 export type Synonyms = {
@@ -193,12 +193,12 @@ export type PaginationSettings = {
   maxTotalHits?: number | null
 }
 
-export type Settings = {
-  filterableAttributes?: FilterableAttributes
-  distinctAttribute?: DistinctAttribute
-  sortableAttributes?: SortableAttributes
-  searchableAttributes?: SearchableAttributes
-  displayedAttributes?: DisplayedAttributes
+export type Settings<T> = {
+  filterableAttributes?: FilterableAttributes<T>
+  distinctAttribute?: DistinctAttribute<T>
+  sortableAttributes?: SortableAttributes<T>
+  searchableAttributes?: SearchableAttributes<T>
+  displayedAttributes?: DisplayedAttributes<T>
   rankingRules?: RankingRules
   stopWords?: StopWords
   synonyms?: Synonyms
@@ -243,7 +243,7 @@ export type EnqueuedTaskObject = {
   enqueuedAt: string
 }
 
-export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
+export type TaskObject<T = Record<string, any>> = Omit<EnqueuedTaskObject, 'taskUid'> & {
   uid: number
   batchUid: number
   details: {
@@ -263,16 +263,16 @@ export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
     rankingRules: RankingRules
 
     // Searchable attributes on settings actions
-    searchableAttributes: SearchableAttributes
+    searchableAttributes: SearchableAttributes<T>
 
     // Displayed attributes on settings actions
-    displayedAttributes: DisplayedAttributes
+    displayedAttributes: DisplayedAttributes<T>
 
     // Filterable attributes on settings actions
-    filterableAttributes: FilterableAttributes
+    filterableAttributes: FilterableAttributes<T>
 
     // Sortable attributes on settings actions
-    sortableAttributes: SortableAttributes
+    sortableAttributes: SortableAttributes<T>
 
     // Stop words on settings actions
     stopWords: StopWords
@@ -281,7 +281,7 @@ export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
     synonyms: Synonyms
 
     // Distinct attribute on settings actions
-    distinctAttribute: DistinctAttribute
+    distinctAttribute: DistinctAttribute<T>
   }
   error?: MeiliSearchErrorInfo
   duration: string
@@ -296,8 +296,8 @@ type CursorResults<T> = {
   next: number
 }
 
-export type TasksResults = CursorResults<Task>
-export type TasksResultsObject = CursorResults<TaskObject>
+export type TasksResults<T = Record<string, any>> = CursorResults<Task<T>>
+export type TasksResultsObject<T = Record<string, any>> = CursorResults<TaskObject<T>>
 
 export type WaitOptions = {
   timeOutMs?: number


### PR DESCRIPTION
This PR adds type constraints so that `*Attributes` (e.g. `FilterableAttributes`, `SortableAttributes`, etc) will use the keys from the index record type instead of being an open `string[]`. This improves type safety / typos when making changes, and also improves the developer experience via intellisense:
![image](https://user-images.githubusercontent.com/4076797/201458232-09809893-1a34-4312-872c-3a753c2ce94e.png)

I scanned through the issue list and couldn't find this, but I thought it was small and straightforward enough to just raise a PR (and it doesn't affect runtime JS, only types, so it's fairly safe). If there are issues with this PR, I can open an issue ticket to discuss it further there instead :)