### PR TITLE
Add the searchForFacetValues method for Meilisearch v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ client.multiSearch(queries?: MultiSearchParams, config?: Partial<Request>): Prom
 #### [Search for facet values](#)
 
 ```ts
-client.index<T>('xxx').searchForFacetValues(params: SearchForFacetValuesParams, config?: Partial<Request>): Promise<SearchForFacetValuesResponse>
+client.index<T>('myIndex').searchForFacetValues(params: SearchForFacetValuesParams, config?: Partial<Request>): Promise<SearchForFacetValuesResponse>
 ```
 
 ### Documents <!-- omit in toc -->

--- a/README.md
+++ b/README.md
@@ -412,6 +412,14 @@ client.multiSearch(queries?: MultiSearchParams, config?: Partial<Request>): Prom
 
 `multiSearch` uses the `POST` method when performing its request to Meilisearch.
 
+### Search For Facet Value
+
+#### [Search for facet value](#)
+
+```ts
+client.index<T>('xxx').searchForFacetValue(params: SearchForFacetValuesParams, config?: Partial<Request>): Promise<SearchForFacetValuesResponse>
+```
+
 ### Documents <!-- omit in toc -->
 
 #### [Add or replace multiple documents](https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents)

--- a/README.md
+++ b/README.md
@@ -412,12 +412,12 @@ client.multiSearch(queries?: MultiSearchParams, config?: Partial<Request>): Prom
 
 `multiSearch` uses the `POST` method when performing its request to Meilisearch.
 
-### Search For Facet Value
+### Search For Facet Values
 
-#### [Search for facet value](#)
+#### [Search for facet values](#)
 
 ```ts
-client.index<T>('xxx').searchForFacetValue(params: SearchForFacetValuesParams, config?: Partial<Request>): Promise<SearchForFacetValuesResponse>
+client.index<T>('xxx').searchForFacetValues(params: SearchForFacetValuesParams, config?: Partial<Request>): Promise<SearchForFacetValuesResponse>
 ```
 
 ### Documents <!-- omit in toc -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.33.0",
+  "version": "0.33.0-prototype-search-for-facet-values.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.33.0-prototype-search-for-facet-values.0",
+  "version": "v0.33.0-prototype-search-for-facet-values.1",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "v0.33.0-prototype-search-for-facet-values.1",
+  "version": "0.33.0-prototype-search-for-facet-values.1",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -45,6 +45,8 @@ import {
   ContentType,
   DocumentsIds,
   DocumentsDeletionQuery,
+  SearchForFacetValuesParams,
+  SearchForFacetValuesResponse,
 } from './types'
 import { removeUndefinedFromObject } from './utils'
 import { HttpRequests } from './http-requests'
@@ -142,6 +144,27 @@ class Index<T extends Record<string, any> = Record<string, any>> {
     return await this.httpRequest.get<SearchResponse<D, S>>(
       url,
       removeUndefinedFromObject(getParams),
+      config
+    )
+  }
+
+  /**
+   * Search for facet values
+   *
+   * @param params - Parameters used to search on the facets
+   * @param config - Additional request configuration options
+   * @returns Promise containing the search response
+   */
+  async searchForFacetValue(
+    params: SearchForFacetValuesParams,
+    config?: Partial<Request>
+  ): Promise<SearchForFacetValuesResponse> {
+    const url = `indexes/${this.uid}/facet-search`
+
+    return await this.httpRequest.post(
+      url,
+      removeUndefinedFromObject(params),
+      undefined,
       config
     )
   }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -155,7 +155,7 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    * @param config - Additional request configuration options
    * @returns Promise containing the search response
    */
