### PR TITLE
Add total field in getTasks response

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -406,6 +406,7 @@ type CursorResults<T> = {
   limit: number
   from: number
   next: number
+  total: number
 }
 
 export type TasksResults = CursorResults<Task>

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -95,6 +95,7 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       const tasks = await client.getTasks()
 
       expect(tasks.results).toBeInstanceOf(Array)
+      expect(tasks.total).toBeDefined()
       expect(tasks.results[0].uid).toEqual(enqueuedTask.taskUid)
     })
 


### PR DESCRIPTION
Related to:

spec: https://github.com/meilisearch/specifications/pull/253


- Add `total` in the response type of `getTasks`
