### PR TITLE
Add new `prefixSearch` and `facetSearch` index settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,26 @@ client.index('myIndex').updateFacetSearch(enabled: boolean): Promise<EnqueuedTas
 client.index('myIndex').resetFacetSearch(): Promise<EnqueuedTask>
 ```
 
+### Prefix search settings <!-- omit in toc -->
+
+#### [Get prefix search settings](https://www.meilisearch.com/docs/reference/api/settings#get-prefix-search-settings)
+
+```ts
+client.index('myIndex').getPrefixSearch(): Promise<PrefixSearch>
+```
+
+#### [Update prefix search settings](https://www.meilisearch.com/docs/reference/api/settings#update-prefix-search-settings)
+
+```ts
+client.index('myIndex').updatePrefixSearch(prefixSearch: PrefixSearch): Promise<EnqueuedTask>
+```
+
+#### [Reset prefix search settings](https://www.meilisearch.com/docs/reference/api/settings#reset-prefix-search-settings)
+
+```ts
+client.index('myIndex').resetPrefixSearch(): Promise<EnqueuedTask>
+```
+
 ### Embedders <!-- omit in toc -->
 
 ⚠️ This feature is experimental. Activate the [`vectorStore` experimental feature to use it](https://www.meilisearch.com/docs/reference/api/experimental_features#configure-experimental-features)

--- a/README.md
+++ b/README.md
@@ -981,6 +981,26 @@ client.index('myIndex').updateProximityPrecision(proximityPrecision: ProximityPr
 client.index('myIndex').resetProximityPrecision(): Promise<EnqueuedTask>
 ```
 
+### Facet search settings <!-- omit in toc -->
+
+#### [Get facet search settings](https://www.meilisearch.com/docs/reference/api/settings#get-facet-search-settings)
+
+```ts
+client.index('myIndex').getFacetSearch(): Promise<boolean>
+```
+
+#### [Update facet search settings](https://www.meilisearch.com/docs/reference/api/settings#update-facet-search-settings)
+
+```ts
+client.index('myIndex').updateFacetSearch(enabled: boolean): Promise<EnqueuedTask>
+```
+
+#### [Reset facet search settings](https://www.meilisearch.com/docs/reference/api/settings#reset-facet-search-settings)
+
+```ts
+client.index('myIndex').resetFacetSearch(): Promise<EnqueuedTask>
+```
+
 ### Embedders <!-- omit in toc -->
 
 ⚠️ This feature is experimental. Activate the [`vectorStore` experimental feature to use it](https://www.meilisearch.com/docs/reference/api/experimental_features#configure-experimental-features)

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -1457,6 +1457,39 @@ class Index<T extends Record<string, any> = Record<string, any>> {
 
     return new EnqueuedTask(task);
   }
+
+  /**
+   * Get the facet search settings.
+   *
+   * @returns Promise containing object of facet search settings
+   */
+  async getFacetSearch(): Promise<boolean> {
+    const url = `indexes/${this.uid}/settings/facet-search`;
+    return await this.httpRequest.get<boolean>(url);
+  }
+
+  /**
+   * Update the facet search settings.
+   *
+   * @param facetSearch - Boolean value
+   * @returns Promise containing an EnqueuedTask
+   */
+  async updateFacetSearch(facetSearch: boolean): Promise<EnqueuedTask> {
+    const url = `indexes/${this.uid}/settings/facet-search`;
+    return await this.httpRequest.put(url, facetSearch);
+  }
+
+  /**
+   * Reset the facet search settings.
+   *
+   * @returns Promise containing an EnqueuedTask
+   */
+  async resetFacetSearch(): Promise<EnqueuedTask> {
+    const url = `indexes/${this.uid}/settings/facet-search`;
+    const task = await this.httpRequest.delete(url);
+
+    return new EnqueuedTask(task);
+  }
 }
 
 export { Index };

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -1532,7 +1532,6 @@ class Index<T extends Record<string, any> = Record<string, any>> {
     const task = await this.httpRequest.delete(url);
     return new EnqueuedTask(task);
   }
