### PR TITLE
Fix pre-release CI not triggering

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   meilisearch-version:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    if: github.event_name != 'pull_request' || startsWith(github.base_ref, 'bump-meilisearch-v') || startsWith(github.base_ref, 'pre-release-beta')
     outputs:
       version: ${{ steps.grep-step.outputs.meilisearch_version }}
     steps:
@@ -27,7 +27,7 @@ jobs:
           echo "meilisearch_version=$MEILISEARCH_VERSION" >> $GITHUB_OUTPUT
   integration_tests:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    if: github.event_name != 'pull_request' || startsWith(github.base_ref, 'bump-meilisearch-v') || startsWith(github.base_ref, 'pre-release-beta')
     needs: ['meilisearch-version']
     services:
       meilisearch:


### PR DESCRIPTION
When a push occurs on a branch pointing to a bump branch, the push action does not trigger as it does not match the required branch patterns. When a pull_request activity on a bump branch occurs, the pre-release tests were triggered but because of the wrong if condition, the jobs were not executed.

The if condition should ensure that the base branch corresponds to the pull_request branch patterns.

Which is now the case