### PR TITLE
Add attributes to search on for Meilisearch v1.3

### DIFF
--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -138,6 +138,7 @@ class Index<T extends Record<string, any> = Record<string, any>> {
       attributesToCrop: options?.attributesToCrop?.join(','),
       attributesToHighlight: options?.attributesToHighlight?.join(','),
       vector: options?.vector?.join(','),
+      attributesToSearchOn: options?.attributesToSearchOn?.join(','),
     }
 
     return await this.httpRequest.get<SearchResponse<D, S>>(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -91,6 +91,7 @@ export type SearchParams = Query &
     hitsPerPage?: number
     page?: number
     vector?: number[] | null
+    attributesToSearchOn?: string[] | null
   }
 
 // Search parameters for searches made with the GET method
@@ -107,6 +108,7 @@ export type SearchRequestGET = Pagination &
     attributesToCrop?: string
     showMatchesPosition?: boolean
     vector?: string | null
+    attributesToSearchOn?: string | null
   }
 
 export type MultiSearchQuery = SearchParams & { indexUid: string }
@@ -649,6 +651,9 @@ export const enum ErrorStatusCode {
 
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_search_vector */
   INVALID_SEARCH_VECTOR = 'invalid_search_vector',
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_search_attributes_to_search_on */
+  INVALID_SEARCH_ATTRIBUTES_TO_SEARCH_ON = 'invalid_search_attributes_to_search_on',
 
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#bad_request */
   BAD_REQUEST = 'bad_request',

--- a/tests/__snapshots__/get_search.test.ts.snap
+++ b/tests/__snapshots__/get_search.test.ts.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test on GET search Admin key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;
+
+exports[`Test on GET search Master key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;
+
+exports[`Test on GET search Search key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;

--- a/tests/__snapshots__/search.test.ts.snap
+++ b/tests/__snapshots__/search.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test on POST search Admin key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "isNull": null,
+      "isTrue": true,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;
+
+exports[`Test on POST search Master key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "isNull": null,
+      "isTrue": true,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;
+
+exports[`Test on POST search Search key: search on attributesToSearchOn set to null 1`] = `
+Object {
+  "estimatedTotalHits": 2,
+  "hits": Array [
+    Object {
+      "comment": "A french book about a prince that walks on little cute planets",
+      "genre": "adventure",
+      "id": 456,
+      "isNull": null,
+      "isTrue": true,
+      "title": "Le Petit Prince",
+    },
+    Object {
+      "comment": "The best book",
+      "genre": "fantasy",
+      "id": 4,
+      "title": "Harry Potter and the Half-Blood Prince",
+    },
+  ],
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0,
+  "query": "prince",
+}
+`;

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -141,6 +141,26 @@ describe.each([
     )
   })
 
+  test(`${permission} key: search on attributesToSearchOn`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).searchGet('prince', {
+      attributesToSearchOn: ['id'],
+    })
+
+    expect(response.hits.length).toEqual(0)
+  })
+
+  test(`${permission} key: search on attributesToSearchOn set to null`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).searchGet('prince', {
+      attributesToSearchOn: null,
+    })
+
+    expect(response).toMatchSnapshot()
+  })
+
   test(`${permission} key: search with options`, async () => {
     const client = await getClient(permission)
     const response = await client

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -272,6 +272,26 @@ describe.each([
     )
   })
 
+  test(`${permission} key: search on attributesToSearchOn`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('prince', {
+      attributesToSearchOn: ['id'],
+    })
+
+    expect(response.hits.length).toEqual(0)
+  })
+
+  test(`${permission} key: search on attributesToSearchOn set to null`, async () => {
+    const client = await getClient(permission)
+
+    const response = await client.index(index.uid).search('prince', {
+      attributesToSearchOn: null,
+    })
+
+    expect(response).toMatchSnapshot()
+  })
+
   test(`${permission} key: search with array options`, async () => {
     const client = await getClient(permission)
 


### PR DESCRIPTION
# Pull Request

## Related issue
issue: https://github.com/meilisearch/meilisearch/issues/3772
spec: Define fields to search on at runtime  [specifications#251](https://github.com/meilisearch/specifications/pull/251)

- Add support for receiving a new key, attributesToSearchOn (which is an array of field names), that will enable running searches over a subset of searchableAttributes without modifying Meilisearch’s index settings.
