### PR TITLE
Create beta version for Meilisearch v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.37.0",
+  "version": "0.38.0-v1.7.0-pre-release.1",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meilisearch",
-  "version": "0.38.0-v1.7.0-pre-release.1",
+  "version": "0.38.0-v1.7.0-pre-release.0",
   "description": "The Meilisearch JS client for Node.js and the browser.",
   "keywords": [
     "meilisearch",

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.38.0-v1.7.0-pre-release.1'
+export const PACKAGE_VERSION = '0.38.0-v1.7.0-pre-release.0'

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '0.37.0'
+export const PACKAGE_VERSION = '0.38.0-v1.7.0-pre-release.1'

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -333,6 +333,7 @@ export type OpenAiEmbedder = {
   model?: string
   apiKey?: string
   documentTemplate?: string
+  dimensions?: number
 }
 
 export type HuggingFaceEmbedder = {
@@ -346,6 +347,7 @@ export type UserProvidedEmbedder = {
   source: 'userProvided'
   dimensions: number
 }
+
 export type Embedder =
   | OpenAiEmbedder
   | HuggingFaceEmbedder

--- a/tests/embedders.test.ts
+++ b/tests/embedders.test.ts
@@ -73,9 +73,10 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         default: {
           source: 'openAi',
           apiKey: '<your-OpenAI-API-key>',
-          model: 'text-embedding-ada-002',
+          model: 'text-embedding-3-small',
           documentTemplate:
             "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
+          dimensions: 1536,
         },
       }
       const task: EnqueuedTask = await client

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -271,18 +271,8 @@ describe.each([
     expect(hit).toHaveProperty('_rankingScore')
   })
 
-  test(`${permission} key: search with showRankingScoreDetails enabled`, async () => {
+  test(`${permission} key: search with showRankingScoreDetails`, async () => {
     const client = await getClient(permission)
-    const key = await getKey(permission)
-
-    await fetch(`${HOST}/experimental-features`, {
-      body: JSON.stringify({ scoreDetails: true }),
-      headers: {
-        Authorization: `Bearer ${key}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'PATCH',
-    })
 
     const response = await client.index(index.uid).search('prince', {
       showRankingScoreDetails: true,


### PR DESCRIPTION
Beta version for Meilisearch v1.7.0.
Linked to release https://github.com/meilisearch/meilisearch-js/releases/tag/v0.38.0-v1.7.0-pre-release.0