### PR TITLE
Add usedDatabaseSize field to stats type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -789,6 +789,7 @@ export type IndexStats = {
 
 export type Stats = {
   databaseSize: number;
+  usedDatabaseSize: number;
   lastUpdate: string;
   indexes: {
     [index: string]: IndexStats;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -547,6 +547,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         const client = await getClient(permission);
         const response: Stats = await client.getStats();
         expect(response).toHaveProperty("databaseSize", expect.any(Number));
+        expect(response).toHaveProperty("usedDatabaseSize", expect.any(Number));
         expect(response).toHaveProperty("lastUpdate"); // TODO: Could be null, find out why
         expect(response).toHaveProperty("indexes", expect.any(Object));
       });


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1873 

## What does this PR do?
Adds usedDatabaseSize metric to `Stats` type.
- [x] Modify the stats API to include the usedDatabaseSize

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
