### PR TITLE
Add types field for backwards compatibility in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "MIT",
   "type": "module",
+  "types": "./dist/types/index.d.ts",
   "main": "./dist/umd/index.min.js",
   "exports": {
     ".": {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes issue that results in the following type error for when [module](https://www.typescriptlang.org/tsconfig/#module) is set to `"node"` or other older version:
![image](https://github.com/user-attachments/assets/c559ace7-d0dd-4e66-9189-c417e2d39848)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
