### PR TITLE
Beta: pre-release for Meilisearch v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.35.0-v1.3.0-pre-release.0",
+  "version": "0.35.0-v1.3.0-pre-release.1",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.34.0",
+  "version": "0.35.0-v1.3.0-pre-release.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.34.0'
+export const PACKAGE_VERSION = '0.35.0-v1.3.0-pre-release.0'

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.35.0-v1.3.0-pre-release.0'
+export const PACKAGE_VERSION = '0.35.0-v1.3.0-pre-release.1'


### PR DESCRIPTION
This version introduces features released on Meilisearch v1.3.0.rc.1 :tada:
Check out the changelog of [Meilisearch v1.3.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.3.0-rc.1) for more information on the changes. 
⚠️ If you want to adopt new features of this release, **update the Meilisearch server** to the according version.

### :rocket: Enhancements

- Add a new method `searchForFacetValues` providing the possibility to search for facet values of a specific facet. #1513 
- (type) Add `sortFacetValuesBy` as a `faceting` setting parameters. Which lets you order your facet values by alpha or count. #1536 
- (type) Add `attributesToSearchOn` as a search parameter to limit in which fields to search. #1538 
- (type) Add `total` in the return object of `getTasks` to know how many tasks were found. #1539 
- (type) Add `showRankingScore` as a search parameter to receive the ranking score of the hits in the `_rankingScore` hit field. #1537 
- [EXPERIMENTAL] (type) Add `vector` as a search parameter to enable vector search.
- [EXPERIMENTAL] (type) Add `showRankingScoreDetails` as a search parameter to receive the details of the ranking score of the hits in `_rankingScoreDetails` hit field. #1537
