### PR TITLE
Add conditional loading for cross-fetch/polyfill - favour native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:ci": "yarn test --ci",
     "test:env": "yarn build && yarn test:env:nodejs && yarn test:env:esm && yarn test:env:node-ts",
     "test:env:node-ts": "yarn --cwd tests/env/typescript-node start",
-    "test:env:nodejs": "node tests/env/node/index.js",
+    "test:env:nodejs": "node tests/env/node/index.js && node tests/env/node/getting_started.js",
     "test:env:esm": "yarn --cwd tests/env/esm && yarn --cwd tests/env/esm start",
     "size": "node scripts/file-size ./dist/bundles/meilisearch.esm.min.js ./dist/bundles/meilisearch.umd.min.js",
     "style": "yarn lint",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:ci": "yarn test --ci",
     "test:env": "yarn build && yarn test:env:nodejs && yarn test:env:esm && yarn test:env:node-ts",
     "test:env:node-ts": "yarn --cwd tests/env/typescript-node start",
-    "test:env:nodejs": "node tests/env/node/index.js && node tests/env/node/getting_started.js",
+    "test:env:nodejs": "yarn build && node tests/env/node/index.js && node tests/env/node/getting_started.js",
     "test:env:esm": "yarn --cwd tests/env/esm && yarn --cwd tests/env/esm start",
     "size": "node scripts/file-size ./dist/bundles/meilisearch.esm.min.js ./dist/bundles/meilisearch.umd.min.js",
     "style": "yarn lint",

--- a/src/errors/meilisearch-communication-error.ts
+++ b/src/errors/meilisearch-communication-error.ts
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill'
 import { FetchError } from '../types'
 
 class MeiliSearchCommunicationError extends Error {

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -1,5 +1,3 @@
-import 'cross-fetch/polyfill'
-
 import { Config, EnqueuedTaskObject } from './types'
 import { PACKAGE_VERSION } from './package-version'
 
@@ -138,6 +136,11 @@ class HttpRequests {
     const headers = { ...this.headers, ...config.headers }
 
     try {
+      if (typeof fetch === 'undefined') {
+        // @ts-expect-error polyfill brings in no meaningful types
+        await import('cross-fetch/polyfill')
+      }
+
       const fetchFn = this.httpClient ? this.httpClient : fetch
       const result = fetchFn(constructURL.toString(), {
         ...config,

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -118,6 +118,10 @@ class HttpRequests {
     body?: any
     config?: Record<string, any>
   }) {
+    if (typeof fetch === 'undefined') {
+      require('cross-fetch/dist/node-polyfill')
+    }
+
     const constructURL = new URL(url, this.url)
     if (params) {
       const queryParams = new URLSearchParams()
@@ -136,11 +140,6 @@ class HttpRequests {
     const headers = { ...this.headers, ...config.headers }
 
     try {
-      if (typeof fetch === 'undefined') {
-        // @ts-expect-error polyfill brings in no meaningful types
-        await import('cross-fetch/polyfill')
-      }
-
       const fetchFn = this.httpClient ? this.httpClient : fetch
       const result = fetchFn(constructURL.toString(), {
         ...config,

--- a/tests/env/node/getting_started.js
+++ b/tests/env/node/getting_started.js
@@ -21,7 +21,8 @@ const { MeiliSearch } = require('../../../dist/bundles/meilisearch.umd.js')
   // If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
   await index.updateFilterableAttributes([
     'director',
-    'genres'
+    'genres',
+    'id'
   ])
 
   let response = await index.addDocuments(dataset)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1487 

## What does this PR do?

Load `cross-fetch/polyfill` only if `fetch` is `undefined`.

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)? #1487 was opened by me though...
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

