### PR TITLE
Fix swapped args in localized-attributes sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -801,8 +801,8 @@ get_localized_attribute_settings_1: |-
   client.index('INDEX_NAME').getLocalizedAttributes()
 update_localized_attribute_settings_1: |-
   client.index('INDEX_NAME').updateLocalizedAttributes([
-    { attributePatterns: ['jpn'], locales: ['*_ja'] },
-  ];)
+    { attributePatterns: ['*_ja'], locales: ['jpn'] },
+  ])
 reset_localized_attribute_settings_1: |-
   client.index('INDEX_NAME').resetLocalizedAttributes()
 get_facet_search_settings_1: |-


### PR DESCRIPTION
In its current state this sample causes the server to throw an error, with this change it's inline with the main cURL sample: https://github.com/meilisearch/documentation/blob/b6e919a4d05a8bc085833181527d27b199647668/.code-samples.meilisearch.yaml#L1367
