### PR TITLE
Make all the fields of details field of TaskObject optional

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -260,28 +260,28 @@ export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
     primaryKey?: string
 
     // Ranking rules on settings actions
-    rankingRules: RankingRules
+    rankingRules?: RankingRules
 
     // Searchable attributes on settings actions
-    searchableAttributes: SearchableAttributes
+    searchableAttributes?: SearchableAttributes
 
     // Displayed attributes on settings actions
-    displayedAttributes: DisplayedAttributes
+    displayedAttributes?: DisplayedAttributes
 
     // Filterable attributes on settings actions
-    filterableAttributes: FilterableAttributes
+    filterableAttributes?: FilterableAttributes
 
     // Sortable attributes on settings actions
-    sortableAttributes: SortableAttributes
+    sortableAttributes?: SortableAttributes
 
     // Stop words on settings actions
-    stopWords: StopWords
+    stopWords?: StopWords
 
     // Stop words on settings actions
-    synonyms: Synonyms
+    synonyms?: Synonyms
 
     // Distinct attribute on settings actions
-    distinctAttribute: DistinctAttribute
+    distinctAttribute?: DistinctAttribute
   }
   error?: MeiliSearchErrorInfo
   duration: string


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1381

## What does this PR do?
Make all the fields of details field of TaskObject optional

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
