### PR TITLE
feat: support facet distribution for federated search

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -153,8 +153,17 @@ export type SearchRequestGET = Pagination &
     locales?: Locale[];
   };
 
+export type MergeFacets = {
+  maxValuesPerFacet?: number | null;
+};
+
 export type FederationOptions = { weight: number };
-export type MultiSearchFederation = { limit?: number; offset?: number };
+export type MultiSearchFederation = {
+  limit?: number;
+  offset?: number;
+  facetsByIndex?: Record<string, string[]>;
+  mergeFacets?: MergeFacets | null;
+};
 
 export type MultiSearchQuery = SearchParams & { indexUid: string };
 export type MultiSearchQueryWithFederation = MultiSearchQuery & {
@@ -229,6 +238,14 @@ export type Hits<T = Record<string, any>> = Array<Hit<T>>;
 export type FacetStat = { min: number; max: number };
 export type FacetStats = Record<string, FacetStat>;
 
+export type FacetsByIndex = Record<
+  string,
+  {
+    distribution: FacetDistribution;
+    stats: FacetStats;
+  }
+>;
+
 export type SearchResponse<
   T = Record<string, any>,
   S extends SearchParams | undefined = undefined,
@@ -238,6 +255,7 @@ export type SearchResponse<
   query: string;
   facetDistribution?: FacetDistribution;
   facetStats?: FacetStats;
+  facetsByIndex?: FacetsByIndex;
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1713

## What does this PR do?
- Addition of the `facetsByIndex` field on multi-search requests
- Addition of the `mergeFacets` field on multi-search requests
- Addition of new tests
- Rename the indexUid of the test dataset from "movies_test" to "books" since we're sending books (no effet on the tests)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
