### PR TITLE
types: fix search default type of `search` and `searchGet`

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -44,7 +44,7 @@ import { HttpRequests } from './http-requests'
 import { Task, TaskClient } from './task'
 import { EnqueuedTask } from './enqueued-task'
 
-class Index<T = Record<string, any>> {
+class Index<D = Record<string, any>> {
   uid: string
   primaryKey: string | undefined
   createdAt: Date | undefined
@@ -78,7 +78,7 @@ class Index<T = Record<string, any>> {
    * @param {Partial<Request>} config? Additional request configuration options
    * @returns {Promise<SearchResponse<T>>} Promise containing the search response
    */
-  async search<T = Record<string, any>>(
+  async search<T = D>(
     query?: string | null,
     options?: SearchParams,
     config?: Partial<Request>
@@ -103,7 +103,7 @@ class Index<T = Record<string, any>> {
    * @param {Partial<Request>} config? Additional request configuration options
    * @returns {Promise<SearchResponse<T>>} Promise containing the search response
    */
-  async searchGet<T = Record<string, any>>(
+  async searchGet<T = D>(
     query?: string | null,
     options?: SearchParams,
     config?: Partial<Request>

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -44,7 +44,7 @@ import { HttpRequests } from './http-requests'
 import { Task, TaskClient } from './task'
 import { EnqueuedTask } from './enqueued-task'
 
-class Index<T = Record<string, any>> {
+class Index<T extends Record<string, any> = Record<string, any>> {
   uid: string
   primaryKey: string | undefined
   createdAt: Date | undefined
@@ -130,7 +130,7 @@ class Index<T = Record<string, any>> {
       attributesToHighlight: options?.attributesToHighlight?.join(','),
     }
 
-    return await this.httpRequest.get<SearchResponse<T>>(
+    return await this.httpRequest.get<SearchResponse<D>>(
       url,
       removeUndefinedFromObject(getParams),
       config

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -44,7 +44,7 @@ import { HttpRequests } from './http-requests'
 import { Task, TaskClient } from './task'
 import { EnqueuedTask } from './enqueued-task'
 
-class Index<D = Record<string, any>> {
+class Index<T = Record<string, any>> {
   uid: string
   primaryKey: string | undefined
   createdAt: Date | undefined
@@ -78,11 +78,11 @@ class Index<D = Record<string, any>> {
    * @param {Partial<Request>} config? Additional request configuration options
    * @returns {Promise<SearchResponse<T>>} Promise containing the search response
    */
-  async search<T = D>(
+  async search<D = T>(
     query?: string | null,
     options?: SearchParams,
     config?: Partial<Request>
-  ): Promise<SearchResponse<T>> {
+  ): Promise<SearchResponse<D>> {
     const url = `indexes/${this.uid}/search`
 
     return await this.httpRequest.post(
@@ -103,11 +103,11 @@ class Index<D = Record<string, any>> {
    * @param {Partial<Request>} config? Additional request configuration options
    * @returns {Promise<SearchResponse<T>>} Promise containing the search response
    */
-  async searchGet<T = D>(
+  async searchGet<D = T>(
     query?: string | null,
     options?: SearchParams,
     config?: Partial<Request>
-  ): Promise<SearchResponse<T>> {
+  ): Promise<SearchResponse<D>> {
     const url = `indexes/${this.uid}/search`
 
     const parseFilter = (filter?: Filter): string | undefined => {

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -15,10 +15,13 @@ const config = {
   apiKey: 'masterKey',
 }
 
-interface Movie {
+export interface Movie {
   id: number
   title: string
   genre?: string
+  comment?: string
+  isNull?: null
+  isTrue?: true
 }
 
 const client = new MeiliSearch(config)

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -15,7 +15,7 @@ const config = {
   apiKey: 'masterKey',
 }
 
-export interface Movie {
+interface Movie {
   id: number
   title: string
   genre?: string

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -10,7 +10,6 @@ import {
   datasetWithNests,
 } from './utils/meilisearch-test-utils'
 
-
 const index = {
   uid: 'movies_test',
 }

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -9,7 +9,7 @@ import {
   getClient,
   datasetWithNests,
 } from './utils/meilisearch-test-utils'
-import { Movie } from './env/typescript-node/src'
+
 
 const index = {
   uid: 'movies_test',
@@ -18,7 +18,7 @@ const emptyIndex = {
   uid: 'empty_test',
 }
 
-const dataset: Movie[] = [
+const dataset = [
   {
     id: 123,
     title: 'Pride and Prejudice',

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -9,6 +9,7 @@ import {
   getClient,
   datasetWithNests,
 } from './utils/meilisearch-test-utils'
+import { Movie } from './env/typescript-node/src'
 
 const index = {
   uid: 'movies_test',
@@ -17,7 +18,7 @@ const emptyIndex = {
   uid: 'empty_test',
 }
 
-const dataset = [
+const dataset: Movie[] = [
   {
     id: 123,
     title: 'Pride and Prejudice',

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -21,6 +21,8 @@ interface Movie {
   title: string
   comment?: string
   genre?: string
+  isNull?: null
+  isTrue?: boolean
 }
 
 interface NestedDocument {


### PR DESCRIPTION
# Pull Request

## Related issue
No

## What does this PR do?
This pr fix the default genetic type params of `search` and `searchGet`, it should use generic type param of `index`

expected type behavior in readme

```ts
client.index<T>('xxx').search(...): Promise<SearchResponse<T>>
```

current actually type, because `search` has a default generic type param `Record<string, any>`:

```ts
client.index<T>('xxx').search(...):
```

is implicit 

```ts
client.index<T>('xxx').search<Record<string, any>>(...):
```

and it's actually

```ts
client.index<T>('xxx').search(...): Promise<SearchResponse<Record<string, any>>>
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
