### PR TITLE
Add building of the project before running the browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "yarn clear_jest && jest --runInBand --verbose",
     "types:watch": "nodemon --config nodemon.json",
     "types": "yarn tsc",
-    "test:env:browser": "yarn --cwd tests/env/express && yarn --cwd tests/env/express test",
+    "test:env:browser": "yarn build && yarn --cwd tests/env/express && yarn --cwd tests/env/express test",
     "test:watch": "yarn clear_jest && yarn test --watch",
     "test:coverage": "yarn test --coverage",
     "test:ci": "yarn test --ci",


### PR DESCRIPTION
Its not clear that the browser tests is using the build of the project and not the up to date source files.
To ensure we avoid running the test on outdated builds, this PR adds `yarn build` before the tests are ran