### PR TITLE
Update dependabot changing ignore list to allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,25 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     labels:
       - 'skip-changelog'
       - 'dependencies'
     rebase-strategy: disabled
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
+    allow:
+      - dependency-name: cross-fetch
+
     schedule:
-      interval: "monthly"
-      time: "04:00"
+      interval: 'monthly'
+      time: '04:00'
     open-pull-requests-limit: 10
     labels:
       - skip-changelog
       - dependencies
     versioning-strategy: increase
     rebase-strategy: disabled
-    ignore:
-      - dependency-name: "eslint*"
-      - dependency-name: "babel-eslint"
-      - dependency-name: "*prettier*"
-      - dependency-name: "lint-staged"
-      - dependency-name: "nodemon"
-      - dependency-name: "*jest*"


### PR DESCRIPTION
To avoid being spammed with none-critical dependencies updates suggested by dependabot, we are changing from `ignore` to `allow` in the dependabot file. Ensuring we only update the critical dependencies.

```
- dependency-name: cross-fetch
```

cross-fetch is kept as it is the only one that is builded with the package. Updates of this library ensure that the library is kept up to date with new versions of `node`.