-
 }
 
 export { Index };

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -56,6 +56,7 @@ import {
   SearchSimilarDocumentsParams,
   LocalizedAttributes,
   UpdateDocumentsByFunctionOptions,
+  PrefixSearch,
 } from "./types";
 import { removeUndefinedFromObject } from "./utils";
 import { HttpRequests } from "./http-requests";
@@ -1458,6 +1459,10 @@ class Index<T extends Record<string, any> = Record<string, any>> {
     return new EnqueuedTask(task);
   }
 
+  ///
+  /// FACET SEARCH SETTINGS
+  ///
+
   /**
    * Get the facet search settings.
    *
@@ -1476,7 +1481,8 @@ class Index<T extends Record<string, any> = Record<string, any>> {
    */
   async updateFacetSearch(facetSearch: boolean): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/facet-search`;
-    return await this.httpRequest.put(url, facetSearch);
+    const task = await this.httpRequest.put(url, facetSearch);
+    return new EnqueuedTask(task);
   }
 
   /**
@@ -1487,9 +1493,46 @@ class Index<T extends Record<string, any> = Record<string, any>> {
   async resetFacetSearch(): Promise<EnqueuedTask> {
     const url = `indexes/${this.uid}/settings/facet-search`;
     const task = await this.httpRequest.delete(url);
-
     return new EnqueuedTask(task);
   }
+
+  ///
+  /// PREFIX SEARCH SETTINGS
+  ///
+
+  /**
+   * Get the prefix search settings.
+   *
+   * @returns Promise containing object of prefix search settings
+   */
+  async getPrefixSearch(): Promise<PrefixSearch> {
+    const url = `indexes/${this.uid}/settings/prefix-search`;
+    return await this.httpRequest.get<PrefixSearch>(url);
+  }
+
+  /**
+   * Update the prefix search settings.
+   *
+   * @param prefixSearch - PrefixSearch value
+   * @returns Promise containing an EnqueuedTask
+   */
+  async updatePrefixSearch(prefixSearch: PrefixSearch): Promise<EnqueuedTask> {
+    const url = `indexes/${this.uid}/settings/prefix-search`;
+    const task = await this.httpRequest.put(url, prefixSearch);
+    return new EnqueuedTask(task);
+  }
+
+  /**
+   * Reset the prefix search settings.
+   *
+   * @returns Promise containing an EnqueuedTask
+   */
+  async resetPrefixSearch(): Promise<EnqueuedTask> {
+    const url = `indexes/${this.uid}/settings/prefix-search`;
+    const task = await this.httpRequest.delete(url);
+    return new EnqueuedTask(task);
+  }
+
 }
 
 export { Index };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -491,7 +491,7 @@ export type LocalizedAttribute = {
 
 export type LocalizedAttributes = LocalizedAttribute[] | null;
 
-export type PrefixSearch = 'indexingTime' | 'disabled';
+export type PrefixSearch = "indexingTime" | "disabled";
 
 export type Settings = {
   filterableAttributes?: FilterableAttributes;
@@ -513,14 +513,10 @@ export type Settings = {
   searchCutoffMs?: SearchCutoffMs;
   localizedAttributes?: LocalizedAttributes;
 
-  /**
-   * Enable facet searching on all the filters of an index.
-   */
+  /** Enable facet searching on all the filters of an index. */
   facetSearch?: boolean;
-  /**
-   * Enable the ability to search a word by prefix on an index.
-   */
-  prefixSearch?: 'indexingTime' | 'disabled';
+  /** Enable the ability to search a word by prefix on an index. */
+  prefixSearch?: "indexingTime" | "disabled";
 };
 
 /*

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -510,6 +510,15 @@ export type Settings = {
   embedders?: Embedders;
   searchCutoffMs?: SearchCutoffMs;
   localizedAttributes?: LocalizedAttributes;
+
+  /**
+   * Enable facet searching on all the filters of an index.
+   */
+  facetSearch?: boolean;
+  /**
+   * Enable the ability to search a word by prefix on an index.
+   */
+  prefixSearch?: 'indexingTime' | false;
 };
 
 /*

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -513,9 +513,9 @@ export type Settings = {
   searchCutoffMs?: SearchCutoffMs;
   localizedAttributes?: LocalizedAttributes;
 
-  /** Enable facet searching on all the filters of an index. */
+  /** Enable facet searching on all the filters of an index (requires Meilisearch 1.12.0 or later) */
   facetSearch?: boolean;
-  /** Enable the ability to search a word by prefix on an index. */
+  /** Enable the ability to search a word by prefix on an index (requires Meilisearch 1.12.0 or later) */
   prefixSearch?: "indexingTime" | "disabled";
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -513,9 +513,15 @@ export type Settings = {
   searchCutoffMs?: SearchCutoffMs;
   localizedAttributes?: LocalizedAttributes;
 
-  /** Enable facet searching on all the filters of an index (requires Meilisearch 1.12.0 or later) */
+  /**
+   * Enable facet searching on all the filters of an index (requires Meilisearch
+   * 1.12.0 or later)
+   */
   facetSearch?: boolean;
-  /** Enable the ability to search a word by prefix on an index (requires Meilisearch 1.12.0 or later) */
+  /**
+   * Enable the ability to search a word by prefix on an index (requires
+   * Meilisearch 1.12.0 or later)
+   */
   prefixSearch?: "indexingTime" | "disabled";
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -491,6 +491,8 @@ export type LocalizedAttribute = {
 
 export type LocalizedAttributes = LocalizedAttribute[] | null;
 
+export type PrefixSearch = 'indexingTime' | 'disabled';
+
 export type Settings = {
   filterableAttributes?: FilterableAttributes;
   distinctAttribute?: DistinctAttribute;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -518,7 +518,7 @@ export type Settings = {
   /**
    * Enable the ability to search a word by prefix on an index.
    */
-  prefixSearch?: 'indexingTime' | false;
+  prefixSearch?: 'indexingTime' | 'disabled';
 };
 
 /*

--- a/tests/__snapshots__/facet_search_settings.test.ts.snap
+++ b/tests/__snapshots__/facet_search_settings.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Test on facet search settings > Admin key: Get facetSearch settings on empty index 1`] = `true`;
+
+exports[`Test on facet search settings > Admin key: Reset facetSearch settings on an empty index 1`] = `true`;
+
+exports[`Test on facet search settings > Master key: Get facetSearch settings on empty index 1`] = `true`;
+
+exports[`Test on facet search settings > Master key: Reset facetSearch settings on an empty index 1`] = `true`;

