### PR TITLE
Add sort order for facet values for Meilisearch v1.3

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -255,9 +255,13 @@ export type TypoTolerance = {
   }
 } | null
 
+export type FacetOrder = 'alpha' | 'count'
+
 export type Faceting = {
   maxValuesPerFacet?: number | null
+  sortFacetValuesBy?: Record<string, FacetOrder> | null
 }
+
 export type PaginationSettings = {
   maxTotalHits?: number | null
 }

--- a/tests/__snapshots__/faceting.test.ts.snap
+++ b/tests/__snapshots__/faceting.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test on faceting Admin key: Get default faceting object 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Admin key: Reset faceting 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Admin key: Update faceting at null 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Admin key: Update faceting settings 1`] = `
+Object {
+  "maxValuesPerFacet": 12,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+    "test": "count",
+  },
+}
+`;
+
+exports[`Test on faceting Master key: Get default faceting object 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Master key: Reset faceting 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Master key: Update faceting at null 1`] = `
+Object {
+  "maxValuesPerFacet": 100,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+  },
+}
+`;
+
+exports[`Test on faceting Master key: Update faceting settings 1`] = `
+Object {
+  "maxValuesPerFacet": 12,
+  "sortFacetValuesBy": Object {
+    "*": "alpha",
+    "test": "count",
+  },
+}
+`;

--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -1,0 +1,773 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test on settings Admin key: Get default settings of an index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Get default settings of empty index with primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Reset settings 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Reset settings of empty index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update searchableAttributes settings on empty index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update searchableAttributes settings on empty index with a primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update settings 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "title",
+  ],
+  "distinctAttribute": "title",
+  "faceting": Object {
+    "maxValuesPerFacet": 50,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [
+    "title",
+  ],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "id:asc",
+    "typo",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [
+    "title",
+  ],
+  "stopWords": Array [
+    "the",
+  ],
+  "synonyms": Object {
+    "harry": Array [
+      "potter",
+    ],
+  },
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [
+      "comment",
+    ],
+    "disableOnWords": Array [
+      "prince",
+    ],
+    "enabled": false,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 1,
+      "twoTypos": 100,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update settings on empty index with primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": "title",
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "title:asc",
+    "typo",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [
+    "the",
+  ],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update settings with all null values 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Get default settings of an index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Get default settings of empty index with primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Reset settings 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Reset settings of empty index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update searchableAttributes settings on empty index 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update searchableAttributes settings on empty index with a primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update settings 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "title",
+  ],
+  "distinctAttribute": "title",
+  "faceting": Object {
+    "maxValuesPerFacet": 50,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [
+    "title",
+  ],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "id:asc",
+    "typo",
+  ],
+  "searchableAttributes": Array [
+    "title",
+  ],
+  "sortableAttributes": Array [
+    "title",
+  ],
+  "stopWords": Array [
+    "the",
+  ],
+  "synonyms": Object {
+    "harry": Array [
+      "potter",
+    ],
+  },
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [
+      "comment",
+    ],
+    "disableOnWords": Array [
+      "prince",
+    ],
+    "enabled": false,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 1,
+      "twoTypos": 100,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update settings on empty index with primary key 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": "title",
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "title:asc",
+    "typo",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [
+    "the",
+  ],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update settings with all null values 1`] = `
+Object {
+  "displayedAttributes": Array [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": Object {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": Object {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": Array [],
+  "pagination": Object {
+    "maxTotalHits": 1000,
+  },
+  "rankingRules": Array [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchableAttributes": Array [
+    "*",
+  ],
+  "sortableAttributes": Array [],
+  "stopWords": Array [],
+  "synonyms": Object {},
+  "typoTolerance": Object {
+    "disableOnAttributes": Array [],
+    "disableOnWords": Array [],
+    "enabled": true,
+    "minWordSizeForTypos": Object {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;

--- a/tests/faceting.test.ts
+++ b/tests/faceting.test.ts
@@ -38,18 +38,21 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getFaceting()
 
-      expect(response).toEqual({ maxValuesPerFacet: 100 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update faceting settings`, async () => {
       const client = await getClient(permission)
-      const newFaceting = { maxValuesPerFacet: 12 }
+      const newFaceting = {
+        maxValuesPerFacet: 12,
+        sortFacetValuesBy: { test: 'count' as 'count' },
+      }
       const task = await client.index(index.uid).updateFaceting(newFaceting)
       await client.index(index.uid).waitForTask(task.taskUid)
 
       const response = await client.index(index.uid).getFaceting()
 
-      expect(response).toEqual(newFaceting)
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update faceting at null`, async () => {
@@ -61,7 +64,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getFaceting()
 
-      expect(response).toEqual({ maxValuesPerFacet: 100 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Reset faceting`, async () => {
@@ -80,7 +83,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getFaceting()
 
-      expect(response).toEqual({ maxValuesPerFacet: 100 })
+      expect(response).toMatchSnapshot()
     })
   }
 )

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { ErrorStatusCode } from '../src/types'
+import { ErrorStatusCode, Settings } from '../src/types'
 import {
   clearAllIndexes,
   config,
@@ -59,7 +59,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
     test(`${permission} key: Update settings`, async () => {
       const client = await getClient(permission)
-      const newSettings = {
+      const newSettings: Settings = {
         filterableAttributes: ['title'],
         sortableAttributes: ['title'],
         distinctAttribute: 'title',
@@ -83,7 +83,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         faceting: {
           maxValuesPerFacet: 50,
           sortFacetValuesBy: {
-            '*': 'alpha' as 'alpha',
+            '*': 'alpha',
           },
         },
       }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -16,48 +16,6 @@ const indexAndPK = {
   primaryKey: 'id',
 }
 
-const defaultRankingRules = [
-  'words',
-  'typo',
-  'proximity',
-  'attribute',
-  'sort',
-  'exactness',
-]
-
-const defaultSettings = {
-  filterableAttributes: [],
-  sortableAttributes: [],
-  distinctAttribute: null,
-  searchableAttributes: ['*'],
-  displayedAttributes: ['*'],
-  rankingRules: [
-    'words',
-    'typo',
-    'proximity',
-    'attribute',
-    'sort',
-    'exactness',
-  ],
-  stopWords: [],
-  synonyms: {},
-  typoTolerance: {
-    enabled: true,
-    minWordSizeForTypos: {
-      oneTypo: 5,
-      twoTypos: 9,
-    },
-    disableOnWords: [],
-    disableOnAttributes: [],
-  },
-  pagination: {
-    maxTotalHits: 1000,
-  },
-  faceting: {
-    maxValuesPerFacet: 100,
-  },
-}
-
 jest.setTimeout(100 * 1000)
 
 afterAll(() => {
@@ -88,15 +46,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty('distinctAttribute', null)
-      expect(response).toHaveProperty('searchableAttributes', ['*'])
-      expect(response).toHaveProperty('displayedAttributes', ['*'])
-      expect(response).toHaveProperty('sortableAttributes', [])
-      expect(response).toHaveProperty('stopWords', [])
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Get default settings of empty index with primary key`, async () => {
@@ -104,15 +54,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(indexAndPK.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty('distinctAttribute', null)
-      expect(response).toHaveProperty('searchableAttributes', ['*'])
-      expect(response).toHaveProperty('displayedAttributes', ['*'])
-      expect(response).toHaveProperty('sortableAttributes', [])
-      expect(response).toHaveProperty('stopWords', [])
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update settings`, async () => {
@@ -140,6 +82,9 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         },
         faceting: {
           maxValuesPerFacet: 50,
+          sortFacetValuesBy: {
+            '*': 'alpha' as 'alpha',
+          },
         },
       }
       // Add the settings
@@ -150,7 +95,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const response = await client.index(index.uid).getSettings()
 
       // tests
-      expect(response).toEqual(newSettings)
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update settings with all null values`, async () => {
@@ -175,6 +120,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         },
         faceting: {
           maxValuesPerFacet: null,
+          sortFacetValuesBy: null,
         },
         pagination: {
           maxTotalHits: null,
@@ -188,7 +134,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const response = await client.index(index.uid).getSettings()
 
       // tests
-      expect(response).toEqual(defaultSettings)
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update settings on empty index with primary key`, async () => {
@@ -205,17 +151,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(indexAndPK.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', newSettings.rankingRules)
-      expect(response).toHaveProperty(
-        'distinctAttribute',
-        newSettings.distinctAttribute
-      )
-      expect(response).toHaveProperty('searchableAttributes', ['*'])
-      expect(response).toHaveProperty('displayedAttributes', ['*'])
-      expect(response).toHaveProperty('stopWords', newSettings.stopWords)
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Reset settings`, async () => {
@@ -225,15 +161,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty('distinctAttribute', null)
-      expect(response).toHaveProperty('searchableAttributes', ['*'])
-      expect(response).toHaveProperty('displayedAttributes', ['*'])
-      expect(response).toHaveProperty('sortableAttributes', [])
-      expect(response).toHaveProperty('stopWords', [])
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Reset settings of empty index`, async () => {
@@ -243,14 +171,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(indexAndPK.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty('distinctAttribute', null)
-      expect(response).toHaveProperty('searchableAttributes', ['*'])
-      expect(response).toHaveProperty('displayedAttributes', ['*'])
-      expect(response).toHaveProperty('stopWords', [])
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update searchableAttributes settings on empty index`, async () => {
@@ -263,20 +184,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response = await client.index(index.uid).getSettings()
 
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty(
-        'distinctAttribute',
-        defaultSettings.distinctAttribute
-      )
-      expect(response).toHaveProperty(
-        'searchableAttributes',
-        newSettings.searchableAttributes
-      )
-      expect(response).toHaveProperty('displayedAttributes', expect.any(Array))
-      expect(response).toHaveProperty('stopWords', defaultSettings.stopWords)
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
 
     test(`${permission} key: Update searchableAttributes settings on empty index with a primary key`, async () => {
@@ -294,25 +202,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       // Fetch settings
       const response = await client.index(indexAndPK.uid).getSettings()
 
-      // Compare searchableAttributes
-      expect(response).toHaveProperty(
-        'searchableAttributes',
-        newSettings.searchableAttributes
-      )
-      expect(response).toHaveProperty('rankingRules', defaultRankingRules)
-      expect(response).toHaveProperty(
-        'distinctAttribute',
-        defaultSettings.distinctAttribute
-      )
-      expect(response).toHaveProperty(
-        'searchableAttributes',
-        newSettings.searchableAttributes
-      )
-      expect(response).toHaveProperty('displayedAttributes', expect.any(Array))
-      expect(response).toHaveProperty('stopWords', defaultSettings.stopWords)
-      expect(response).toHaveProperty('synonyms', {})
-      expect(response).toHaveProperty('faceting', { maxValuesPerFacet: 100 })
-      expect(response).toHaveProperty('pagination', { maxTotalHits: 1000 })
+      expect(response).toMatchSnapshot()
     })
   }
 )


### PR DESCRIPTION
# Pull Request

## Related issue
issue: https://github.com/meilisearch/meilisearch/issues/3612
discussion: https://github.com/meilisearch/product/discussions/519#discussioncomment-6030480

## What does this PR do?

Adds the ability to sort facets by their value which could be by using alphanumerical or count.

Ensure the SDKs can handle the new search parameter sortFacetValuesBy. This enum can only take count or alphanumeric.


- Adds the `sortFacetValuesBy` setting in `Settings['faceting']`