### PR TITLE
Experimental vector search for MS v1.3.0

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -137,6 +137,7 @@ class Index<T extends Record<string, any> = Record<string, any>> {
       attributesToRetrieve: options?.attributesToRetrieve?.join(','),
       attributesToCrop: options?.attributesToCrop?.join(','),
       attributesToHighlight: options?.attributesToHighlight?.join(','),
+      vector: options?.vector?.join(','),
     }
 
     return await this.httpRequest.get<SearchResponse<D, S>>(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -90,6 +90,7 @@ export type SearchParams = Query &
     matchingStrategy?: MatchingStrategies
     hitsPerPage?: number
     page?: number
+    vector?: number[] | null
   }
 
 // Search parameters for searches made with the GET method
@@ -105,6 +106,7 @@ export type SearchRequestGET = Pagination &
     attributesToHighlight?: string
     attributesToCrop?: string
     showMatchesPosition?: boolean
+    vector?: string | null
   }
 
 export type MultiSearchQuery = SearchParams & { indexUid: string }
@@ -142,6 +144,7 @@ export type SearchResponse<
   facetDistribution?: FacetDistribution
   query: string
   facetStats?: FacetStats
+  vector: number[]
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -6,6 +6,7 @@ import {
   BAD_HOST,
   MeiliSearch,
   getClient,
+  HOST,
 } from './utils/meilisearch-test-utils'
 
 const index = {
@@ -422,6 +423,24 @@ describe.each([
       'message',
       'The filter query parameter should be in string format when using searchGet'
     )
+  })
+  test.only(`${permission} key: search with vectors`, async () => {
+    const client = await getClient(permission)
+
+    await fetch(`${HOST}/experimental-features`, {
+      body: JSON.stringify({ vectorStore: true }),
+      headers: {
+        Authorization: 'Bearer masterKey',
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    })
+
+    const response = await client
+      .index(emptyIndex.uid)
+      .searchGet('', { vector: [1] })
+
+    expect(response.vector).toEqual([1])
   })
 
   test(`${permission} key: Try to search on deleted index and fail`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -8,7 +8,12 @@ import {
   MeiliSearch,
   getClient,
   datasetWithNests,
+  HOST,
 } from './utils/meilisearch-test-utils'
+
+if (typeof fetch === 'undefined') {
+  require('cross-fetch/polyfill')
+}
 
 const index = {
   uid: 'movies_test',
@@ -765,6 +770,25 @@ describe.each([
     expect(response).toHaveProperty('hits', [])
     expect(response).toHaveProperty('query', 'prince')
     expect(response.hits.length).toEqual(0)
+  })
+
+  test(`${permission} key: search with vectors`, async () => {
+    const client = await getClient(permission)
+
+    await fetch(`${HOST}/experimental-features`, {
+      body: JSON.stringify({ vectorStore: true }),
+      headers: {
+        Authorization: 'Bearer masterKey',
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    })
+
+    const response = await client
+      .index(emptyIndex.uid)
+      .search('', { vector: [1] })
+
+    expect(response.vector).toEqual([1])
   })
 
   test(`${permission} key: Try to search on deleted index and fail`, async () => {


### PR DESCRIPTION
# Pull Request

issue: https://github.com/meilisearch/meilisearch/issues/3798
spec: https://github.com/meilisearch/specifications/pull/248


## What does this PR do?

- Add the `vector` search parameter, which requests the nearest documents based on the query vector embedding being given.


