### PR TITLE
Fix wrong naming in docker prototype script

### DIFF
--- a/.github/scripts/prototype-docker-version.sh
+++ b/.github/scripts/prototype-docker-version.sh
@@ -14,6 +14,6 @@
 prototype_branch=$1                                                        # $GITHUB_REF_NAME
 prototype_branch=$(echo $prototype_branch | sed -r 's/prototype-beta\///') # remove pre-prending prototype-beta/
 
-docker_image=$(curl "https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags?&page_size=100" | jq | grep "$prototype_name" | head -1)
+docker_image=$(curl "https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags?&page_size=100" | jq | grep "$prototype_branch" | head -1)
 docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
 echo $docker_image


### PR DESCRIPTION
Script was failing because of a variable named incorrectly