### PR TITLE
Update CONTRIBUTING.md with minimal Node version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ First of all, thank you for contributing to Meilisearch! The goal of this docume
 
 To run this project, you will need:
 
-- Node.js >= v14 and node <= 18
+- Node.js >= v16 and node <= 18
 - Yarn
-
+- vitest
 
 ### Setup
 


### PR DESCRIPTION
with the minimum version of node required

Hey, I tried to run the test and encountered multiple errors coming from our outdated `CONTRIBUTING.md`.

It says the minimum version of node supported is the v14, but when I tried it gave me this error:
![image](https://github.com/user-attachments/assets/1dc3eabf-dba3-48b4-8849-9e27613caf5b)

Then I tried the v15 and it gave me this error:
![image](https://github.com/user-attachments/assets/4ded7fb2-11a4-45ea-9dde-4a9b706d5dd5)

Finally, the v16 worked, so the range of accepted version should be v16 to v18.

-----

Then I tried to run the tests, which doesn't work anymore because apparently we now requires the installation of vitest