### PR TITLE
Remove min max being optional in facetStats results

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -127,6 +127,9 @@ export type Hit<T = Record<string, any>> = T & {
 
 export type Hits<T = Record<string, any>> = Array<Hit<T>>
 
+export type FacetStat = { min: number; max: number }
+export type FacetStats = Record<string, FacetStat>
+
 export type SearchResponse<
   T = Record<string, any>,
   S extends SearchParams | undefined = undefined
@@ -135,7 +138,7 @@ export type SearchResponse<
   processingTimeMs: number
   facetDistribution?: FacetDistribution
   query: string
-  facetStats?: Record<string, { min?: number; max?: number }>
+  facetStats?: FacetStats
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -515,8 +515,7 @@ describe.each([
       id: { '123': 1, '2': 1 },
     })
 
-    expect(response).toHaveProperty('facetStats', { id: { min: 2, max: 123 } })
-    expect(response.facetStats?.['id']?.min).toBe(2)
+    expect(response.facetStats).toEqual({ id: { min: 2, max: 123 } })
     expect(response.facetStats?.['id']?.max).toBe(123)
     expect(response).toHaveProperty('hits', expect.any(Array))
     expect(response.hits.length).toEqual(2)


### PR DESCRIPTION
If a facetStat for a given facet is present, it will always contain min and max.