### PR TITLE
Add indices to matches position

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -185,7 +185,7 @@ export type CategoriesDistribution = {
 export type Facet = string;
 export type FacetDistribution = Record<Facet, CategoriesDistribution>;
 export type MatchesPosition<T> = Partial<
-  Record<keyof T, Array<{ start: number; length: number }>>
+  Record<keyof T, Array<{ start: number; length: number; indices?: number[] }>>
 >;
 
 export type RankingScoreDetails = {

--- a/tests/__snapshots__/get_search.test.ts.snap
+++ b/tests/__snapshots__/get_search.test.ts.snap
@@ -5,14 +5,21 @@ exports[`Test on GET search > Admin key: search on attributesToSearchOn set to n
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },
@@ -29,14 +36,21 @@ exports[`Test on GET search > Master key: search on attributesToSearchOn set to 
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },
@@ -53,14 +67,21 @@ exports[`Test on GET search > Search key: search on attributesToSearchOn set to 
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },

--- a/tests/__snapshots__/search.test.ts.snap
+++ b/tests/__snapshots__/search.test.ts.snap
@@ -5,16 +5,23 @@ exports[`Test on POST search > Admin key: search on attributesToSearchOn set to 
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "isNull": null,
       "isTrue": true,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },
@@ -31,16 +38,23 @@ exports[`Test on POST search > Master key: search on attributesToSearchOn set to
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "isNull": null,
       "isTrue": true,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },
@@ -57,16 +71,23 @@ exports[`Test on POST search > Search key: search on attributesToSearchOn set to
   "estimatedTotalHits": 2,
   "hits": [
     {
+      "author": "Antoine de Saint-Exupéry",
       "comment": "A french book about a prince that walks on little cute planets",
-      "genre": "adventure",
+      "genre": [
+        "adventure",
+      ],
       "id": 456,
       "isNull": null,
       "isTrue": true,
       "title": "Le Petit Prince",
     },
     {
+      "author": "J.K. Rowling",
       "comment": "The best book",
-      "genre": "fantasy",
+      "genre": [
+        "fantasy",
+        "adventure",
+      ],
       "id": 4,
       "title": "Harry Potter and the Half-Blood Prince",
     },

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -560,6 +560,17 @@ describe.each([
     expect(response.hits[0]).not.toHaveProperty("_vectors");
   });
 
+  test(`${permission} key: matches position contain indices`, async () => {
+    const client = await getClient(permission);
+    const response = await client.index(index.uid).searchGet("fantasy", {
+      showMatchesPosition: true,
+    });
+    expect(response.hits[0]._matchesPosition).toEqual({
+      genre: [{ start: 0, length: 7, indices: [0] }],
+    });
+  });
+
+  // This test deletes the index, so following tests may fail if they need an existing index
   test(`${permission} key: Try to search on deleted index and fail`, async () => {
     const client = await getClient(permission);
     const masterClient = await getClient("Master");
@@ -568,16 +579,6 @@ describe.each([
     await expect(
       client.index(index.uid).searchGet("prince"),
     ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INDEX_NOT_FOUND);
-  });
-
-  test(`${permission} key: search with match position indices`, async () => {
-    const client = await getClient(permission);
-    const response = await client.index(index.uid).search("fantasy", {
-      showMatchesPosition: true,
-    });
-    expect(response.hits[0]._matchesPosition).toEqual({
-      genre: [{ start: 0, length: 7, indices: [0] }],
-    });
   });
 });
 

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -23,39 +23,43 @@ const dataset = [
     id: 123,
     title: "Pride and Prejudice",
     comment: "A great book",
-    genre: "romance",
+    genre: ["romance", "classic"],
   },
   {
     id: 456,
     title: "Le Petit Prince",
     comment: "A french book about a prince that walks on little cute planets",
-    genre: "adventure",
+    genre: ["adventure", "fantasy"],
   },
   {
     id: 2,
     title: "Le Rouge et le Noir",
     comment: "Another french book",
-    genre: "romance",
+    genre: ["romance", "classic"],
   },
   {
     id: 1,
     title: "Alice In Wonderland",
     comment: "A weird book",
-    genre: "adventure",
+    genre: ["adventure", "fantasy"],
   },
   {
     id: 1344,
     title: "The Hobbit",
     comment: "An awesome book",
-    genre: "sci fi",
+    genre: ["sci-fi", "fantasy", "adventure"],
   },
   {
     id: 4,
     title: "Harry Potter and the Half-Blood Prince",
     comment: "The best book",
-    genre: "fantasy",
+    genre: ["fantasy", "adventure"],
   },
-  { id: 42, title: "The Hitchhiker's Guide to the Galaxy", genre: "fantasy" },
+  {
+    id: 42,
+    title: "The Hitchhiker's Guide to the Galaxy",
+    genre: ["fantasy", "sci-fi", "comedy"]
+  },
 ];
 
 afterAll(() => {
@@ -189,7 +193,7 @@ describe.each([
         id: 4,
         title: "Harry Potter and the Half-Blood Prince",
         comment: "The best book",
-        genre: "fantasy",
+        genre: ["fantasy", "adventure"],
       },
     ]);
     expect(response).toHaveProperty("offset", 1);

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -22,43 +22,56 @@ const dataset = [
   {
     id: 123,
     title: "Pride and Prejudice",
+    author: "Jane Austen",
     comment: "A great book",
-    genre: ["romance", "classic"],
+    genre: ["romance"],
   },
   {
     id: 456,
     title: "Le Petit Prince",
+    author: "Antoine de Saint-Exupéry",
     comment: "A french book about a prince that walks on little cute planets",
-    genre: ["adventure", "fantasy"],
+    genre: ["adventure"],
   },
   {
     id: 2,
     title: "Le Rouge et le Noir",
+    author: "Stendhal",
     comment: "Another french book",
-    genre: ["romance", "classic"],
+    genre: ["romance"],
   },
   {
     id: 1,
     title: "Alice In Wonderland",
+    author: "Lewis Carroll",
     comment: "A weird book",
-    genre: ["adventure", "fantasy"],
+    genre: ["adventure"],
   },
   {
     id: 1344,
     title: "The Hobbit",
+    author: "J.R.R. Tolkien",
     comment: "An awesome book",
-    genre: ["sci-fi", "fantasy", "adventure"],
+    genre: ["fantasy", "adventure"],
   },
   {
     id: 4,
     title: "Harry Potter and the Half-Blood Prince",
+    author: "J.K. Rowling",
     comment: "The best book",
+    genre: ["fantasy", "adventure"],
+  },
+  {
+    id: 5,
+    title: "Harry Potter and the Deathly Hallows",
+    author: "J.K. Rowling",
     genre: ["fantasy", "adventure"],
   },
   {
     id: 42,
     title: "The Hitchhiker's Guide to the Galaxy",
-    genre: ["fantasy", "sci-fi", "comedy"]
+    author: "Douglas Adams",
+    genre: ["sci fi", "comedy"]
   },
 ];
 
@@ -79,7 +92,7 @@ describe.each([
     const { taskUid: task2 } = await client.createIndex(emptyIndex.uid);
     await client.waitForTask(task2);
 
-    const newFilterableAttributes = ["genre", "title", "id"];
+    const newFilterableAttributes = ["genre", "title", "id", "author"];
     const { taskUid: task3 }: EnqueuedTask = await client
       .index(index.uid)
       .updateSettings({
@@ -192,6 +205,7 @@ describe.each([
       {
         id: 4,
         title: "Harry Potter and the Half-Blood Prince",
+        author: "J.K. Rowling",
         comment: "The best book",
         genre: ["fantasy", "adventure"],
       },
@@ -419,9 +433,9 @@ describe.each([
       facets: ["genre"],
     });
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: { adventure: 3, fantasy: 3 },
     });
-    expect(response.hits.length).toEqual(2);
+    expect(response.hits.length).toEqual(3);
   });
 
   test(`${permission} key: search with multiple filter and null query (placeholder)`, async () => {
@@ -431,10 +445,13 @@ describe.each([
       facets: ["genre"],
     });
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: {
+        adventure: 3,
+        fantasy: 3
+      },
     });
-    expect(response.hits.length).toEqual(2);
-    expect(response.estimatedTotalHits).toEqual(2);
+    expect(response.hits.length).toEqual(3);
+    expect(response.estimatedTotalHits).toEqual(3);
   });
 
   test(`${permission} key: search with multiple filter and empty string query (placeholder)`, async () => {
@@ -445,9 +462,9 @@ describe.each([
     });
 
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: { adventure: 3, fantasy: 3 },
     });
-    expect(response.hits.length).toEqual(2);
+    expect(response.hits.length).toEqual(3);
   });
 
   test(`${permission} key: Try to search with wrong format filter`, async () => {
@@ -496,9 +513,9 @@ describe.each([
     const client = await getClient(permission);
     const response = await client
       .index(index.uid)
-      .search("", { distinct: "genre" });
+      .search("", { distinct: "author" });
 
-    expect(response.hits.length).toEqual(4);
+    expect(response.hits.length).toEqual(7);
   });
 
   test(`${permission} key: search with retrieveVectors to true`, async () => {

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -71,7 +71,7 @@ const dataset = [
     id: 42,
     title: "The Hitchhiker's Guide to the Galaxy",
     author: "Douglas Adams",
-    genre: ["sci fi", "comedy"]
+    genre: ["sci fi", "comedy"],
   },
 ];
 
@@ -447,7 +447,7 @@ describe.each([
     expect(response).toHaveProperty("facetDistribution", {
       genre: {
         adventure: 3,
-        fantasy: 3
+        fantasy: 3,
       },
     });
     expect(response.hits.length).toEqual(3);

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -569,6 +569,16 @@ describe.each([
       client.index(index.uid).searchGet("prince"),
     ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INDEX_NOT_FOUND);
   });
+
+  test(`${permission} key: search with match position indices`, async () => {
+    const client = await getClient(permission);
+    const response = await client.index(index.uid).search("fantasy", {
+      showMatchesPosition: true,
+    });
+    expect(response.hits[0]._matchesPosition).toEqual({
+      genre: [{ start: 0, length: 7, indices: [0] }],
+    });
+  });
 });
 
 describe.each([

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -42,42 +42,59 @@ const dataset = [
   {
     id: 123,
     title: "Pride and Prejudice",
+    author: "Jane Austen",
     comment: "A great book",
-    genre: "romance",
+    genre: ["romance"],
   },
   {
     id: 456,
     title: "Le Petit Prince",
+    author: "Antoine de Saint-Exupéry",
     comment: "A french book about a prince that walks on little cute planets",
-    genre: "adventure",
+    genre: ["adventure"],
     isNull: null,
     isTrue: true,
   },
   {
     id: 2,
     title: "Le Rouge et le Noir",
+    author: "Stendhal",
     comment: "Another french book",
-    genre: "romance",
+    genre: ["romance"],
   },
   {
     id: 1,
     title: "Alice In Wonderland",
+    author: "Lewis Carroll",
     comment: "A weird book",
-    genre: "adventure",
+    genre: ["adventure"],
   },
   {
     id: 1344,
     title: "The Hobbit",
+    author: "J.R.R. Tolkien",
     comment: "An awesome book",
-    genre: "sci fi",
+    genre: ["fantasy", "adventure"],
   },
   {
     id: 4,
     title: "Harry Potter and the Half-Blood Prince",
+    author: "J.K. Rowling",
     comment: "The best book",
-    genre: "fantasy",
+    genre: ["fantasy", "adventure"],
   },
-  { id: 42, title: "The Hitchhiker's Guide to the Galaxy", genre: "fantasy" },
+  {
+    id: 5,
+    title: "Harry Potter and the Deathly Hallows",
+    author: "J.K. Rowling",
+    genre: ["fantasy", "adventure"],
+  },
+  {
+    id: 42,
+    title: "The Hitchhiker's Guide to the Galaxy",
+    author: "Douglas Adams",
+    genre: ["sci fi", "comedy"]
+  },
 ];
 
 type Movies = {
@@ -111,7 +128,7 @@ describe.each([
     await client.createIndex(index.uid);
     await client.createIndex(emptyIndex.uid);
 
-    const newFilterableAttributes = ["genre", "title", "id"];
+    const newFilterableAttributes = ["genre", "title", "id", "author"];
     const { taskUid: task1 }: EnqueuedTask = await client
       .index(index.uid)
       .updateSettings({
@@ -634,9 +651,10 @@ describe.each([
     expect(response).toHaveProperty("hits", [
       {
         id: 4,
+        author: "J.K. Rowling",
         title: "Harry Potter and the Half-Blood Prince",
         comment: "The best book",
-        genre: "fantasy",
+        genre: ["fantasy", "adventure"],
       },
     ]);
     expect(response).toHaveProperty("offset", 1);
@@ -896,9 +914,9 @@ describe.each([
       facets: ["genre"],
     });
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: { adventure: 3, fantasy: 3 },
     });
-    expect(response.hits.length).toEqual(2);
+    expect(response.hits.length).toEqual(3);
   });
 
   test(`${permission} key: search with multiple filter and null query (placeholder)`, async () => {
@@ -908,9 +926,9 @@ describe.each([
       facets: ["genre"],
     });
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: { adventure: 3, fantasy: 3 },
     });
-    expect(response.hits.length).toEqual(2);
+    expect(response.hits.length).toEqual(3);
   });
 
   test(`${permission} key: search with multiple filter and empty string query (placeholder)`, async () => {
@@ -920,9 +938,9 @@ describe.each([
       facets: ["genre"],
     });
     expect(response).toHaveProperty("facetDistribution", {
-      genre: { fantasy: 2 },
+      genre: { adventure: 3, fantasy: 3 },
     });
-    expect(response.hits.length).toEqual(2);
+    expect(response.hits.length).toEqual(3);
   });
 
   test(`${permission} key: search with pagination parameters: hitsPerPage and page`, async () => {
@@ -934,10 +952,10 @@ describe.each([
     });
 
     expect(response.hits.length).toEqual(1);
-    expect(response.totalPages).toEqual(7);
+    expect(response.totalPages).toEqual(8);
     expect(response.hitsPerPage).toEqual(1);
     expect(response.page).toEqual(1);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters: hitsPerPage at 0 and page at 1`, async () => {
@@ -952,7 +970,7 @@ describe.each([
     expect(response.hitsPerPage).toEqual(0);
     expect(response.page).toEqual(1);
     expect(response.totalPages).toEqual(0);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters: hitsPerPage at 0`, async () => {
@@ -966,7 +984,7 @@ describe.each([
     expect(response.hitsPerPage).toEqual(0);
     expect(response.page).toEqual(1);
     expect(response.totalPages).toEqual(0);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalHits).toEqual(8);
     // @ts-expect-error Not present in the SearchResponse type because `page` and/or `hitsPerPage` is provided in the search params.
     expect(response.limit).toBeUndefined();
     // @ts-expect-error Not present in the SearchResponse type because `page` and/or `hitsPerPage` is provided in the search params.
@@ -986,8 +1004,8 @@ describe.each([
     expect(response.hits.length).toEqual(0);
     expect(response.hitsPerPage).toEqual(1);
     expect(response.page).toEqual(0);
-    expect(response.totalPages).toEqual(7);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalPages).toEqual(8);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters: page at 0`, async () => {
@@ -1001,7 +1019,7 @@ describe.each([
     expect(response.hitsPerPage).toEqual(20);
     expect(response.page).toEqual(0);
     expect(response.totalPages).toEqual(1);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters: hitsPerPage at 0 and page at 0`, async () => {
@@ -1024,7 +1042,7 @@ describe.each([
     expect(response.hitsPerPage).toEqual(0);
     expect(response.page).toEqual(0);
     expect(response.totalPages).toEqual(0);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters hitsPerPage/page and offset/limit`, async () => {
@@ -1046,8 +1064,8 @@ describe.each([
     expect(response.estimatedTotalHits).toBeUndefined();
     expect(response.hitsPerPage).toEqual(1);
     expect(response.page).toEqual(1);
-    expect(response.totalPages).toEqual(7);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalPages).toEqual(8);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters hitsPerPage/page and offset`, async () => {
@@ -1068,8 +1086,8 @@ describe.each([
     expect(response.estimatedTotalHits).toBeUndefined();
     expect(response.hitsPerPage).toEqual(1);
     expect(response.page).toEqual(1);
-    expect(response.totalHits).toEqual(7);
-    expect(response.totalPages).toEqual(7);
+    expect(response.totalHits).toEqual(8);
+    expect(response.totalPages).toEqual(8);
   });
 
   test(`${permission} key: search with pagination parameters hitsPerPage/page and limit`, async () => {
@@ -1090,8 +1108,8 @@ describe.each([
     expect(response.estimatedTotalHits).toBeUndefined();
     expect(response.page).toEqual(1);
     expect(response.hitsPerPage).toEqual(1);
-    expect(response.totalPages).toEqual(7);
-    expect(response.totalHits).toEqual(7);
+    expect(response.totalPages).toEqual(8);
+    expect(response.totalHits).toEqual(8);
   });
 
   test(`${permission} key: search on index with no documents and no primary key`, async () => {
@@ -1114,9 +1132,9 @@ describe.each([
     const client = await getClient(permission);
     const response = await client
       .index(index.uid)
-      .search("", { distinct: "genre" });
+      .search("", { distinct: "author" });
 
-    expect(response.hits.length).toEqual(4);
+    expect(response.hits.length).toEqual(7);
   });
 
   test(`${permission} key: search with retrieveVectors to true`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -93,7 +93,7 @@ const dataset = [
     id: 42,
     title: "The Hitchhiker's Guide to the Galaxy",
     author: "Douglas Adams",
-    genre: ["sci fi", "comedy"]
+    genre: ["sci fi", "comedy"],
   },
 ];
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1207,6 +1207,16 @@ describe.each([
       client.index(index.uid).search("prince", {}),
     ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INDEX_NOT_FOUND);
   });
+
+  test(`${permission} key: search with match position indices`, async () => {
+    const client = await getClient(permission);
+    const response = await client.index(index.uid).search("fantasy", {
+      showMatchesPosition: true,
+    });
+    expect(response.hits[0]._matchesPosition).toEqual({
+      genre: [{ start: 0, length: 7, indices: [0] }],
+    });
+  });
 });
 
 describe.each([{ permission: "No" }])(

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1197,6 +1197,17 @@ describe.each([
     expect(searchResponse.hits.length).toEqual(2);
   });
 
+  test(`${permission} key: matches position contain indices`, async () => {
+    const client = await getClient(permission);
+    const response = await client.index(index.uid).search("fantasy", {
+      showMatchesPosition: true,
+    });
+    expect(response.hits[0]._matchesPosition).toEqual({
+      genre: [{ start: 0, length: 7, indices: [0] }],
+    });
+  });
+
+  // This test deletes the index, so following tests may fail if they need an existing index
   test(`${permission} key: Try to search on deleted index and fail`, async () => {
     const client = await getClient(permission);
     const masterClient = await getClient("Master");
@@ -1206,16 +1217,6 @@ describe.each([
     await expect(
       client.index(index.uid).search("prince", {}),
     ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INDEX_NOT_FOUND);
-  });
-
-  test(`${permission} key: search with match position indices`, async () => {
-    const client = await getClient(permission);
-    const response = await client.index(index.uid).search("fantasy", {
-      showMatchesPosition: true,
-    });
-    expect(response.hits[0]._matchesPosition).toEqual({
-      genre: [{ start: 0, length: 7, indices: [0] }],
-    });
   });
 });
 

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -28,7 +28,7 @@ interface Movie {
   id: number;
   title: string;
   comment?: string;
-  genre?: string;
+  genre?: string[];
   isNull?: null;
   isTrue?: boolean;
 }
@@ -46,42 +46,59 @@ const dataset = [
   {
     id: 123,
     title: "Pride and Prejudice",
+    author: "Jane Austen",
     comment: "A great book",
-    genre: "romance",
+    genre: ["romance"],
   },
   {
     id: 456,
     title: "Le Petit Prince",
+    author: "Antoine de Saint-Exupéry",
     comment: "A french book about a prince that walks on little cute planets",
-    genre: "adventure",
+    genre: ["adventure"],
     isNull: null,
     isTrue: true,
   },
   {
     id: 2,
     title: "Le Rouge et le Noir",
+    author: "Stendhal",
     comment: "Another french book",
-    genre: "romance",
+    genre: ["romance"],
   },
   {
     id: 1,
     title: "Alice In Wonderland",
+    author: "Lewis Carroll",
     comment: "A weird book",
-    genre: "adventure",
+    genre: ["adventure"],
   },
   {
     id: 1344,
     title: "The Hobbit",
+    author: "J.R.R. Tolkien",
     comment: "An awesome book",
-    genre: "sci fi",
+    genre: ["fantasy", "adventure"],
   },
   {
     id: 4,
     title: "Harry Potter and the Half-Blood Prince",
+    author: "J.K. Rowling",
     comment: "The best book",
-    genre: "fantasy",
+    genre: ["fantasy", "adventure"],
   },
-  { id: 42, title: "The Hitchhiker's Guide to the Galaxy", genre: "fantasy" },
+  {
+    id: 5,
+    title: "Harry Potter and the Deathly Hallows",
+    author: "J.K. Rowling",
+    genre: ["fantasy", "adventure"],
+  },
+  {
+    id: 42,
+    title: "The Hitchhiker's Guide to the Galaxy",
+    author: "Douglas Adams",
+    genre: ["sci fi", "comedy"]
+  },
 ];
 
 afterAll(() => {
@@ -162,7 +179,7 @@ describe.each([
       "Harry Potter and the Half-Blood Prince",
     );
     expect(response.hits[0].comment).toEqual("The best book");
-    expect(response.hits[0].genre).toEqual("fantasy");
+    expect(response.hits[0].genre).toEqual(["fantasy", "adventure"]);
     expect(response.query === "prince").toBeTruthy();
   });
 
@@ -340,8 +357,8 @@ describe.each([
       filter: ["genre = fantasy"],
       facets: ["genre"],
     });
-    expect(response.facetDistribution?.genre?.fantasy === 2).toBeTruthy();
-    expect(response.hits.length === 2).toBeTruthy();
+    expect(response.facetDistribution?.genre?.fantasy === 3).toBeTruthy();
+    expect(response.hits.length === 3).toBeTruthy();
   });
 
   test(`${permission} key: Search with multiple filter and placeholder search using NULL`, async () => {
@@ -350,8 +367,8 @@ describe.each([
       filter: ["genre = fantasy"],
       facets: ["genre"],
     });
-    expect(response.facetDistribution?.genre?.fantasy === 2).toBeTruthy();
-    expect(response.hits.length === 2).toBeTruthy();
+    expect(response.facetDistribution?.genre?.fantasy === 3).toBeTruthy();
+    expect(response.hits.length === 3).toBeTruthy();
   });
 
   test(`${permission} key: Search on index with no documents and no primary key`, async () => {
@@ -375,8 +392,8 @@ describe.each([
     expect(response.hits.length).toEqual(1);
     expect(response.hitsPerPage === 1).toBeTruthy();
     expect(response.page === 1).toBeTruthy();
-    expect(response.totalPages === 7).toBeTruthy();
-    expect(response.totalHits === 7).toBeTruthy();
+    expect(response.totalPages === 8).toBeTruthy();
+    expect(response.totalHits === 8).toBeTruthy();
   });
 
   test(`${permission} key: Try to Search on deleted index and fail`, async () => {

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -97,7 +97,7 @@ const dataset = [
     id: 42,
     title: "The Hitchhiker's Guide to the Galaxy",
     author: "Douglas Adams",
-    genre: ["sci fi", "comedy"]
+    genre: ["sci fi", "comedy"],
   },
 ];
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1772 

## What does this PR do?
- Updates the dataset used in tests so `genre` is an array
- Updates the tests to still work after making `genre` an array
- Uses the new `genre` array to test that `_matchesPosition` return the correct value when matching against arrays
