### PR TITLE
Update crypto statement to fix vite issue

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -709,7 +709,7 @@ tenant_token_guide_generate_sdk_1: |-
   const apiKeyUid = '85c3c2f9-bdd6-41f1-abd8-11fcf80e0f76'
   const expiresAt = new Date('2025-12-20') // optional
 
-  const token = client.generateTenantToken(apiKeyUid, searchRules, {
+  const token = await client.generateTenantToken(apiKeyUid, searchRules, {
     apiKey: apiKey,
     expiresAt: expiresAt,
   })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.8"
-
 services:
   package:
-    image: node:16
+    image: node:18
     tty: true
     stdin_open: true
     working_dir: /home/package

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -475,11 +475,11 @@ class Client {
     _apiKeyUid: string,
     _searchRules: TokenSearchRules,
     _options?: TokenOptions
-  ): string {
+  ): Promise<string> {
     const error = new Error()
-    throw new Error(
-      `Meilisearch: failed to generate a tenant token. Generation of a token only works in a node environment \n ${error.stack}.`
-    )
+    error.message = `Meilisearch: failed to generate a tenant token. Generation of a token only works in a node environment \n ${error.stack}.`
+
+    return Promise.reject(error)
   }
 }
 

--- a/src/clients/node-client.ts
+++ b/src/clients/node-client.ts
@@ -18,15 +18,19 @@ class MeiliSearch extends Client {
    * @param options - Token options to customize some aspect of the token.
    * @returns The token in JWT format.
    */
-  generateTenantToken(
+  async generateTenantToken(
     apiKeyUid: string,
     searchRules: TokenSearchRules,
     options?: TokenOptions
-  ): string {
+  ): Promise<string> {
     if (typeof window === 'undefined') {
-      return this.tokens.generateTenantToken(apiKeyUid, searchRules, options)
+      return await this.tokens.generateTenantToken(
+        apiKeyUid,
+        searchRules,
+        options
+      )
     }
-    return super.generateTenantToken(apiKeyUid, searchRules, options)
+    return await super.generateTenantToken(apiKeyUid, searchRules, options)
   }
 }
 export { MeiliSearch }


### PR DESCRIPTION
After the introduction of this PR https://github.com/meilisearch/meilisearch-js/pull/1616 we had a bunch of issues related to vite configuration on client projects as shown here https://github.com/meilisearch/meilisearch-js-plugins/issues/1299

This PR introduces the rollback needed to fix the consumer's code. If this change is not enough, I will completely reverse the PR 1616.


Edit:

I was able to solve the issue, by using this branch with this [reproduction repo](https://github.com/flexchar/meili-issue-1299) I could build the project and also run the application without any issue.

But this change introduces some breaking changes in the JWT code:

Now it is required to use await: `await client.generateTenantToken(..)` instead of just `client.generateTenantToken(..)`.