### PR TITLE
Add documents database metrics to indexStats type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -785,6 +785,8 @@ export type IndexStats = {
   fieldDistribution: FieldDistribution;
   numberOfEmbeddedDocuments: number;
   numberOfEmbeddings: number;
+  rawDocumentDbSize: number;
+  avgDocumentSize: number;
 };
 
 export type Stats = {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -367,6 +367,8 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       expect(response).toHaveProperty("fieldDistribution", {});
       expect(response).toHaveProperty("numberOfEmbeddedDocuments", 0);
       expect(response).toHaveProperty("numberOfEmbeddings", 0);
+      expect(response).toHaveProperty("rawDocumentDbSize", 0);
+      expect(response).toHaveProperty("avgDocumentSize", 0);
     });
 
     test(`${permission} key: Get updatedAt and createdAt through fetch info`, async () => {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1875 

## What does this PR do?
adds the documents database metrics to `indexStats` type.
- [x] Modify the stats API to include indexes.INDEXNAME.rawDocumentDbSize
- [x] Modify the stats API to include indexes.INDEXNAME.avgDocumentSize

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
