### PR TITLE
fix: add `dumpCreation` in type `TaskTypes`

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -351,16 +351,17 @@ export const enum TaskStatus {
 }
 
 export const enum TaskTypes {
-  INDEX_CREATION = 'indexCreation',
-  INDEX_UPDATE = 'indexUpdate',
-  INDEX_DELETION = 'indexDeletion',
   DOCUMENTS_ADDITION_OR_UPDATE = 'documentAdditionOrUpdate',
   DOCUMENT_DELETION = 'documentDeletion',
-  SETTINGS_UPDATE = 'settingsUpdate',
+  DUMP_CREATION = 'dumpCreation',
+  INDEX_CREATION = 'indexCreation',
+  INDEX_DELETION = 'indexDeletion',
   INDEXES_SWAP = 'indexSwap',
-  TASK_DELETION = 'taskDeletion',
+  INDEX_UPDATE = 'indexUpdate',
+  SETTINGS_UPDATE = 'settingsUpdate',
   SNAPSHOT_CREATION = 'snapshotCreation',
   TASK_CANCELATION = 'taskCancelation',
+  TASK_DELETION = 'taskDeletion',
 }
 
 export type TasksQuery = {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1567

Meilisearch tasks type can be `dumpCreation` but it's missing in the type `TaskTypes` in `meilisearch-js`.
See tasks documentation here: https://www.meilisearch.com/docs/reference/api/tasks#type

## What does this PR do?
-  Add `dumpCreation` in type `TaskTypes`
- Reorder in alphabetical order

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
