### PR TITLE
feat: hybrid search improvements for v1.8.x

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -215,7 +215,6 @@ export type SearchResponse<
   query: string
   facetDistribution?: FacetDistribution
   facetStats?: FacetStats
-  vector?: number[]
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>
@@ -335,12 +334,18 @@ export type NonSeparatorTokens = string[] | null
 export type Dictionary = string[] | null
 export type ProximityPrecision = 'byWord' | 'byAttribute'
 
+export type Distribution = {
+  mean: number
+  sigma: number
+}
+
 export type OpenAiEmbedder = {
   source: 'openAi'
   model?: string
   apiKey?: string
   documentTemplate?: string
   dimensions?: number
+  distribution?: Distribution
 }
 
 export type HuggingFaceEmbedder = {
@@ -348,17 +353,44 @@ export type HuggingFaceEmbedder = {
   model?: string
   revision?: string
   documentTemplate?: string
+  distribution?: Distribution
 }
 
 export type UserProvidedEmbedder = {
   source: 'userProvided'
   dimensions: number
+  distribution?: Distribution
+}
+
+export type RestEmbedder = {
+  source: 'rest'
+  url: string
+  apiKey?: string
+  dimensions?: number
+  documentTemplate?: string
+  inputField?: string[] | null
+  inputType?: 'text' | 'textArray'
+  query?: Record<string, any> | null
+  pathToEmbeddings?: string[] | null
+  embeddingObject?: string[] | null
+  distribution?: Distribution
+}
+
+export type OllamaEmbedder = {
+  source: 'ollama'
+  url?: string
+  apiKey?: string
+  model?: string
+  documentTemplate?: string
+  distribution?: Distribution
 }
 
 export type Embedder =
   | OpenAiEmbedder
   | HuggingFaceEmbedder
   | UserProvidedEmbedder
+  | RestEmbedder
+  | OllamaEmbedder
   | null
 
 export type Embedders = Record<string, Embedder> | null

--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -94,6 +94,53 @@ exports[`Test on settings Admin key: Get default settings of empty index with pr
 }
 `;
 
+exports[`Test on settings Admin key: Reset embedders settings  1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
 exports[`Test on settings Admin key: Reset settings 1`] = `
 {
   "dictionary": [],
@@ -148,6 +195,66 @@ exports[`Test on settings Admin key: Reset settings of empty index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Admin key: Update embedders settings  1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "embedders": {
+    "default": {
+      "apiKey": "<yoXXXXX...",
+      "dimensions": 1536,
+      "distribution": {
+        "mean": 0.7,
+        "sigma": 0.3,
+      },
+      "documentTemplate": "A document template",
+      "model": "text-embedding-3-small",
+      "source": "openAi",
+    },
+  },
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {
@@ -536,6 +643,53 @@ exports[`Test on settings Master key: Get default settings of empty index with p
 }
 `;
 
+exports[`Test on settings Master key: Reset embedders settings  1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
 exports[`Test on settings Master key: Reset settings 1`] = `
 {
   "dictionary": [],
@@ -590,6 +744,66 @@ exports[`Test on settings Master key: Reset settings of empty index 1`] = `
     "*",
   ],
   "distinctAttribute": null,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings Master key: Update embedders settings  1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "embedders": {
+    "default": {
+      "apiKey": "<yoXXXXX...",
+      "dimensions": 1536,
+      "distribution": {
+        "mean": 0.7,
+        "sigma": 0.3,
+      },
+      "documentTemplate": "A document template",
+      "model": "text-embedding-3-small",
+      "source": "openAi",
+    },
+  },
   "faceting": {
     "maxValuesPerFacet": 100,
     "sortFacetValuesBy": {

--- a/tests/embedders.test.ts
+++ b/tests/embedders.test.ts
@@ -54,6 +54,10 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
         default: {
           source: 'userProvided',
           dimensions: 1,
+          distribution: {
+            mean: 0.7,
+            sigma: 0.3,
+          },
         },
       }
       const task: EnqueuedTask = await client
@@ -77,6 +81,39 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
           documentTemplate:
             "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
           dimensions: 1536,
+          distribution: {
+            mean: 0.7,
+            sigma: 0.3,
+          },
+        },
+      }
+      const task: EnqueuedTask = await client
+        .index(index.uid)
+        .updateEmbedders(newEmbedder)
+      await client.waitForTask(task.taskUid)
+
+      const response: Embedders = await client.index(index.uid).getEmbedders()
+
+      expect(response).toEqual({
+        default: {
+          ...newEmbedder.default,
+          apiKey: '<yoXXXXX...',
+        },
+      })
+    })
+
+    test(`${permission} key: Update embedders with 'huggingFace' source`, async () => {
+      const client = await getClient(permission)
+      const newEmbedder: Embedders = {
+        default: {
+          source: 'huggingFace',
+          model: 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+          documentTemplate:
+            "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
+          distribution: {
+            mean: 0.7,
+            sigma: 0.3,
+          },
         },
       }
       const task: EnqueuedTask = await client
@@ -89,14 +126,27 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
       expect(response).toEqual(newEmbedder)
     })
 
