### PR TITLE
Update version for the next release (v0.30.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.29.0'
+export const PACKAGE_VERSION = '0.30.0'


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0rc1 :tada:
Check out the changelog of [Meilisearch v0.29.1](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0rc1) for more information on the changes.

## 🚀 Enhancements

- New `pagination` strategy with the search parameters`page` and `hitsPerPage` #1372 
- New filters on `getTasks`: `uid`, `beforeEnqueuedAt`, `afterEnqueuedAt`, ... see #1376
- New `client.cancelTasks` method that lets you cancel `enqueued` and `processing` tasks #1379 
- New `client.deleteTasks` method that lets you deleted tasks #1382 
- New `client.swapIndexes` method that lets you swap two indexes #1384 

## ⚠️ Breaking change

- Parameters on `getTasks` name changes: #1391
   - `status` -> `statuses`
   - `index_uid` -> `index_uids`
   - `type` -> `types`
- Task detail `receivedDocumentIds` renamed to `providedIds` #1386 
- Remove `batchUid` from `Task` class #1388
- Error field in `Task` is now always present and has a `null` value when there are no errors #1389 
- Add and rename some error codes: #1393