### PR TITLE
Update error inheritance to extend `MeiliSearchError`

### DIFF
--- a/src/errors/meilisearch-api-error.ts
+++ b/src/errors/meilisearch-api-error.ts
@@ -1,6 +1,7 @@
 import { MeiliSearchErrorInfo } from '../types'
+import { MeiliSearchError } from './meilisearch-error'
 
-const MeiliSearchApiError = class extends Error {
+const MeiliSearchApiError = class extends MeiliSearchError {
   httpStatus: number
   code: string
   link: string

--- a/src/errors/meilisearch-communication-error.ts
+++ b/src/errors/meilisearch-communication-error.ts
@@ -1,6 +1,7 @@
 import { FetchError } from '../types'
+import { MeiliSearchError } from './meilisearch-error'
 
-class MeiliSearchCommunicationError extends Error {
+class MeiliSearchCommunicationError extends MeiliSearchError {
   statusCode?: number
   errno?: string
   code?: string

--- a/src/errors/meilisearch-timeout-error.ts
+++ b/src/errors/meilisearch-timeout-error.ts
@@ -1,4 +1,6 @@
-class MeiliSearchTimeOutError extends Error {
+import { MeiliSearchError } from './meilisearch-error'
+
+class MeiliSearchTimeOutError extends MeiliSearchError {
   constructor(message: string) {
     super(message)
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1565 

## What does this PR do?
- Ensure that the base error class(MeiliSearchError) inherits the standard error.
- All other error classes inherit the MeiliSearchError.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
