### PR TITLE
Add facetStats type in searchResponse for MS v1.1.0

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -131,6 +131,7 @@ export type SearchResponse<
   processingTimeMs: number
   facetDistribution?: FacetDistribution
   query: string
+  facetStats?: Record<string, { min?: number; max?: number }>
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -94,6 +94,7 @@ describe.each([
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
+    expect(response.facetStats).toBeUndefined()
     expect(response.hits.length).toEqual(2)
     // @ts-expect-error Not present in the SearchResponse type because neither `page` or `hitsPerPage` is provided in the search params.
     expect(response.hitsPerPage).toBeUndefined()
@@ -453,12 +454,17 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index(index.uid).search('a', {
       filter: ['genre = romance'],
-      facets: ['genre'],
+      facets: ['genre', 'id'],
     })
 
     expect(response).toHaveProperty('facetDistribution', {
       genre: { romance: 2 },
+      id: { '123': 1, '2': 1 },
     })
+
+    expect(response).toHaveProperty('facetStats', { id: { min: 2, max: 123 } })
+    expect(response.facetStats?.['id']?.min).toBe(2)
+    expect(response.facetStats?.['id']?.max).toBe(123)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response.hits.length).toEqual(2)
   })


### PR DESCRIPTION
As per [the specification](https://github.com/meilisearch/specifications/pull/224)

A new response field, `facetStats` is returned when `facets` is used in the search parameters. It contains the min max value of facets that contain numeric values.