-    test(`${permission} key: Update embedders with 'huggingFace' source`, async () => {
+    test(`${permission} key: Update embedders with 'rest' source`, async () => {
       const client = await getClient(permission)
       const newEmbedder: Embedders = {
         default: {
-          source: 'huggingFace',
-          model: 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+          source: 'rest',
+          url: 'https://api.openai.com/v1/embeddings',
+          apiKey: '<your-openai-api-key>',
+          dimensions: 1536,
           documentTemplate:
             "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
+          inputField: ['input'],
+          inputType: 'textArray',
+          query: {
+            model: 'text-embedding-ada-002',
+          },
+          pathToEmbeddings: ['data'],
+          embeddingObject: ['embedding'],
+          distribution: {
+            mean: 0.7,
+            sigma: 0.3,
+          },
         },
       }
       const task: EnqueuedTask = await client
@@ -106,7 +156,42 @@ describe.each([{ permission: 'Master' }, { permission: 'Admin' }])(
 
       const response: Embedders = await client.index(index.uid).getEmbedders()
 
-      expect(response).toEqual(newEmbedder)
+      expect(response).toEqual({
+        default: {
+          ...newEmbedder.default,
+          apiKey: '<yoXXXXX...',
+        },
+      })
+    })
+
+    test(`${permission} key: Update embedders with 'ollama' source`, async () => {
+      const client = await getClient(permission)
+      const newEmbedder: Embedders = {
+        default: {
+          source: 'ollama',
+          url: 'http://localhost:11434/api/embeddings',
+          apiKey: '<your-ollama-api-key>',
+          model: 'nomic-embed-text',
+          documentTemplate: 'blabla',
+          distribution: {
+            mean: 0.7,
+            sigma: 0.3,
+          },
+        },
+      }
+      const task: EnqueuedTask = await client
+        .index(index.uid)
+        .updateEmbedders(newEmbedder)
+      await client.waitForTask(task.taskUid)
+
+      const response: Embedders = await client.index(index.uid).getEmbedders()
+
+      expect(response).toEqual({
+        default: {
+          ...newEmbedder.default,
+          apiKey: '<yoXXXXX...',
+        },
+      })
     })
 
     test(`${permission} key: Update embedders with a specific name`, async () => {

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -473,7 +473,19 @@ describe.each([
       .index(emptyIndex.uid)
       .searchGet('', { vector: [1], hybridSemanticRatio: 1.0 })
 
-    expect(response.vector).toEqual([1])
+    expect(response).toHaveProperty('hits')
+    expect(response).toHaveProperty('semanticHitCount')
+    // Those fields are no longer returned by the search response
+    // We want to ensure that they don't appear in it anymore
+    expect(response).not.toHaveProperty('vector')
+    expect(response).not.toHaveProperty('_semanticScore')
+  })
+
+  test(`${permission} key: search without vectors`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search('prince', {})
+
+    expect(response).not.toHaveProperty('semanticHitCount')
   })
 
   test(`${permission} key: Try to search on deleted index and fail`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -859,7 +859,19 @@ describe.each([
       },
     })
 
-    expect(response.vector).toEqual([1])
+    expect(response).toHaveProperty('hits')
+    expect(response).toHaveProperty('semanticHitCount')
+    // Those fields are no longer returned by the search response
+    // We want to ensure that they don't appear in it anymore
+    expect(response).not.toHaveProperty('vector')
+    expect(response).not.toHaveProperty('_semanticScore')
+  })
+
+  test(`${permission} key: search without vectors`, async () => {
+    const client = await getClient(permission)
+    const response = await client.index(index.uid).search('prince', {})
+
+    expect(response).not.toHaveProperty('semanticHitCount')
   })
 
   test(`${permission} key: Try to search on deleted index and fail`, async () => {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1641

## What does this PR do?
- Removal of the `vector` and `_semanticScore` fields from the SearchResponse
- Addition of a new `distribution` field to all embedders
- Addition of 2 new embedders: `REST` and `Ollama`
- Update failing tests & snapshots
- Addition of tests + missing tests
 
⚠️ **CI failing**

CI fails because of 2 things:
- The `distribution` field is not retrieved correctly on the `settings/embedders` routes (see https://github.com/meilisearch/meilisearch/issues/4594)
- The Ollama embedder isn't retrieved completely (see https://github.com/meilisearch/meilisearch/issues/4595 )

Once those 2 things are fixed, it should be fine 🙌

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
