### PR TITLE
client.stats() isn't a function in the latest release, it seems `client.getStats()` is the correct function.

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -265,7 +265,7 @@ reset_typo_tolerance_1: |-
 get_index_stats_1: |-
   client.index('movies').getStats()
 get_indexes_stats_1: |-
-  client.stats()
+  client.getStats()
 get_health_1: |-
   client.health()
 get_version_1: |-


### PR DESCRIPTION
`client.stats()` isn't a function according to the latest version of `meilisearch-js`, so I went ahead and corrected the documentation for [here](https://www.meilisearch.com/docs/reference/api/stats#stats-object).

As `client.getStats()` is correct function that should be displayed.

## What does this PR do?
Corrects documentation's recommended function, as that function doesn't exist within the new release, its `getStats()` vs the incorrect function that is `stats()`
