### PR TITLE
Publish to JSR alongside NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Check release validity
@@ -18,16 +21,16 @@ jobs:
       - name: Check tag format
         run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
       - name: Install dependencies
-        run: yarn install
+        run: yarn
       - name: Build meilisearch-js
         run: yarn build
       - name: Publish with latest tag
         if: '!github.event.release.prerelease'
-        run: npm publish .
+        run: npm publish && yarn publish:jsr
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish with beta tag
         if: 'github.event.release.prerelease'
-        run: npm publish . --tag beta
+        run: npm publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Check release validity

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
+# JSR generated config
+jsr.json
+
 # Generated Docs
 docs/
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "scripts": {
     "playground:javascript": "yarn --cwd ./playgrounds/javascript && yarn --cwd ./playgrounds/javascript dev",
+    "publish:jsr": "node scripts/make-jsr-json.js && npx jsr publish",
     "build:docs": "typedoc",
     "build": "vite build && tsc -p tsconfig.build.json && vite --mode production-umd build",
     "postbuild": "node scripts/build.js",

--- a/scripts/make-jsr-json.js
+++ b/scripts/make-jsr-json.js
@@ -1,0 +1,23 @@
+import { writeFileSync } from "node:fs";
+import pkg from "../package.json" with { type: "json" };
+
+const { name, version, exports, files } = pkg;
+
+writeFileSync(
+  new URL("../jsr.json", import.meta.url),
+  JSON.stringify(
+    {
+      name,
+      version,
+      exports: Object.fromEntries(
+        Object.entries(exports).map(([key, val]) => [
+          key,
+          val.import.replace("dist/esm", "src").replace(".js", ".ts"),
+        ]),
+      ),
+      publish: { include: files.filter((v) => v !== "dist") },
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/make-jsr-json.js
+++ b/scripts/make-jsr-json.js
@@ -7,7 +7,7 @@ writeFileSync(
   new URL("../jsr.json", import.meta.url),
   JSON.stringify(
     {
-      name,
+      name: `@meilisearch/${name}`,
       version,
       exports: Object.fromEntries(
         Object.entries(exports).map(([key, val]) => [

--- a/src/errors/version-hint-message.ts
+++ b/src/errors/version-hint-message.ts
@@ -1,3 +1,6 @@
-export function versionErrorHintMessage(message: string, method: string) {
+export function versionErrorHintMessage(
+  message: string,
+  method: string,
+): string {
   return `${message}\nHint: It might not be working because maybe you're not up to date with the Meilisearch version that ${method} call requires.`;
 }

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -122,7 +122,7 @@ class HttpRequests {
     params?: { [key: string]: any };
     body?: any;
     config?: Record<string, any>;
-  }) {
+  }): Promise<any> {
     const constructURL = new URL(url, this.url);
     if (params) {
       const queryParams = new URLSearchParams();


### PR DESCRIPTION
# Pull Request

Let's try and publish to [JSR](https://jsr.io) as well.

- add script that creates `jsr.json` from `package.json`
- add necessary entries to `publish.yaml` workflow according to https://jsr.io/docs/publishing-packages#publishing-from-github-actions

To do for @curquiza:

- create a JSR account, then scope (`@meilisearch`) and package (`meilisearch`) according to https://jsr.io/docs/publishing-packages#creating-a-scope-and-package
-  link package to GitHub repository from package settings in JSR, detailed here: https://jsr.io/docs/publishing-packages#publishing-from-github-actions

And that should be it. If any issues arise we can discuss it, or maybe I could get some access to this JSR scope and package, see what else we can properly set up there.

## Related issue
Fixes #1792

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
