### PR TITLE
Beta: pre-release for Meilisearch v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ client.index<T>('xxx').search(query: string, options: SearchParams = {}, config?
 client.index<T>('xxx').searchGet(query: string, options: SearchParams = {}, config?: Partial<Request>): Promise<SearchResponse<T>>
 ```
 
+### Multi Search
+
+#### [Make multiple search requests](https://docs.meilisearch.com/reference/api/multi-search.html)
+
+```ts
+client.multiSearch(queries?: MultiSearchParams, config?: Partial<Request>): Promise<Promise<MultiSearchResponse<T>>>
+```
+
+`multiSearch` uses the `POST` method when performing its request to Meilisearch.
+
 ### Documents <!-- omit in toc -->
 
 #### [Add or replace multiple documents](https://docs.meilisearch.com/reference/api/documents.html#add-or-replace-documents)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.31.1",
+  "version": "0.32.0-v1.1.0-pre-release.2",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -32,6 +32,8 @@ import {
   SwapIndexesParams,
   CancelTasksQuery,
   DeleteTasksQuery,
+  MultiSearchParams,
+  MultiSearchResponse,
 } from '../types'
 import { HttpRequests } from '../http-requests'
 import { TaskClient, Task } from '../task'
@@ -187,6 +189,40 @@ class Client {
   async swapIndexes(params: SwapIndexesParams): Promise<EnqueuedTask> {
     const url = '/swap-indexes'
     return await this.httpRequest.post(url, params)
+  }
+
+  ///
+  /// Multi Search
+  ///
+
+  /**
+   * Perform multiple search queries.
+   *
+   * It is possible to make multiple search queries on the same index or on
+   * different ones
+   *
+   * @example
+   *
+   * ```ts
+   * client.multiSearch({
+   *   queries: [
+   *     { indexUid: 'movies', q: 'wonder' },
+   *     { indexUid: 'books', q: 'flower' },
+   *   ],
+   * })
+   * ```
+   *
+   * @param queries - Search queries
+   * @param config - Additional request configuration options
+   * @returns Promise containing the search responses
+   */
+  async multiSearch<T extends Record<string, any> = Record<string, any>>(
+    queries?: MultiSearchParams,
+    config?: Partial<Request>
+  ): Promise<MultiSearchResponse<T>> {
+    const url = `/multi-search`
+
+    return await this.httpRequest.post(url, queries, undefined, config)
   }
 
   ///

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.31.1'
+export const PACKAGE_VERSION = '0.32.0-v1.1.0-pre-release.2'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -106,6 +106,10 @@ export type SearchRequestGET = Pagination &
     showMatchesPosition?: boolean
   }
 
+export type MultiSearchParams = {
+  queries: Array<SearchParams & { indexUid: string }>
+}
+
 export type CategoriesDistribution = {
   [category: string]: number
 }
@@ -167,6 +171,10 @@ type HasHitsPerPage<S extends SearchParams> = undefined extends S['hitsPerPage']
 type HasPage<S extends SearchParams> = undefined extends S['page']
   ? false
   : true
+
+export type MultiSearchResponse<T = Record<string, any>> = {
+  results: Array<SearchResponse<T> & { indexUid: string }>
+}
 
 export type FieldDistribution = {
   [field: string]: number

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -129,6 +129,9 @@ export type Hit<T = Record<string, any>> = T & {
 
 export type Hits<T = Record<string, any>> = Array<Hit<T>>
 
+export type FacetStat = { min: number; max: number }
+export type FacetStats = Record<string, FacetStat>
+
 export type SearchResponse<
   T = Record<string, any>,
   S extends SearchParams | undefined = undefined
@@ -137,7 +140,7 @@ export type SearchResponse<
   processingTimeMs: number
   facetDistribution?: FacetDistribution
   query: string
-  facetStats?: Record<string, { min?: number; max?: number }>
+  facetStats?: FacetStats
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -135,6 +135,7 @@ export type SearchResponse<
   processingTimeMs: number
   facetDistribution?: FacetDistribution
   query: string
+  facetStats?: Record<string, { min?: number; max?: number }>
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -106,8 +106,10 @@ export type SearchRequestGET = Pagination &
     showMatchesPosition?: boolean
   }
 
+export type MultiSearchQuery = SearchParams & { indexUid: string }
+
 export type MultiSearchParams = {
-  queries: Array<SearchParams & { indexUid: string }>
+  queries: MultiSearchQuery[]
 }
 
 export type CategoriesDistribution = {
@@ -173,8 +175,10 @@ type HasPage<S extends SearchParams> = undefined extends S['page']
   ? false
   : true
 
+export type MultiSearchResult<T> = SearchResponse<T> & { indexUid: string }
+
 export type MultiSearchResponse<T = Record<string, any>> = {
-  results: Array<SearchResponse<T> & { indexUid: string }>
+  results: Array<MultiSearchResult<T>>
 }
 
 export type FieldDistribution = {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -147,6 +147,7 @@ describe.each([
     expect(response).toHaveProperty('offset', 0)
     expect(response).toHaveProperty('processingTimeMs', expect.any(Number))
     expect(response).toHaveProperty('query', 'prince')
+    expect(response.facetStats).toBeUndefined()
     expect(response.hits.length).toEqual(2)
     // @ts-expect-error Not present in the SearchResponse type because neither `page` or `hitsPerPage` is provided in the search params.
     expect(response.hitsPerPage).toBeUndefined()
@@ -506,12 +507,17 @@ describe.each([
     const client = await getClient(permission)
     const response = await client.index(index.uid).search('a', {
       filter: ['genre = romance'],
-      facets: ['genre'],
+      facets: ['genre', 'id'],
     })
 
     expect(response).toHaveProperty('facetDistribution', {
       genre: { romance: 2 },
+      id: { '123': 1, '2': 1 },
     })
+
+    expect(response).toHaveProperty('facetStats', { id: { min: 2, max: 123 } })
+    expect(response.facetStats?.['id']?.min).toBe(2)
+    expect(response.facetStats?.['id']?.max).toBe(123)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response.hits.length).toEqual(2)
   })

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -515,8 +515,7 @@ describe.each([
       id: { '123': 1, '2': 1 },
     })
 
-    expect(response).toHaveProperty('facetStats', { id: { min: 2, max: 123 } })
-    expect(response.facetStats?.['id']?.min).toBe(2)
+    expect(response.facetStats).toEqual({ id: { min: 2, max: 123 } })
     expect(response.facetStats?.['id']?.max).toBe(123)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response.hits.length).toEqual(2)


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.1.0.rc.1 :tada:
Check out the changelog of [Meilisearch v1.1.0.rc.1](https://github.com/meilisearch/meilisearch/releases/tag/v1.1.0-rc.1) for more information on the changes.

## 🚀 Enhancements

- Support for facetStats returned in the search response #1459 
- New `client.multiSearch` route to perform multiple search requests.
