### PR TITLE
fix: snapshots after removing embedders from default settings

### DIFF
--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -7,7 +7,6 @@ exports[`Test on settings Admin key: Get default settings of an index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -54,7 +53,6 @@ exports[`Test on settings Admin key: Get default settings of empty index with pr
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -101,7 +99,6 @@ exports[`Test on settings Admin key: Reset settings 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -148,7 +145,6 @@ exports[`Test on settings Admin key: Reset settings of empty index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -195,7 +191,6 @@ exports[`Test on settings Admin key: Update searchableAttributes settings on emp
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -242,7 +237,6 @@ exports[`Test on settings Admin key: Update searchableAttributes settings on emp
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -292,7 +286,6 @@ exports[`Test on settings Admin key: Update settings 1`] = `
     "title",
   ],
   "distinctAttribute": "title",
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 50,
     "sortFacetValuesBy": {
@@ -357,7 +350,6 @@ exports[`Test on settings Admin key: Update settings on empty index with primary
     "*",
   ],
   "distinctAttribute": "title",
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -402,7 +394,6 @@ exports[`Test on settings Admin key: Update settings with all null values 1`] = 
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -449,7 +440,6 @@ exports[`Test on settings Master key: Get default settings of an index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -496,7 +486,6 @@ exports[`Test on settings Master key: Get default settings of empty index with p
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -543,7 +532,6 @@ exports[`Test on settings Master key: Reset settings 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -590,7 +578,6 @@ exports[`Test on settings Master key: Reset settings of empty index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -637,7 +624,6 @@ exports[`Test on settings Master key: Update searchableAttributes settings on em
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -684,7 +670,6 @@ exports[`Test on settings Master key: Update searchableAttributes settings on em
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -734,7 +719,6 @@ exports[`Test on settings Master key: Update settings 1`] = `
     "title",
   ],
   "distinctAttribute": "title",
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 50,
     "sortFacetValuesBy": {
@@ -799,7 +783,6 @@ exports[`Test on settings Master key: Update settings on empty index with primar
     "*",
   ],
   "distinctAttribute": "title",
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -844,7 +827,6 @@ exports[`Test on settings Master key: Update settings with all null values 1`] =
     "*",
   ],
   "distinctAttribute": null,
-  "embedders": {},
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Update snapshots which were failing after `embedders` were removed from the settings by default

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
