### PR TITLE
feat: AI-powered search changes for v1.11

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -98,7 +98,7 @@ export type SearchForFacetValuesResponse = {
 };
 
 export type HybridSearch = {
-  embedder?: string;
+  embedder: string;
   semanticRatio?: number;
 };
 
@@ -389,6 +389,8 @@ export type OpenAiEmbedder = {
   dimensions?: number;
   distribution?: Distribution;
   url?: string;
+  documentTemplateMaxBytes?: number;
+  binaryQuantized?: boolean;
 };
 
 export type HuggingFaceEmbedder = {
@@ -397,12 +399,15 @@ export type HuggingFaceEmbedder = {
   revision?: string;
   documentTemplate?: string;
   distribution?: Distribution;
+  documentTemplateMaxBytes?: number;
+  binaryQuantized?: boolean;
 };
 
 export type UserProvidedEmbedder = {
   source: "userProvided";
   dimensions: number;
   distribution?: Distribution;
+  binaryQuantized?: boolean;
 };
 
 export type RestEmbedder = {
@@ -415,6 +420,8 @@ export type RestEmbedder = {
   request: Record<string, any>;
   response: Record<string, any>;
   headers?: Record<string, string>;
+  documentTemplateMaxBytes?: number;
+  binaryQuantized?: boolean;
 };
 
 export type OllamaEmbedder = {
@@ -425,6 +432,8 @@ export type OllamaEmbedder = {
   documentTemplate?: string;
   distribution?: Distribution;
   dimensions?: number;
+  documentTemplateMaxBytes?: number;
+  binaryQuantized?: boolean;
 };
 
 export type Embedder =

--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -249,8 +249,9 @@ exports[`Test on settings > Admin key: Update embedders settings  1`] = `
   "distinctAttribute": null,
   "embedders": {
     "default": {
-      "documentTemplate": "{% for field in fields %} {{ field.name }}: {{ field.value }}
-{% endfor %}",
+      "documentTemplate": "{% for field in fields %}{% if field.is_searchable and field.value != nil %}{{ field.name }}: {{ field.value }}
+{% endif %}{% endfor %}",
+      "documentTemplateMaxBytes": 400,
       "model": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "source": "huggingFace",
     },
@@ -804,8 +805,9 @@ exports[`Test on settings > Master key: Update embedders settings  1`] = `
   "distinctAttribute": null,
   "embedders": {
     "default": {
-      "documentTemplate": "{% for field in fields %} {{ field.name }}: {{ field.value }}
-{% endfor %}",
+      "documentTemplate": "{% for field in fields %}{% if field.is_searchable and field.value != nil %}{{ field.name }}: {{ field.value }}
+{% endif %}{% endfor %}",
+      "documentTemplateMaxBytes": 400,
       "model": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
       "source": "huggingFace",
     },

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -457,41 +457,6 @@ describe.each([
       "The filter query parameter should be in string format when using searchGet",
     );
   });
-  test(`${permission} key: search with vectors`, async () => {
-    const client = await getClient(permission);
-    const adminClient = await getClient("Admin");
-    const adminKey = await getKey("Admin");
-
-    await fetch(`${HOST}/experimental-features`, {
-      body: JSON.stringify({ vectorStore: true }),
-      headers: {
-        Authorization: `Bearer ${adminKey}`,
-        "Content-Type": "application/json",
-      },
-      method: "PATCH",
-    });
-
-    const { taskUid } = await adminClient
-      .index(emptyIndex.uid)
-      .updateEmbedders({
-        default: {
-          source: "userProvided",
-          dimensions: 1,
-        },
-      });
-    await adminClient.waitForTask(taskUid);
-
-    const response = await client
-      .index(emptyIndex.uid)
-      .searchGet("", { vector: [1], hybridSemanticRatio: 1.0 });
-
-    expect(response).toHaveProperty("hits");
-    expect(response).toHaveProperty("semanticHitCount");
-    // Those fields are no longer returned by the search response
-    // We want to ensure that they don't appear in it anymore
-    expect(response).not.toHaveProperty("vector");
-    expect(response).not.toHaveProperty("_semanticScore");
-  });
 
   test(`${permission} key: search without vectors`, async () => {
     const client = await getClient(permission);

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -936,45 +936,6 @@ describe.each([
     expect(response.hits.length).toEqual(0);
   });
 
-  test(`${permission} key: search with vectors`, async () => {
-    const client = await getClient(permission);
-    const adminClient = await getClient("Admin");
-    const adminKey = await getKey("Admin");
-
-    await fetch(`${HOST}/experimental-features`, {
-      body: JSON.stringify({ vectorStore: true }),
-      headers: {
-        Authorization: `Bearer ${adminKey}`,
-        "Content-Type": "application/json",
-      },
-      method: "PATCH",
-    });
-
-    const { taskUid } = await adminClient
-      .index(emptyIndex.uid)
-      .updateEmbedders({
-        default: {
-          source: "userProvided",
-          dimensions: 1,
-        },
-      });
-    await adminClient.waitForTask(taskUid);
-
-    const response = await client.index(emptyIndex.uid).search("", {
-      vector: [1],
-      hybrid: {
-        semanticRatio: 1.0,
-      },
-    });
-
-    expect(response).toHaveProperty("hits");
-    expect(response).toHaveProperty("semanticHitCount");
-    // Those fields are no longer returned by the search response
-    // We want to ensure that they don't appear in it anymore
-    expect(response).not.toHaveProperty("vector");
-    expect(response).not.toHaveProperty("_semanticScore");
-  });
-
   test(`${permission} key: search without vectors`, async () => {
     const client = await getClient(permission);
     const response = await client.index(index.uid).search("prince", {});


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1714

## What does this PR do?
- Moved the AI-search-related tests to the `embedders` test file for easier maintenance
- Adapt types related to AI-search:
  - `embedder` is now mandatory for GET and POST searches
  -  Addition of `documentTemplateMaxBytes` (except for userProvided embedders)
  - Addition of `binaryQuantized`
- Update snapshots (`documentTemplate` has been updated)
- Update tests

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