--- a/tests/__snapshots__/prefix_search_settings.test.ts.snap
+++ b/tests/__snapshots__/prefix_search_settings.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Test on prefix search settings > Admin key: Get prefixSearch settings on empty index 1`] = `"indexingTime"`;
+
+exports[`Test on prefix search settings > Admin key: Reset prefixSearch settings on an empty index 1`] = `"indexingTime"`;
+
+exports[`Test on prefix search settings > Master key: Get prefixSearch settings on empty index 1`] = `"indexingTime"`;
+
+exports[`Test on prefix search settings > Master key: Reset prefixSearch settings on an empty index 1`] = `"indexingTime"`;

--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -309,6 +309,106 @@ exports[`Test on settings > Admin key: Update embedders settings  1`] = `
 }
 `;
 
+exports[`Test on settings > Admin key: Update facetSearch settings on empty index 1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "facetSearch": false,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "localizedAttributes": null,
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "prefixSearch": "indexingTime",
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings > Admin key: Update prefixSearch settings on an empty index 1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "facetSearch": true,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "localizedAttributes": null,
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "prefixSearch": "disabled",
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
 exports[`Test on settings > Admin key: Update searchableAttributes settings on empty index 1`] = `
 {
   "dictionary": [],
@@ -858,6 +958,106 @@ exports[`Test on settings > Master key: Update embedders settings  1`] = `
     "maxTotalHits": 1000,
   },
   "prefixSearch": "indexingTime",
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings > Master key: Update facetSearch settings on empty index 1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "facetSearch": false,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "localizedAttributes": null,
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "prefixSearch": "indexingTime",
+  "proximityPrecision": "byWord",
+  "rankingRules": [
+    "words",
+    "typo",
+    "proximity",
+    "attribute",
+    "sort",
+    "exactness",
+  ],
+  "searchCutoffMs": null,
+  "searchableAttributes": [
+    "*",
+  ],
+  "separatorTokens": [],
+  "sortableAttributes": [],
+  "stopWords": [],
+  "synonyms": {},
+  "typoTolerance": {
+    "disableOnAttributes": [],
+    "disableOnWords": [],
+    "enabled": true,
+    "minWordSizeForTypos": {
+      "oneTypo": 5,
+      "twoTypos": 9,
+    },
+  },
+}
+`;
+
+exports[`Test on settings > Master key: Update prefixSearch settings on an empty index 1`] = `
+{
+  "dictionary": [],
+  "displayedAttributes": [
+    "*",
+  ],
+  "distinctAttribute": null,
+  "facetSearch": true,
+  "faceting": {
+    "maxValuesPerFacet": 100,
+    "sortFacetValuesBy": {
+      "*": "alpha",
+    },
+  },
+  "filterableAttributes": [],
+  "localizedAttributes": null,
+  "nonSeparatorTokens": [],
+  "pagination": {
+    "maxTotalHits": 1000,
+  },
+  "prefixSearch": "disabled",
   "proximityPrecision": "byWord",
   "rankingRules": [
     "words",

--- a/tests/facet_search_settings.test.ts
+++ b/tests/facet_search_settings.test.ts
@@ -37,7 +37,9 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     test(`${permission} key: Set facetSearch settings with dedicated endpoint on empty index`, async () => {
       const client = await getClient(permission);
 
-      const { taskUid } = await client.index(index.uid).updateFacetSearch(false);
+      const { taskUid } = await client
+        .index(index.uid)
+        .updateFacetSearch(false);
       await client.index(index.uid).waitForTask(taskUid);
 
       const updatedSettings = await client.index(index.uid).getFacetSearch();

--- a/tests/facet_search_settings.test.ts
+++ b/tests/facet_search_settings.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, expect, test, describe, beforeEach } from "vitest";
+import { ErrorStatusCode } from "../src/types";
+import {
+  clearAllIndexes,
+  config,
+  BAD_HOST,
+  MeiliSearch,
+  getClient,
+  dataset,
+} from "./utils/meilisearch-test-utils";
+
+const index = {
+  uid: "movies_test",
+};
+
+afterAll(() => {
+  return clearAllIndexes(config);
+});
+
+describe.each([{ permission: "Master" }, { permission: "Admin" }])(
+  "Test on facet search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.index(index.uid).addDocuments(dataset);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: Get facetSearch settings on empty index`, async () => {
+      const client = await getClient(permission);
+
+      const response = await client.index(index.uid).getFacetSearch();
+      expect(response).toMatchSnapshot();
+    });
+
+    test(`${permission} key: Set facetSearch settings with dedicated endpoint on empty index`, async () => {
+      const client = await getClient(permission);
+
+      const { taskUid } = await client.index(index.uid).updateFacetSearch(false);
+      await client.index(index.uid).waitForTask(taskUid);
+
+      const updatedSettings = await client.index(index.uid).getFacetSearch();
+      expect(updatedSettings).toBe(false);
+    });
+
+    test(`${permission} key: Reset facetSearch settings on an empty index`, async () => {
+      const client = await getClient(permission);
+
+      const { taskUid } = await client.index(index.uid).resetFacetSearch();
+      await client.index(index.uid).waitForTask(taskUid);
+
+      const response = await client.index(index.uid).getFacetSearch();
+      expect(response).toMatchSnapshot();
+    });
+  },
+);
+
+describe.each([{ permission: "Search" }])(
+  "Test on facet search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.createIndex(index.uid);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: try to get facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).getFacetSearch(),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+
+    test(`${permission} key: try to update facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).updateFacetSearch(false),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+
+    test(`${permission} key: try to reset facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).resetFacetSearch(),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+  },
+);
+
+describe.each([{ permission: "No" }])(
+  "Test on facet search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.createIndex(index.uid);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: try to get facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).getFacetSearch(),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+
+    test(`${permission} key: try to update facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).updateFacetSearch(false),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+
+    test(`${permission} key: try to reset facet search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).resetFacetSearch(),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+  },
+);
+
+describe.each([
+  { host: BAD_HOST, trailing: false },
+  { host: `${BAD_HOST}/api`, trailing: false },
+  { host: `${BAD_HOST}/trailing/`, trailing: true },
+])("Tests on url construction", ({ host, trailing }) => {
+  test(`getFacetSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/facet-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).getFacetSearch(),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+
+  test(`updateFacetSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/facet-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).updateFacetSearch(false),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+
+  test(`resetFacetSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/facet-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).resetFacetSearch(),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+});

--- a/tests/prefix_search_settings.test.ts
+++ b/tests/prefix_search_settings.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, expect, test, describe, beforeEach } from "vitest";
+import { ErrorStatusCode } from "../src/types";
+import {
+  clearAllIndexes,
+  config,
+  BAD_HOST,
+  MeiliSearch,
+  getClient,
+  dataset,
+} from "./utils/meilisearch-test-utils";
+
+const index = {
+  uid: "movies_test",
+};
+
+afterAll(() => {
+  return clearAllIndexes(config);
+});
+
+describe.each([{ permission: "Master" }, { permission: "Admin" }])(
+  "Test on prefix search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.index(index.uid).addDocuments(dataset);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: Get prefixSearch settings on empty index`, async () => {
+      const client = await getClient(permission);
+
+      const response = await client.index(index.uid).getPrefixSearch();
+      expect(response).toMatchSnapshot();
+    });
+
+    test(`${permission} key: Set prefixSearch settings with dedicated endpoint on empty index`, async () => {
+      const client = await getClient(permission);
+
+      const { taskUid } = await client.index(index.uid).updatePrefixSearch('disabled');
+      await client.index(index.uid).waitForTask(taskUid);
+
+      const updatedSettings = await client.index(index.uid).getPrefixSearch();
+      expect(updatedSettings).toBe('disabled');
+    });
+
+    test(`${permission} key: Reset prefixSearch settings on an empty index`, async () => {
+      const client = await getClient(permission);
+
+      const { taskUid } = await client.index(index.uid).resetPrefixSearch();
+      await client.index(index.uid).waitForTask(taskUid);
+
+      const response = await client.index(index.uid).getPrefixSearch();
+      expect(response).toMatchSnapshot();
+    });
+  },
+);
+
+describe.each([{ permission: "Search" }])(
+  "Test on prefix search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.createIndex(index.uid);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: try to get prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).getPrefixSearch(),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+
+    test(`${permission} key: try to update prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).updatePrefixSearch('disabled'),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+
+    test(`${permission} key: try to reset prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).resetPrefixSearch(),
+      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
+    });
+  },
+);
+
+describe.each([{ permission: "No" }])(
+  "Test on prefix search settings",
+  ({ permission }) => {
+    beforeEach(async () => {
+      await clearAllIndexes(config);
+      const client = await getClient("Master");
+      const { taskUid } = await client.createIndex(index.uid);
+      await client.waitForTask(taskUid);
+    });
+
+    test(`${permission} key: try to get prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).getPrefixSearch(),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+
+    test(`${permission} key: try to update prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).updatePrefixSearch('disabled'),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+
+    test(`${permission} key: try to reset prefix search settings and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(
+        client.index(index.uid).resetPrefixSearch(),
+      ).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+  },
+);
+
+describe.each([
+  { host: BAD_HOST, trailing: false },
+  { host: `${BAD_HOST}/api`, trailing: false },
+  { host: `${BAD_HOST}/trailing/`, trailing: true },
+])("Tests on url construction", ({ host, trailing }) => {
+  test(`getPrefixSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/prefix-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).getPrefixSearch(),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+
+  test(`updatePrefixSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/prefix-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).updatePrefixSearch('disabled'),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+
+  test(`resetPrefixSearch route`, async () => {
+    const route = `indexes/${index.uid}/settings/prefix-search`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+    await expect(
+      client.index(index.uid).resetPrefixSearch(),
+    ).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+});

--- a/tests/prefix_search_settings.test.ts
+++ b/tests/prefix_search_settings.test.ts
@@ -37,11 +37,13 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     test(`${permission} key: Set prefixSearch settings with dedicated endpoint on empty index`, async () => {
       const client = await getClient(permission);
 
-      const { taskUid } = await client.index(index.uid).updatePrefixSearch('disabled');
+      const { taskUid } = await client
+        .index(index.uid)
+        .updatePrefixSearch("disabled");
       await client.index(index.uid).waitForTask(taskUid);
 
       const updatedSettings = await client.index(index.uid).getPrefixSearch();
-      expect(updatedSettings).toBe('disabled');
+      expect(updatedSettings).toBe("disabled");
     });
 
     test(`${permission} key: Reset prefixSearch settings on an empty index`, async () => {
@@ -76,7 +78,7 @@ describe.each([{ permission: "Search" }])(
     test(`${permission} key: try to update prefix search settings and be denied`, async () => {
       const client = await getClient(permission);
       await expect(
-        client.index(index.uid).updatePrefixSearch('disabled'),
+        client.index(index.uid).updatePrefixSearch("disabled"),
       ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
     });
 
@@ -112,7 +114,7 @@ describe.each([{ permission: "No" }])(
     test(`${permission} key: try to update prefix search settings and be denied`, async () => {
       const client = await getClient(permission);
       await expect(
-        client.index(index.uid).updatePrefixSearch('disabled'),
+        client.index(index.uid).updatePrefixSearch("disabled"),
       ).rejects.toHaveProperty(
         "cause.code",
         ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
@@ -153,7 +155,7 @@ describe.each([
     const client = new MeiliSearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
-      client.index(index.uid).updatePrefixSearch('disabled'),
+      client.index(index.uid).updatePrefixSearch("disabled"),
     ).rejects.toHaveProperty(
       "message",
       `Request to ${strippedHost}/${route} has failed`,

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -271,31 +271,24 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       expect(response).toMatchSnapshot();
     });
 
-    test(`${permission} key: Update settings with facetSearch`, async () => {
+    test(`${permission} key: Update facetSearch settings on empty index`, async () => {
       const client = await getClient(permission);
-
-      const initialSettings = await client.index(index.uid).getSettings();
-      expect(initialSettings.facetSearch).toBe(true);
 
       const { taskUid } = await client.index(index.uid).updateSettings({  facetSearch: false  });
       await client.index(index.uid).waitForTask(taskUid);
-      const updatedSettings = await client.index(index.uid).getSettings();
-      expect(updatedSettings.facetSearch).toBe(false);
+
+      const response = await client.index(index.uid).getSettings();
+      expect(response).toMatchSnapshot();
     });
 
-
-
-    test(`${permission} key: Update settings with prefixSearch`, async () => {
+    test(`${permission} key: Update prefixSearch settings on an empty index`, async () => {
       const client = await getClient(permission);
 
-      const initialSettings = await client.index(index.uid).getSettings();
-      expect(initialSettings.prefixSearch).toBe('indexingTime');
-
-      const newSettings = { prefixSearch: 'disabled' } satisfies Settings;
-      const { taskUid } = await client.index(index.uid).updateSettings(newSettings);
+      const { taskUid } = await client.index(index.uid).updateSettings({ prefixSearch: 'disabled' });
       await client.index(index.uid).waitForTask(taskUid);
-      const updatedSettings = await client.index(index.uid).getSettings();
-      expect(updatedSettings.prefixSearch).toBe('disabled');
+
+      const response = await client.index(index.uid).getSettings();
+      expect(response).toMatchSnapshot();
     });
   },
 );

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -282,6 +282,21 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       const updatedSettings = await client.index(index.uid).getSettings();
       expect(updatedSettings.facetSearch).toBe(false);
     });
+
+
+
+    test(`${permission} key: Update settings with prefixSearch`, async () => {
+      const client = await getClient(permission);
+
+      const initialSettings = await client.index(index.uid).getSettings();
+      expect(initialSettings.prefixSearch).toBe('indexingTime');
+
+      const newSettings = { prefixSearch: 'disabled' } satisfies Settings;
+      const { taskUid } = await client.index(index.uid).updateSettings(newSettings);
+      await client.index(index.uid).waitForTask(taskUid);
+      const updatedSettings = await client.index(index.uid).getSettings();
+      expect(updatedSettings.prefixSearch).toBe('disabled');
+    });
   },
 );
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -92,6 +92,8 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         nonSeparatorTokens: ["&sep", "/", "|"],
         dictionary: ["J. K.", "J. R. R."],
         searchCutoffMs: 1000,
+        facetSearch: true,
+        prefixSearch: 'indexingTime',
       };
       // Add the settings
       const task = await client.index(index.uid).updateSettings(newSettings);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -270,6 +270,18 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       expect(response).toMatchSnapshot();
     });
+
+    test(`${permission} key: Update settings with facetSearch`, async () => {
+      const client = await getClient(permission);
+
+      const initialSettings = await client.index(index.uid).getSettings();
+      expect(initialSettings.facetSearch).toBe(true);
+
+      const { taskUid } = await client.index(index.uid).updateSettings({  facetSearch: false  });
+      await client.index(index.uid).waitForTask(taskUid);
+      const updatedSettings = await client.index(index.uid).getSettings();
+      expect(updatedSettings.facetSearch).toBe(false);
+    });
   },
 );
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -93,7 +93,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         dictionary: ["J. K.", "J. R. R."],
         searchCutoffMs: 1000,
         facetSearch: true,
-        prefixSearch: 'indexingTime',
+        prefixSearch: "indexingTime",
       };
       // Add the settings
       const task = await client.index(index.uid).updateSettings(newSettings);
@@ -274,7 +274,9 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     test(`${permission} key: Update facetSearch settings on empty index`, async () => {
       const client = await getClient(permission);
 
-      const { taskUid } = await client.index(index.uid).updateSettings({  facetSearch: false  });
+      const { taskUid } = await client
+        .index(index.uid)
+        .updateSettings({ facetSearch: false });
       await client.index(index.uid).waitForTask(taskUid);
 
       const response = await client.index(index.uid).getSettings();
@@ -284,7 +286,9 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     test(`${permission} key: Update prefixSearch settings on an empty index`, async () => {
       const client = await getClient(permission);
 
-      const { taskUid } = await client.index(index.uid).updateSettings({ prefixSearch: 'disabled' });
+      const { taskUid } = await client
+        .index(index.uid)
+        .updateSettings({ prefixSearch: "disabled" });
       await client.index(index.uid).waitForTask(taskUid);
 
       const response = await client.index(index.uid).getSettings();


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1770 

## What does this PR do?
- Update `Settings` type so the methods getSettings(), and updateSettings can accept the new settings fields: facetSearch & prefixSearch
- Add the methods for facet search settings:  `getFacetSearch()`, `updateFacetSearch()`, and `resetFacetSearch()` 
- Add the new methods for prefix search settings: `getPrefixSearch()`, `updatePrefixSearch()`, and `resetPrefixSearch()` calling the appropriate Meilisearch routes
- Add the necessary tests (I took example on the tests for displayed attributes settings)
- Update the README
