### PR TITLE
feat: added support for custom request config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,46 @@ index
 controller.abort()
 ```
 
+
+### Using Meilisearch behind a proxy <!-- omit in toc -->
+
+#### Custom request config <!-- omit in toc -->
+
+You can provide a custom request configuration. for example, with custom headers.
+
+```ts
+const client: MeiliSearch = new MeiliSearch({
+  host: 'http://localhost:3000/api/meilisearch/proxy',
+  requestConfig: {
+    headers: {
+      Authorization: AUTH_TOKEN
+    },
+    // OR
+    credentials: 'include'
+  }
+})
+```
+
+#### Custom http client <!-- omit in toc -->
+
+You can use your own HTTP client, for example, with [`axios`](https://github.com/axios/axios).
+
+```ts
+const client: MeiliSearch = new MeiliSearch({
+  host: 'http://localhost:3000/api/meilisearch/proxy',
+  httpClient: async (url, opts) => {
+    const response = await $axios.request({
+      url,
+      data: opts?.body,
+      headers: opts?.headers,
+      method: (opts?.method?.toLocaleUpperCase() as Method) ?? 'GET'
+    })
+
+    return response.data
+  }
+})
+```
+
 ## 🤖 Compatibility with Meilisearch
 
 This package guarantees compatibility with [version v1.x of Meilisearch](https://github.com/meilisearch/meilisearch/releases/latest), but some features may not be present. Please check the [issues](https://github.com/meilisearch/meilisearch-js/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Aenhancement) for more info.

--- a/src/clients/browser-client.ts
+++ b/src/clients/browser-client.ts
@@ -1,5 +1,5 @@
-import { Client } from './client'
 import { Config } from '../types'
+import { Client } from './client'
 
 class MeiliSearch extends Client {
   constructor(config: Config) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -10,7 +10,8 @@ export type Config = {
   host: string
   apiKey?: string
   clientAgents?: string[]
-  headers?: Record<string, any>
+  requestConfig?: Partial<Omit<RequestInit, 'body' | 'method'>>
+  httpClient?: (input: string, init?: RequestInit) => Promise<any>
 }
 
 ///


### PR DESCRIPTION
feat: added support for custom http client

# Pull Request

## Related issue


## What does this PR do?
- adds support for usages with preconfigured http clients like axios for using ms through a proxy for example
```
const client: MeiliSearch = new MeiliSearch({
      host: 'http://localhost:3000/api/v0/meilisearch/proxy',
      httpClient: async (url, opts) => {
        const response = await $charles.http!.getClient().request({
          url,
          data: opts?.body,
          headers: opts?.headers
        })

        return response.data
      }
    })
```
- adds support for customizing the requests created by `httpRequests` 

### BREAKING CHANGES:
- removes `headers` config param and introduces `requestConfig` instead which can be used to customize all fetch config

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
