### PR TITLE
Fix multiSearch to allow using host config with path

### DIFF
--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -220,7 +220,7 @@ class Client {
     queries?: MultiSearchParams,
     config?: Partial<Request>
   ): Promise<MultiSearchResponse<T>> {
-    const url = `/multi-search`
+    const url = `multi-search`
 
     return await this.httpRequest.post(url, queries, undefined, config)
   }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1478

## What does this PR do?

Remove the extra slash in the URL segment for multi-search which prevents the host configuration's path being used.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
