### PR TITLE
Updated Type definition for multiSearch return types for better TS support

### DIFF
--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -29,9 +29,8 @@ import {
   CancelTasksQuery,
   DeleteTasksQuery,
   MultiSearchParams,
-  MultiSearchResponse,
-  SearchResponse,
   FederatedMultiSearchParams,
+  MultiSearchResponseOrSearchResponse,
 } from "./types";
 import { HttpRequests } from "./http-requests";
 import { TaskClient, Task } from "./task";
@@ -214,18 +213,13 @@ export class MeiliSearch {
    * @param config - Additional request configuration options
    * @returns Promise containing the search responses
    */
-  multiSearch<T extends Record<string, unknown> = Record<string, any>>(
-    queries: MultiSearchParams,
+  async multiSearch<
+    T1 extends MultiSearchParams | FederatedMultiSearchParams,
+    T2 extends Record<string, unknown> = Record<string, any>,
+  >(
+    queries: T1,
     config?: Partial<Request>,
-  ): Promise<MultiSearchResponse<T>>;
-  multiSearch<T extends Record<string, unknown> = Record<string, any>>(
-    queries: FederatedMultiSearchParams,
-    config?: Partial<Request>,
-  ): Promise<SearchResponse<T>>;
-  async multiSearch<T extends Record<string, unknown> = Record<string, any>>(
-    queries: MultiSearchParams | FederatedMultiSearchParams,
-    config?: Partial<Request>,
-  ): Promise<MultiSearchResponse<T> | SearchResponse<T>> {
+  ): Promise<MultiSearchResponseOrSearchResponse<T1, T2>> {
     const url = `multi-search`;
 
     return await this.httpRequest.post(url, queries, undefined, config);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -299,6 +299,13 @@ export type MultiSearchResponse<T = Record<string, any>> = {
   results: Array<MultiSearchResult<T>>;
 };
 
+export type MultiSearchResponseOrSearchResponse<
+  T1 extends FederatedMultiSearchParams | MultiSearchParams,
+  T2 extends Record<string, unknown> = Record<string, any>,
+> = T1 extends FederatedMultiSearchParams
+  ? SearchResponse<T2>
+  : MultiSearchResponse<T2>;
+
 export type FieldDistribution = {
   [field: string]: number;
 };


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1767 

## What does this PR do?
- Added a conditional return type for the `multiSearch`function, so now if the _query_ is of type `MultiSearchParams` it should return a `MultiSearchResponse` type and if the _query_ is `FederatedMultiSearchParams` it should return `SearchResponse`

So if we have a query that contains the `federation` option the type is infered correctly:

![multisearch1](https://github.com/user-attachments/assets/3972a581-0523-4cac-a52e-28d6f21f6d7b)

Same goes when we leave it out:

![multisearch2](https://github.com/user-attachments/assets/dbe3be2e-fe84-47cd-99a7-3fe27686d469)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
