### PR TITLE
Add setting detail providedIds for v0.30.0

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -277,7 +277,7 @@ export type TaskObject = Omit<EnqueuedTaskObject, 'taskUid'> & {
     deletedDocuments?: number
 
     // Number of documents found on a batch-delete
-    matchedDocuments?: number
+    providedIds?: number
 
     // Primary key on index creation
     primaryKey?: string

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -366,7 +366,7 @@ describe('Documents tests', () => {
         const returnedIds = documents.results.map((x) => x.id)
 
         expect(resolvedTask.details.deletedDocuments).toEqual(2)
-        expect(resolvedTask.details.matchedDocuments).toEqual(2)
+        expect(resolvedTask.details.providedIds).toEqual(2)
         expect(documents.results.length).toEqual(dataset.length - 2)
         expect(returnedIds).not.toContain(ids[0])
         expect(returnedIds).not.toContain(ids[1])


### PR DESCRIPTION
As per [this issue](https://github.com/meilisearch/meilisearch/pull/3081)

# Changes:

- `matched_documents` introduced here #1386 is renamed to `providedIds`