### PR TITLE
remove PUT on contentType enum

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -211,7 +211,6 @@ export type ContentType =
   | 'text/csv'
   | 'application/x-ndjson'
   | 'application/json'
-  | 'PUT'
 
 export type RawDocumentAdditionOptions = DocumentOptions & {
   csvDelimiter?: string


### PR DESCRIPTION
`PUT` is not a value of `ContentType` and should not be part of it