-  async searchForFacetValue(
+  async searchForFacetValues(
     params: SearchForFacetValuesParams,
     config?: Partial<Request>
   ): Promise<SearchForFacetValuesResponse> {

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.33.0-prototype-search-for-facet-values.0'
+export const PACKAGE_VERSION = 'v0.33.0-prototype-search-for-facet-values.1'

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.33.0'
+export const PACKAGE_VERSION = '0.33.0-prototype-search-for-facet-values.0'

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = 'v0.33.0-prototype-search-for-facet-values.1'
+export const PACKAGE_VERSION = '0.33.0-prototype-search-for-facet-values.1'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -851,9 +851,6 @@ export const enum ErrorStatusCode {
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_facet_search_name */
   INVALID_FACET_SEARCH_NAME = 'invalid_facet_search_name',
 
-  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_search_facet */
-  INVALID_SEARCH_FACET = 'invalid_search_facet',
-
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#missing_facet_search_facet_name */
   MISSING_FACET_SEARCH_FACET_NAME = 'missing_facet_search_facet_name',
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -95,8 +95,8 @@ export type FacetHit = {
 }
 
 export type SearchForFacetValuesResponse = {
-  hits: FacetHit[]
-  query: string | null
+  facetHits: FacetHit[]
+  facetQuery: string | null
   processingTimeMs: number
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -839,6 +839,21 @@ export const enum ErrorStatusCode {
 
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_api_key_offset */
   INVALID_API_KEY_OFFSET = 'invalid_api_key_offset',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_facet_search_facet_name */
+  INVALID_FACET_SEARCH_FACET_NAME = 'invalid_facet_search_facet_name',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_facet_search_query */
+  INVALID_FACET_SEARCH_QUERY = 'invalid_facet_search_query',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_facet_search_name */
+  INVALID_FACET_SEARCH_NAME = 'invalid_facet_search_name',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_search_facet */
+  INVALID_SEARCH_FACET = 'invalid_search_facet',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#missing_facet_search_facet_name */
+  MISSING_FACET_SEARCH_FACET_NAME = 'missing_facet_search_facet_name',
 }
 
 export type TokenIndexRules = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -190,6 +190,29 @@ export type FieldDistribution = {
 }
 
 /*
+ * Facet search
+ */
+
+export type SearchForFacetValuesParams = SearchParams & {
+  facetName: string
+  facetQuery?: string
+  q?: string
+  filter?: Filter
+  matchingStrategy?: MatchingStrategies
+}
+
+export type FacetHit = {
+  value: string
+  count: number
+}
+
+export type SearchForFacetValuesResponse = {
+  hits: FacetHit[]
+  query: string | null
+  processingTimeMs: number
+}
+
+/*
  ** Documents
  */
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -78,6 +78,28 @@ export type Crop = {
   cropMarker?: string
 }
 
+export const SortFacetValuesBy = {
+  COUNT: 'error',
+  ALPHA: 'alpha',
+}
+
+export type SortFacetValuesBy = typeof SortFacetValuesBy[keyof typeof SortFacetValuesBy]
+
+export type SearchForFacetValuesParams = Omit<SearchParams, 'facetName'> & {
+  facetName: string
+}
+
+export type FacetHit = {
+  value: string
+  count: number
+}
+
+export type SearchForFacetValuesResponse = {
+  hits: FacetHit[]
+  query: string | null
+  processingTimeMs: number
+}
+
 export type SearchParams = Query &
   Pagination &
   Highlight &
@@ -90,6 +112,9 @@ export type SearchParams = Query &
     matchingStrategy?: MatchingStrategies
     hitsPerPage?: number
     page?: number
+    sortFacetValuesBy?: SortFacetValuesBy
+    facetName?: string
+    facetQuery?: string
   }
 
 // Search parameters for searches made with the GET method
@@ -187,29 +212,6 @@ export type MultiSearchResponse<T = Record<string, any>> = {
 
 export type FieldDistribution = {
   [field: string]: number
-}
-
-/*
- * Facet search
- */
-
-export type SearchForFacetValuesParams = SearchParams & {
-  facetName: string
-  facetQuery?: string
-  q?: string
-  filter?: Filter
-  matchingStrategy?: MatchingStrategies
-}
-
-export type FacetHit = {
-  value: string
-  count: number
-}
-
-export type SearchForFacetValuesResponse = {
-  hits: FacetHit[]
-  query: string | null
-  processingTimeMs: number
 }
 
 /*

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -1,0 +1,108 @@
+import {
+  clearAllIndexes,
+  config,
+  getClient,
+} from './utils/meilisearch-test-utils'
+
+const index = {
+  uid: 'movies_test',
+}
+
+const dataset = [
+  {
+    id: 123,
+    title: 'Pride and Prejudice',
+    genres: ['romance', 'action'],
+  },
+  {
+    id: 456,
+    title: 'Le Petit Prince',
+    genres: ['adventure', 'comedy'],
+  },
+  {
+    id: 2,
+    title: 'Le Rouge et le Noir',
+    genres: 'romance',
+  },
+  {
+    id: 1,
+    title: 'Alice In Wonderland',
+    genres: ['adventure'],
+  },
+]
+
+describe.each([
+  { permission: 'Master' },
+  { permission: 'Admin' },
+  { permission: 'Search' },
+])('Test on POST search', ({ permission }) => {
+  beforeAll(async () => {
+    await clearAllIndexes(config)
+    const client = await getClient('Master')
+    const newFilterableAttributes = ['genres', 'title']
+
+    await client.createIndex(index.uid)
+    await client.index(index.uid).updateSettings({
+      filterableAttributes: newFilterableAttributes,
+    })
+    const { taskUid } = await client.index(index.uid).addDocuments(dataset)
+    await client.waitForTask(taskUid)
+  })
+
+  test(`${permission} key: basic facet value search`, async () => {
+    const client = await getClient(permission)
+
+    const params = {
+      facetQuery: 'a',
+      facetName: 'genres',
+    }
+    const response = await client.index(index.uid).searchForFacetValue(params)
+
+    expect(response.hits.length).toEqual(2)
+    expect(response.query).toEqual('a')
+  })
+
+  test(`${permission} key: facet value search with no facet query`, async () => {
+    const client = await getClient(permission)
+
+    const params = {
+      facetName: 'genres',
+    }
+    const response = await client.index(index.uid).searchForFacetValue(params)
+
+    expect(response.hits.length).toEqual(4)
+    expect(response.query).toEqual(null)
+  })
+
+  test(`${permission} key: facet value search with filter`, async () => {
+    const client = await getClient(permission)
+
+    const params = {
+      facetName: 'genres',
+      facetQuery: 'a',
+      filter: ['genres = action'],
+    }
+    const response = await client.index(index.uid).searchForFacetValue(params)
+
+    expect(response.hits.length).toEqual(1)
+  })
+
+  test(`${permission} key: facet value search with search query`, async () => {
+    const client = await getClient(permission)
+
+    const params = {
+      facetName: 'genres',
+      facetQuery: 'a',
+      q: 'Alice',
+    }
+    const response = await client.index(index.uid).searchForFacetValue(params)
+
+    expect(response.hits.length).toEqual(1)
+  })
+})
+
+jest.setTimeout(100 * 1000)
+
+afterAll(() => {
+  return clearAllIndexes(config)
+})

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -40,7 +40,6 @@ describe.each([
     await clearAllIndexes(config)
     const client = await getClient('Master')
     const newFilterableAttributes = ['genres', 'title']
-
     await client.createIndex(index.uid)
     await client.index(index.uid).updateSettings({
       filterableAttributes: newFilterableAttributes,
@@ -49,14 +48,14 @@ describe.each([
     await client.waitForTask(taskUid)
   })
 
-  test(`${permission} key: basic facet value search`, async () => {
+  test.only(`${permission} key: basic facet value search`, async () => {
     const client = await getClient(permission)
 
     const params = {
       facetQuery: 'a',
       facetName: 'genres',
     }
-    const response = await client.index(index.uid).searchForFacetValue(params)
+    const response = await client.index('games').searchForFacetValues(params)
 
     expect(response.hits.length).toEqual(2)
     expect(response.query).toEqual('a')
@@ -68,7 +67,7 @@ describe.each([
     const params = {
       facetName: 'genres',
     }
-    const response = await client.index(index.uid).searchForFacetValue(params)
+    const response = await client.index(index.uid).searchForFacetValues(params)
 
     expect(response.hits.length).toEqual(4)
     expect(response.query).toEqual(null)
@@ -82,7 +81,8 @@ describe.each([
       facetQuery: 'a',
       filter: ['genres = action'],
     }
-    const response = await client.index(index.uid).searchForFacetValue(params)
+
+    const response = await client.index(index.uid).searchForFacetValues(params)
 
     expect(response.hits.length).toEqual(1)
   })
@@ -95,7 +95,7 @@ describe.each([
       facetQuery: 'a',
       q: 'Alice',
     }
-    const response = await client.index(index.uid).searchForFacetValue(params)
+    const response = await client.index(index.uid).searchForFacetValues(params)
 
     expect(response.hits.length).toEqual(1)
   })

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -57,8 +57,8 @@ describe.each([
     }
     const response = await client.index(index.uid).searchForFacetValues(params)
 
-    expect(response.hits.length).toEqual(2)
-    expect(response.query).toEqual('a')
+    expect(response.facetHits.length).toEqual(2)
+    expect(response.facetQuery).toEqual('a')
   })
 
   test(`${permission} key: facet value search with no facet query`, async () => {
@@ -69,8 +69,8 @@ describe.each([
     }
     const response = await client.index(index.uid).searchForFacetValues(params)
 
-    expect(response.hits.length).toEqual(4)
-    expect(response.query).toEqual(null)
+    expect(response.facetHits.length).toEqual(4)
+    expect(response.facetQuery).toEqual(null)
   })
 
   test(`${permission} key: facet value search with filter`, async () => {
@@ -84,7 +84,7 @@ describe.each([
 
     const response = await client.index(index.uid).searchForFacetValues(params)
 
-    expect(response.hits.length).toEqual(1)
+    expect(response.facetHits.length).toEqual(1)
   })
 
   test(`${permission} key: facet value search with search query`, async () => {
@@ -97,7 +97,7 @@ describe.each([
     }
     const response = await client.index(index.uid).searchForFacetValues(params)
 
-    expect(response.hits.length).toEqual(1)
+    expect(response.facetHits.length).toEqual(1)
   })
 })
 

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -48,7 +48,7 @@ describe.each([
     await client.waitForTask(taskUid)
   })
 
-  test.only(`${permission} key: basic facet value search`, async () => {
+  test(`${permission} key: basic facet value search`, async () => {
     const client = await getClient(permission)
 
     const params = {

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -55,7 +55,7 @@ describe.each([
       facetQuery: 'a',
       facetName: 'genres',
     }
-    const response = await client.index('games').searchForFacetValues(params)
+    const response = await client.index(index.uid).searchForFacetValues(params)
 
     expect(response.hits.length).toEqual(2)
     expect(response.query).toEqual('a')


### PR DESCRIPTION
## index.searchForFacetValue

A new method `index.searchForFacetvalue` method is introduced.

See explanation on this [method here](https://github.com/meilisearch/product/discussions/515#discussioncomment-5806759).

[related PR](https://github.com/meilisearch/meilisearch/pull/3699)

Usage example:

```js
await client.index(index.uid).searchForFacetValue({
  facetQuery: 'act',
  facetName: 'genres',
})
```
