### PR TITLE
Make `SearchResponse` types more strict regarding to pagination

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -75,11 +75,11 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    * @param config - Additional request configuration options
    * @returns Promise containing the search response
    */
-  async search<D extends Record<string, any> = T>(
+  async search<D extends Record<string, any> = T, S extends SearchParams = SearchParams>(
     query?: string | null,
-    options?: SearchParams,
+    options?: S,
     config?: Partial<Request>
-  ): Promise<SearchResponse<D>> {
+  ): Promise<SearchResponse<D, S>> {
     const url = `indexes/${this.uid}/search`
 
     return await this.httpRequest.post(
@@ -98,11 +98,11 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    * @param config - Additional request configuration options
    * @returns Promise containing the search response
    */
-  async searchGet<D extends Record<string, any> = T>(
+  async searchGet<D extends Record<string, any> = T, S extends SearchParams = SearchParams>(
     query?: string | null,
-    options?: SearchParams,
+    options?: S,
     config?: Partial<Request>
-  ): Promise<SearchResponse<D>> {
+  ): Promise<SearchResponse<D, S>> {
     const url = `indexes/${this.uid}/search`
 
     const parseFilter = (filter?: Filter): string | undefined => {
@@ -125,7 +125,7 @@ class Index<T extends Record<string, any> = Record<string, any>> {
       attributesToHighlight: options?.attributesToHighlight?.join(','),
     }
 
-    return await this.httpRequest.get<SearchResponse<D>>(
+    return await this.httpRequest.get<SearchResponse<D, S>>(
       url,
       removeUndefinedFromObject(getParams),
       config

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -75,7 +75,10 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    * @param config - Additional request configuration options
    * @returns Promise containing the search response
    */
-  async search<D extends Record<string, any> = T, S extends SearchParams = SearchParams>(
+  async search<
+    D extends Record<string, any> = T,
+    S extends SearchParams = SearchParams
+  >(
     query?: string | null,
     options?: S,
     config?: Partial<Request>
@@ -98,7 +101,10 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    * @param config - Additional request configuration options
    * @returns Promise containing the search response
    */
-  async searchGet<D extends Record<string, any> = T, S extends SearchParams = SearchParams>(
+  async searchGet<
+    D extends Record<string, any> = T,
+    S extends SearchParams = SearchParams
+  >(
     query?: string | null,
     options?: S,
     config?: Partial<Request>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -123,19 +123,50 @@ export type Hit<T = Record<string, any>> = T & {
 
 export type Hits<T = Record<string, any>> = Array<Hit<T>>
 
-export type SearchResponse<T = Record<string, any>> = {
+export type SearchResponse<
+  T = Record<string, any>,
+  S extends SearchParams | undefined = undefined
+> = {
   hits: Hits<T>
   processingTimeMs: number
   facetDistribution?: FacetDistribution
   query: string
-  totalHits?: number
-  hitsPerPage?: number
-  page?: number
-  totalPages?: number
-  offset?: number
-  limit?: number
-  estimatedTotalHits?: number
+} & (undefined extends S
+  ? Partial<FinitePagination & InfinitePagination>
+  : true extends IsFinitePagination<NonNullable<S>>
+  ? FinitePagination
+  : InfinitePagination)
+
+type FinitePagination = {
+  totalHits: number
+  hitsPerPage: number
+  page: number
+  totalPages: number
 }
+type InfinitePagination = {
+  offset: number
+  limit: number
+  estimatedTotalHits: number
+}
+
+type IsFinitePagination<S extends SearchParams> = Or<
+  HasHitsPerPage<S>,
+  HasPage<S>
+>
+
+type Or<A extends boolean, B extends boolean> = true extends A
+  ? true
+  : true extends B
+  ? true
+  : false
+
+type HasHitsPerPage<S extends SearchParams> = undefined extends S['hitsPerPage']
+  ? false
+  : true
+
+type HasPage<S extends SearchParams> = undefined extends S['page']
+  ? false
+  : true
 
 export type FieldDistribution = {
   [field: string]: number

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -598,8 +598,11 @@ describe.each([
 
     expect(response.hits.length).toEqual(0)
 
+    // @ts-expect-error Property not existing on type
     expect(response.limit).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.offset).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.estimatedTotalHits).toBeUndefined()
 
     expect(response.hitsPerPage).toEqual(0)
@@ -619,8 +622,11 @@ describe.each([
     })
 
     expect(response.hits.length).toEqual(1)
+    // @ts-expect-error Property not existing on type
     expect(response.limit).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.offset).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.estimatedTotalHits).toBeUndefined()
     expect(response.hitsPerPage).toEqual(1)
     expect(response.page).toEqual(1)
@@ -638,8 +644,11 @@ describe.each([
     })
 
     expect(response.hits.length).toEqual(1)
+    // @ts-expect-error Property not existing on type
     expect(response.limit).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.offset).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.estimatedTotalHits).toBeUndefined()
     expect(response.hitsPerPage).toEqual(1)
     expect(response.page).toEqual(1)
@@ -657,8 +666,11 @@ describe.each([
     })
 
     expect(response.hits.length).toEqual(1)
+    // @ts-expect-error Property not existing on type
     expect(response.limit).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.offset).toBeUndefined()
+    // @ts-expect-error Property not existing on type
     expect(response.estimatedTotalHits).toBeUndefined()
     expect(response.page).toEqual(1)
     expect(response.hitsPerPage).toEqual(1)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1434

## What does this PR do?
As described in #1434 with this PR the type of `SearchResponse` is determined by the params used for the search.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
