### PR TITLE
Change target in tsconfig to ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
       "module": "esnext",
+      "target": "ES6",
       "noEmit": true,
       "allowJs": false,
       "removeComments": false,


### PR DESCRIPTION
By default, the target in a tsconfig is `ES3`. This ensures compatibility with environments that predates 2015. The downside of having this insurance is the size of the bundle.

By changing from `ES3` to `esnext` we go from a bundle size of 108k to a bundle size of 60k.

Looking at what other libraries do, they seem to agree on using `esnext` as a target. While you might argue that it raises some risks, our library, like the other ones using `esnext`, is made to be used in modern environments.
