### PR TITLE
feat: add `rankingScoreThreshold` to `searchGet`

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -125,9 +125,9 @@ export type SearchParams = Query &
     vector?: number[] | null;
     showRankingScore?: boolean;
     showRankingScoreDetails?: boolean;
+    rankingScoreThreshold?: number;
     attributesToSearchOn?: string[] | null;
     hybrid?: HybridSearch;
-    rankingScoreThreshold?: number;
   };
 
 // Search parameters for searches made with the GET method
@@ -147,6 +147,7 @@ export type SearchRequestGET = Pagination &
     attributesToSearchOn?: string | null;
     hybridEmbedder?: string;
     hybridSemanticRatio?: number;
+    rankingScoreThreshold?: number;
   };
 
 export type MultiSearchQuery = SearchParams & { indexUid: string };

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -483,9 +483,32 @@ describe.each([
 
   test(`${permission} key: search without vectors`, async () => {
     const client = await getClient(permission);
-    const response = await client.index(index.uid).search('prince', {});
+    const response = await client.index(index.uid).searchGet('prince', {});
 
     expect(response).not.toHaveProperty('semanticHitCount');
+  });
+
+  test(`${permission} key: search with rankingScoreThreshold filter`, async () => {
+    const client = await getClient(permission);
+
+    const response = await client.index(index.uid).searchGet('prince', {
+      showRankingScore: true,
+      rankingScoreThreshold: 0.8,
+    });
+
+    const hit = response.hits[0];
+
+    expect(response).toHaveProperty('hits', expect.any(Array));
+    expect(response).toHaveProperty('query', 'prince');
+    expect(hit).toHaveProperty('_rankingScore');
+    expect(hit['_rankingScore']).toBeGreaterThanOrEqual(0.8);
+
+    const response2 = await client.index(index.uid).search('prince', {
+      showRankingScore: true,
+      rankingScoreThreshold: 0.9,
+    });
+
+    expect(response2.hits.length).toBeLessThanOrEqual(0);
   });
 
   test(`${permission} key: Try to search on deleted index and fail`, async () => {


### PR DESCRIPTION
# Pull Request

## Related issue
Related to https://github.com/meilisearch/meilisearch-js/issues/1665

## What does this PR do?
- Add `rankingScoreThreshold` to `searchGet` + add related test

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
