### PR TITLE
Add multi search method of Meilisearch v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ client.index<T>('xxx').search(query: string, options: SearchParams = {}, config?
 client.index<T>('xxx').searchGet(query: string, options: SearchParams = {}, config?: Partial<Request>): Promise<SearchResponse<T>>
 ```
 
+### Multi Search
+
+#### [Make multiple search requests](https://docs.meilisearch.com/reference/api/multi-search.html)
+
+```ts
+client.multiSearch(queries?: MultiSearchParams, config?: Partial<Request>): Promise<Promise<MultiSearchResponse<T>>>
+```
+
+`multiSearch` uses the `POST` method when performing its request to Meilisearch.
+
 ### Documents <!-- omit in toc -->
 
 #### [Add or replace multiple documents](https://docs.meilisearch.com/reference/api/documents.html#add-or-replace-documents)

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -32,6 +32,8 @@ import {
   SwapIndexesParams,
   CancelTasksQuery,
   DeleteTasksQuery,
+  MultiSearchParams,
+  MultiSearchResponse,
 } from '../types'
 import { HttpRequests } from '../http-requests'
 import { TaskClient, Task } from '../task'
@@ -187,6 +189,40 @@ class Client {
   async swapIndexes(params: SwapIndexesParams): Promise<EnqueuedTask> {
     const url = '/swap-indexes'
     return await this.httpRequest.post(url, params)
+  }
+
+  ///
+  /// Multi Search
+  ///
+
+  /**
+   * Perform multiple search queries.
+   *
+   * It is possible to make multiple search queries on the same index or on
+   * different ones
+   *
+   * @example
+   *
+   * ```ts
+   * client.multiSearch({
+   *   queries: [
+   *     { indexUid: 'movies', q: 'wonder' },
+   *     { indexUid: 'books', q: 'flower' },
+   *   ],
+   * })
+   * ```
+   *
+   * @param queries - Search queries
+   * @param config - Additional request configuration options
+   * @returns Promise containing the search responses
+   */
+  async multiSearch<T extends Record<string, any> = Record<string, any>>(
+    queries?: MultiSearchParams,
+    config?: Partial<Request>
+  ): Promise<MultiSearchResponse<T>> {
+    const url = `/multi-search`
+
+    return await this.httpRequest.post(url, queries, undefined, config)
   }
 
   ///

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -106,6 +106,10 @@ export type SearchRequestGET = Pagination &
     showMatchesPosition?: boolean
   }
 
+export type MultiSearchParams = {
+  queries: Array<SearchParams & { indexUid: string }>
+}
+
 export type CategoriesDistribution = {
   [category: string]: number
 }
@@ -167,6 +171,10 @@ type HasHitsPerPage<S extends SearchParams> = undefined extends S['hitsPerPage']
 type HasPage<S extends SearchParams> = undefined extends S['page']
   ? false
   : true
+
+export type MultiSearchResponse<T = Record<string, any>> = {
+  results: Array<SearchResponse<T> & { indexUid: string }>
+}
 
 export type FieldDistribution = {
   [field: string]: number


### PR DESCRIPTION
Introduces the `client.multiSearch()` method as per the [specifications](https://github.com/meilisearch/specifications/pull/225)

SDK requirements: https://github.com/meilisearch/integration-guides/issues/251