### PR TITLE
fix(type): getTypoTolerance return value type

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -914,9 +914,9 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    *
    * @returns Promise containing the typo tolerance settings.
    */
-  async getTypoTolerance(): Promise<string[]> {
+  async getTypoTolerance(): Promise<TypoTolerance> {
     const url = `indexes/${this.uid}/settings/typo-tolerance`
-    return await this.httpRequest.get<string[]>(url)
+    return await this.httpRequest.get<TypoTolerance>(url)
   }
 
   /**


### PR DESCRIPTION
# Pull Request

getTypoTolerance function should return type "TypoTolerance" rather than string array.

## What does this PR do?
- replace getTypoTolerance return value type with "TypoTolerance"

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
