### PR TITLE
Improve indexes

### DIFF
--- a/playgrounds/javascript/src/meilisearch.ts
+++ b/playgrounds/javascript/src/meilisearch.ts
@@ -12,7 +12,7 @@ const index = client.index<{ id: number; title: string; genres: string[] }>(
 export async function addDocuments(): Promise<void> {
   await client.deleteIndexIfExists(indexUid);
 
-  await client.createIndex(indexUid).waitTask();
+  await client.createIndex({ uid: indexUid }).waitTask();
 
   await index
     .addDocuments([

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -57,7 +57,11 @@ import {
 } from "./task.js";
 
 export class Index<T extends RecordAny = RecordAny> {
-  uid: string;
+  readonly #uid: string;
+  get uid() {
+    return this.#uid;
+  }
+
   httpRequest: HttpRequests;
   tasks: TaskClient;
   readonly #httpRequestsWithTask: HttpRequestsWithEnqueuedTaskPromise;
@@ -68,7 +72,7 @@ export class Index<T extends RecordAny = RecordAny> {
    * @param primaryKey - Primary Key of the index
    */
   constructor(config: Config, uid: string) {
-    this.uid = uid;
+    this.#uid = uid;
     this.httpRequest = new HttpRequests(config);
     this.tasks = new TaskClient(this.httpRequest, config.defaultWaitOptions);
     this.#httpRequestsWithTask = getHttpRequestsWithEnqueuedTaskPromise(
@@ -95,7 +99,7 @@ export class Index<T extends RecordAny = RecordAny> {
     extraRequestInit?: ExtraRequestInit,
   ): Promise<SearchResponse<D, S>> {
     return await this.httpRequest.post<SearchResponse<D, S>>({
-      path: `indexes/${this.uid}/search`,
+      path: `indexes/${this.#uid}/search`,
       body: { q: query, ...options },
       extraRequestInit,
     });
@@ -141,7 +145,7 @@ export class Index<T extends RecordAny = RecordAny> {
     };
 
     return await this.httpRequest.get<SearchResponse<D, S>>({
-      path: `indexes/${this.uid}/search`,
+      path: `indexes/${this.#uid}/search`,
       params: getParams,
       extraRequestInit,
     });
@@ -159,7 +163,7 @@ export class Index<T extends RecordAny = RecordAny> {
     extraRequestInit?: ExtraRequestInit,
   ): Promise<SearchForFacetValuesResponse> {
     return await this.httpRequest.post<SearchForFacetValuesResponse>({
-      path: `indexes/${this.uid}/facet-search`,
+      path: `indexes/${this.#uid}/facet-search`,
       body: params,
       extraRequestInit,
     });
@@ -176,7 +180,7 @@ export class Index<T extends RecordAny = RecordAny> {
     S extends SearchParams = SearchParams,
   >(params: SearchSimilarDocumentsParams): Promise<SearchResponse<D, S>> {
     return await this.httpRequest.post<SearchResponse<D, S>>({
-      path: `indexes/${this.uid}/similar`,
+      path: `indexes/${this.#uid}/similar`,
       body: params,
     });
   }
@@ -192,7 +196,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getStats(): Promise<IndexStats> {
     return await this.httpRequest.get<IndexStats>({
-      path: `indexes/${this.uid}/stats`,
+      path: `indexes/${this.#uid}/stats`,
     });
   }
 
@@ -210,7 +214,7 @@ export class Index<T extends RecordAny = RecordAny> {
   async getDocuments<D extends RecordAny = T>(
     params?: DocumentsQuery<D>,
   ): Promise<ResourceResults<D[]>> {
-    const relativeBaseURL = `indexes/${this.uid}/documents`;
+    const relativeBaseURL = `indexes/${this.#uid}/documents`;
 
     return params?.filter !== undefined
       ? // In case `filter` is provided, use `POST /documents/fetch`
@@ -241,7 +245,7 @@ export class Index<T extends RecordAny = RecordAny> {
       : undefined;
 
     return await this.httpRequest.get<D>({
-      path: `indexes/${this.uid}/documents/${documentId}`,
+      path: `indexes/${this.#uid}/documents/${documentId}`,
       params: { ...parameters, fields },
     });
   }
@@ -255,7 +259,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   addDocuments(documents: T[], options?: DocumentOptions): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.post({
-      path: `indexes/${this.uid}/documents`,
+      path: `indexes/${this.#uid}/documents`,
       params: options,
       body: documents,
     });
@@ -277,7 +281,7 @@ export class Index<T extends RecordAny = RecordAny> {
     queryParams?: RawDocumentAdditionOptions,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.post({
-      path: `indexes/${this.uid}/documents`,
+      path: `indexes/${this.#uid}/documents`,
       body: documents,
       params: queryParams,
       contentType,
@@ -320,7 +324,7 @@ export class Index<T extends RecordAny = RecordAny> {
     options?: DocumentOptions,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/documents`,
+      path: `indexes/${this.#uid}/documents`,
       params: options,
       body: documents,
     });
@@ -366,7 +370,7 @@ export class Index<T extends RecordAny = RecordAny> {
     queryParams?: RawDocumentAdditionOptions,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/documents`,
+      path: `indexes/${this.#uid}/documents`,
       body: documents,
       params: queryParams,
       contentType,
@@ -381,7 +385,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   deleteDocument(documentId: string | number): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/documents/${documentId}`,
+      path: `indexes/${this.#uid}/documents/${documentId}`,
     });
   }
 
@@ -407,7 +411,7 @@ export class Index<T extends RecordAny = RecordAny> {
       : "documents/delete-batch";
 
     return this.#httpRequestsWithTask.post({
-      path: `indexes/${this.uid}/${endpoint}`,
+      path: `indexes/${this.#uid}/${endpoint}`,
       body: params,
     });
   }
@@ -419,7 +423,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   deleteAllDocuments(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/documents`,
+      path: `indexes/${this.#uid}/documents`,
     });
   }
 
@@ -439,7 +443,7 @@ export class Index<T extends RecordAny = RecordAny> {
     options: UpdateDocumentsByFunctionOptions,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.post({
-      path: `indexes/${this.uid}/documents/edit`,
+      path: `indexes/${this.#uid}/documents/edit`,
       body: options,
     });
   }
@@ -455,7 +459,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSettings(): Promise<Settings> {
     return await this.httpRequest.get<Settings>({
-      path: `indexes/${this.uid}/settings`,
+      path: `indexes/${this.#uid}/settings`,
     });
   }
 
@@ -467,7 +471,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateSettings(settings: Settings): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}/settings`,
+      path: `indexes/${this.#uid}/settings`,
       body: settings,
     });
   }
@@ -479,7 +483,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSettings(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings`,
+      path: `indexes/${this.#uid}/settings`,
     });
   }
 
@@ -494,7 +498,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getPagination(): Promise<PaginationSettings> {
     return await this.httpRequest.get<PaginationSettings>({
-      path: `indexes/${this.uid}/settings/pagination`,
+      path: `indexes/${this.#uid}/settings/pagination`,
     });
   }
 
@@ -506,7 +510,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updatePagination(pagination: PaginationSettings): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}/settings/pagination`,
+      path: `indexes/${this.#uid}/settings/pagination`,
       body: pagination,
     });
   }
@@ -518,7 +522,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetPagination(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/pagination`,
+      path: `indexes/${this.#uid}/settings/pagination`,
     });
   }
 
@@ -533,7 +537,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSynonyms(): Promise<Record<string, string[]>> {
     return await this.httpRequest.get<Record<string, string[]>>({
-      path: `indexes/${this.uid}/settings/synonyms`,
+      path: `indexes/${this.#uid}/settings/synonyms`,
     });
   }
 
@@ -545,7 +549,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateSynonyms(synonyms: Synonyms): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/synonyms`,
+      path: `indexes/${this.#uid}/settings/synonyms`,
       body: synonyms,
     });
   }
@@ -557,7 +561,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSynonyms(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/synonyms`,
+      path: `indexes/${this.#uid}/settings/synonyms`,
     });
   }
 
@@ -572,7 +576,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getStopWords(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/stop-words`,
+      path: `indexes/${this.#uid}/settings/stop-words`,
     });
   }
 
@@ -584,7 +588,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateStopWords(stopWords: StopWords): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/stop-words`,
+      path: `indexes/${this.#uid}/settings/stop-words`,
       body: stopWords,
     });
   }
@@ -596,7 +600,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetStopWords(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/stop-words`,
+      path: `indexes/${this.#uid}/settings/stop-words`,
     });
   }
 
@@ -611,7 +615,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getRankingRules(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/ranking-rules`,
+      path: `indexes/${this.#uid}/settings/ranking-rules`,
     });
   }
 
@@ -624,7 +628,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateRankingRules(rankingRules: RankingRules): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/ranking-rules`,
+      path: `indexes/${this.#uid}/settings/ranking-rules`,
       body: rankingRules,
     });
   }
@@ -636,7 +640,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetRankingRules(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/ranking-rules`,
+      path: `indexes/${this.#uid}/settings/ranking-rules`,
     });
   }
 
@@ -651,7 +655,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getDistinctAttribute(): Promise<DistinctAttribute> {
     return await this.httpRequest.get<DistinctAttribute>({
-      path: `indexes/${this.uid}/settings/distinct-attribute`,
+      path: `indexes/${this.#uid}/settings/distinct-attribute`,
     });
   }
 
@@ -665,7 +669,7 @@ export class Index<T extends RecordAny = RecordAny> {
     distinctAttribute: DistinctAttribute,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/distinct-attribute`,
+      path: `indexes/${this.#uid}/settings/distinct-attribute`,
       body: distinctAttribute,
     });
   }
@@ -677,7 +681,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetDistinctAttribute(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/distinct-attribute`,
+      path: `indexes/${this.#uid}/settings/distinct-attribute`,
     });
   }
 
@@ -692,7 +696,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getFilterableAttributes(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/filterable-attributes`,
+      path: `indexes/${this.#uid}/settings/filterable-attributes`,
     });
   }
 
@@ -707,7 +711,7 @@ export class Index<T extends RecordAny = RecordAny> {
     filterableAttributes: FilterableAttributes,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/filterable-attributes`,
+      path: `indexes/${this.#uid}/settings/filterable-attributes`,
       body: filterableAttributes,
     });
   }
@@ -719,7 +723,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetFilterableAttributes(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/filterable-attributes`,
+      path: `indexes/${this.#uid}/settings/filterable-attributes`,
     });
   }
 
@@ -734,7 +738,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSortableAttributes(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/sortable-attributes`,
+      path: `indexes/${this.#uid}/settings/sortable-attributes`,
     });
   }
 
@@ -749,7 +753,7 @@ export class Index<T extends RecordAny = RecordAny> {
     sortableAttributes: SortableAttributes,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/sortable-attributes`,
+      path: `indexes/${this.#uid}/settings/sortable-attributes`,
       body: sortableAttributes,
     });
   }
@@ -761,7 +765,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSortableAttributes(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/sortable-attributes`,
+      path: `indexes/${this.#uid}/settings/sortable-attributes`,
     });
   }
 
@@ -776,7 +780,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSearchableAttributes(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/searchable-attributes`,
+      path: `indexes/${this.#uid}/settings/searchable-attributes`,
     });
   }
 
@@ -791,7 +795,7 @@ export class Index<T extends RecordAny = RecordAny> {
     searchableAttributes: SearchableAttributes,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/searchable-attributes`,
+      path: `indexes/${this.#uid}/settings/searchable-attributes`,
       body: searchableAttributes,
     });
   }
@@ -803,7 +807,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSearchableAttributes(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/searchable-attributes`,
+      path: `indexes/${this.#uid}/settings/searchable-attributes`,
     });
   }
 
@@ -818,7 +822,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getDisplayedAttributes(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/displayed-attributes`,
+      path: `indexes/${this.#uid}/settings/displayed-attributes`,
     });
   }
 
@@ -833,7 +837,7 @@ export class Index<T extends RecordAny = RecordAny> {
     displayedAttributes: DisplayedAttributes,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/displayed-attributes`,
+      path: `indexes/${this.#uid}/settings/displayed-attributes`,
       body: displayedAttributes,
     });
   }
@@ -845,7 +849,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetDisplayedAttributes(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/displayed-attributes`,
+      path: `indexes/${this.#uid}/settings/displayed-attributes`,
     });
   }
 
@@ -860,7 +864,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getTypoTolerance(): Promise<TypoTolerance> {
     return await this.httpRequest.get<TypoTolerance>({
-      path: `indexes/${this.uid}/settings/typo-tolerance`,
+      path: `indexes/${this.#uid}/settings/typo-tolerance`,
     });
   }
 
@@ -873,7 +877,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateTypoTolerance(typoTolerance: TypoTolerance): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}/settings/typo-tolerance`,
+      path: `indexes/${this.#uid}/settings/typo-tolerance`,
       body: typoTolerance,
     });
   }
@@ -885,7 +889,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetTypoTolerance(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/typo-tolerance`,
+      path: `indexes/${this.#uid}/settings/typo-tolerance`,
     });
   }
 
@@ -900,7 +904,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getFaceting(): Promise<Faceting> {
     return await this.httpRequest.get<Faceting>({
-      path: `indexes/${this.uid}/settings/faceting`,
+      path: `indexes/${this.#uid}/settings/faceting`,
     });
   }
 
@@ -912,7 +916,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateFaceting(faceting: Faceting): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}/settings/faceting`,
+      path: `indexes/${this.#uid}/settings/faceting`,
       body: faceting,
     });
   }
@@ -924,7 +928,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetFaceting(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/faceting`,
+      path: `indexes/${this.#uid}/settings/faceting`,
     });
   }
 
@@ -939,7 +943,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSeparatorTokens(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/separator-tokens`,
+      path: `indexes/${this.#uid}/settings/separator-tokens`,
     });
   }
 
@@ -951,7 +955,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateSeparatorTokens(separatorTokens: SeparatorTokens): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/separator-tokens`,
+      path: `indexes/${this.#uid}/settings/separator-tokens`,
       body: separatorTokens,
     });
   }
@@ -963,7 +967,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSeparatorTokens(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/separator-tokens`,
+      path: `indexes/${this.#uid}/settings/separator-tokens`,
     });
   }
 
@@ -978,7 +982,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getNonSeparatorTokens(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/non-separator-tokens`,
+      path: `indexes/${this.#uid}/settings/non-separator-tokens`,
     });
   }
 
@@ -992,7 +996,7 @@ export class Index<T extends RecordAny = RecordAny> {
     nonSeparatorTokens: NonSeparatorTokens,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/non-separator-tokens`,
+      path: `indexes/${this.#uid}/settings/non-separator-tokens`,
       body: nonSeparatorTokens,
     });
   }
@@ -1004,7 +1008,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetNonSeparatorTokens(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/non-separator-tokens`,
+      path: `indexes/${this.#uid}/settings/non-separator-tokens`,
     });
   }
 
@@ -1019,7 +1023,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getDictionary(): Promise<string[]> {
     return await this.httpRequest.get<string[]>({
-      path: `indexes/${this.uid}/settings/dictionary`,
+      path: `indexes/${this.#uid}/settings/dictionary`,
     });
   }
 
@@ -1031,7 +1035,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateDictionary(dictionary: Dictionary): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/dictionary`,
+      path: `indexes/${this.#uid}/settings/dictionary`,
       body: dictionary,
     });
   }
@@ -1043,7 +1047,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetDictionary(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/dictionary`,
+      path: `indexes/${this.#uid}/settings/dictionary`,
     });
   }
 
@@ -1058,7 +1062,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getProximityPrecision(): Promise<ProximityPrecision> {
     return await this.httpRequest.get<ProximityPrecision>({
-      path: `indexes/${this.uid}/settings/proximity-precision`,
+      path: `indexes/${this.#uid}/settings/proximity-precision`,
     });
   }
 
@@ -1073,7 +1077,7 @@ export class Index<T extends RecordAny = RecordAny> {
     proximityPrecision: ProximityPrecision,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/proximity-precision`,
+      path: `indexes/${this.#uid}/settings/proximity-precision`,
       body: proximityPrecision,
     });
   }
@@ -1085,7 +1089,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetProximityPrecision(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/proximity-precision`,
+      path: `indexes/${this.#uid}/settings/proximity-precision`,
     });
   }
 
@@ -1100,7 +1104,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getEmbedders(): Promise<Embedders> {
     return await this.httpRequest.get<Embedders>({
-      path: `indexes/${this.uid}/settings/embedders`,
+      path: `indexes/${this.#uid}/settings/embedders`,
     });
   }
 
@@ -1112,7 +1116,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateEmbedders(embedders: Embedders): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}/settings/embedders`,
+      path: `indexes/${this.#uid}/settings/embedders`,
       body: embedders,
     });
   }
@@ -1124,7 +1128,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetEmbedders(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/embedders`,
+      path: `indexes/${this.#uid}/settings/embedders`,
     });
   }
 
@@ -1139,7 +1143,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getSearchCutoffMs(): Promise<SearchCutoffMs> {
     return await this.httpRequest.get<SearchCutoffMs>({
-      path: `indexes/${this.uid}/settings/search-cutoff-ms`,
+      path: `indexes/${this.#uid}/settings/search-cutoff-ms`,
     });
   }
 
@@ -1151,7 +1155,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateSearchCutoffMs(searchCutoffMs: SearchCutoffMs): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/search-cutoff-ms`,
+      path: `indexes/${this.#uid}/settings/search-cutoff-ms`,
       body: searchCutoffMs,
     });
   }
@@ -1163,7 +1167,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetSearchCutoffMs(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/search-cutoff-ms`,
+      path: `indexes/${this.#uid}/settings/search-cutoff-ms`,
     });
   }
 
@@ -1178,7 +1182,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getLocalizedAttributes(): Promise<LocalizedAttributes> {
     return await this.httpRequest.get<LocalizedAttributes>({
-      path: `indexes/${this.uid}/settings/localized-attributes`,
+      path: `indexes/${this.#uid}/settings/localized-attributes`,
     });
   }
 
@@ -1192,7 +1196,7 @@ export class Index<T extends RecordAny = RecordAny> {
     localizedAttributes: LocalizedAttributes,
   ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/localized-attributes`,
+      path: `indexes/${this.#uid}/settings/localized-attributes`,
       body: localizedAttributes,
     });
   }
@@ -1204,7 +1208,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetLocalizedAttributes(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/localized-attributes`,
+      path: `indexes/${this.#uid}/settings/localized-attributes`,
     });
   }
 
@@ -1219,7 +1223,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getFacetSearch(): Promise<boolean> {
     return await this.httpRequest.get<boolean>({
-      path: `indexes/${this.uid}/settings/facet-search`,
+      path: `indexes/${this.#uid}/settings/facet-search`,
     });
   }
 
@@ -1231,7 +1235,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updateFacetSearch(facetSearch: boolean): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/facet-search`,
+      path: `indexes/${this.#uid}/settings/facet-search`,
       body: facetSearch,
     });
   }
@@ -1243,7 +1247,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetFacetSearch(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/facet-search`,
+      path: `indexes/${this.#uid}/settings/facet-search`,
     });
   }
 
@@ -1258,7 +1262,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   async getPrefixSearch(): Promise<PrefixSearch> {
     return await this.httpRequest.get<PrefixSearch>({
-      path: `indexes/${this.uid}/settings/prefix-search`,
+      path: `indexes/${this.#uid}/settings/prefix-search`,
     });
   }
 
@@ -1270,7 +1274,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   updatePrefixSearch(prefixSearch: PrefixSearch): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.put({
-      path: `indexes/${this.uid}/settings/prefix-search`,
+      path: `indexes/${this.#uid}/settings/prefix-search`,
       body: prefixSearch,
     });
   }
@@ -1282,7 +1286,7 @@ export class Index<T extends RecordAny = RecordAny> {
    */
   resetPrefixSearch(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}/settings/prefix-search`,
+      path: `indexes/${this.#uid}/settings/prefix-search`,
     });
   }
 }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -58,7 +58,6 @@ import {
 
 export class Index<T extends RecordAny = RecordAny> {
   uid: string;
-  primaryKey: string | undefined;
   httpRequest: HttpRequests;
   tasks: TaskClient;
   readonly #httpRequestsWithTask: HttpRequestsWithEnqueuedTaskPromise;
@@ -68,9 +67,8 @@ export class Index<T extends RecordAny = RecordAny> {
    * @param uid - UID of the index
    * @param primaryKey - Primary Key of the index
    */
-  constructor(config: Config, uid: string, primaryKey?: string) {
+  constructor(config: Config, uid: string) {
     this.uid = uid;
-    this.primaryKey = primaryKey;
     this.httpRequest = new HttpRequests(config);
     this.tasks = new TaskClient(this.httpRequest, config.defaultWaitOptions);
     this.#httpRequestsWithTask = getHttpRequestsWithEnqueuedTaskPromise(

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -12,8 +12,6 @@ import type {
   SearchParams,
   Filter,
   SearchRequestGET,
-  IndexObject,
-  IndexOptions,
   IndexStats,
   DocumentsQuery,
   DocumentQuery,
@@ -61,8 +59,6 @@ import {
 export class Index<T extends RecordAny = RecordAny> {
   uid: string;
   primaryKey: string | undefined;
-  createdAt: Date | undefined;
-  updatedAt: Date | undefined;
   httpRequest: HttpRequests;
   tasks: TaskClient;
   readonly #httpRequestsWithTask: HttpRequestsWithEnqueuedTaskPromise;
@@ -184,92 +180,6 @@ export class Index<T extends RecordAny = RecordAny> {
     return await this.httpRequest.post<SearchResponse<D, S>>({
       path: `indexes/${this.uid}/similar`,
       body: params,
-    });
-  }
-
-  ///
-  /// INDEX
-  ///
-
-  /**
-   * Get index information.
-   *
-   * @returns Promise containing index information
-   */
-  async getRawInfo(): Promise<IndexObject> {
-    const res = await this.httpRequest.get<IndexObject>({
-      path: `indexes/${this.uid}`,
-    });
-    this.primaryKey = res.primaryKey;
-    this.updatedAt = new Date(res.updatedAt);
-    this.createdAt = new Date(res.createdAt);
-    return res;
-  }
-
-  /**
-   * Fetch and update Index information.
-   *
-   * @returns Promise to the current Index object with updated information
-   */
-  async fetchInfo(): Promise<this> {
-    await this.getRawInfo();
-    return this;
-  }
-
-  /**
-   * Get Primary Key.
-   *
-   * @returns Promise containing the Primary Key of the index
-   */
-  async fetchPrimaryKey(): Promise<string | undefined> {
-    this.primaryKey = (await this.getRawInfo()).primaryKey;
-    return this.primaryKey;
-  }
-
-  /**
-   * Create an index.
-   *
-   * @param uid - Unique identifier of the Index
-   * @param options - Index options
-   * @param config - Request configuration options
-   * @returns Newly created Index object
-   */
-  static create(
-    uid: string,
-    options: IndexOptions = {},
-    config: Config,
-  ): EnqueuedTaskPromise {
-    const httpRequests = new HttpRequests(config);
-    return getHttpRequestsWithEnqueuedTaskPromise(
-      httpRequests,
-      new TaskClient(httpRequests),
-    ).post({
-      path: "indexes",
-      body: { ...options, uid },
-    });
-  }
-
-  /**
-   * Update an index.
-   *
-   * @param data - Data to update
-   * @returns Promise to the current Index object with updated information
-   */
-  update(data?: IndexOptions): EnqueuedTaskPromise {
-    return this.#httpRequestsWithTask.patch({
-      path: `indexes/${this.uid}`,
-      body: data,
-    });
-  }
-
-  /**
-   * Delete an index.
-   *
-   * @returns Promise which resolves when index is deleted successfully
-   */
-  delete(): EnqueuedTaskPromise {
-    return this.#httpRequestsWithTask.delete({
-      path: `indexes/${this.uid}`,
     });
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
 export * from "./indexes.js";
-export * from "./task_and_batch.js";
+export * from "./task-and-batch.js";
 export * from "./token.js";
 export * from "./types.js";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./indexes.js";
 export * from "./task_and_batch.js";
 export * from "./token.js";
 export * from "./types.js";

--- a/src/types/indexes.ts
+++ b/src/types/indexes.ts
@@ -1,0 +1,47 @@
+import type { PaginationView } from "./shared.js";
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/indexes#query-parameters}
+ *
+ * @see `meilisearch::routes::indexes::ListIndexes`
+ */
+export type ListIndexes = {
+  offset?: number;
+  limit?: number;
+};
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/indexes#index-object}
+ *
+ * @see `meilisearch::routes::indexes::IndexView`
+ */
+export type IndexView = {
+  uid: string;
+  createdAt: string;
+  updatedAt: string;
+  primaryKey: string | null;
+};
+
+/** {@link https://www.meilisearch.com/docs/reference/api/indexes#response} */
+export type IndexViewList = PaginationView<IndexView>;
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/indexes#body-1}
+ *
+ * @see `meilisearch::routes::indexes::UpdateIndexRequest`
+ */
+export type UpdateIndexRequest = { primaryKey?: string | null };
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/indexes#body}
+ *
+ * @see `meilisearch::routes::indexes::IndexCreateRequest`
+ */
+export type IndexCreateRequest = UpdateIndexRequest & { uid: string };
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/indexes#body-2}
+ *
+ * @see `meilisearch::routes::swap_indexes::SwapIndexesPayload`
+ */
+export type SwapIndexesPayload = { indexes: [string, string] };

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -1,10 +1,10 @@
 import type { RecordAny } from "./types.js";
 
-export type CursorResults<T> = {
+/** @see `meilisearch::routes::PaginationView` */
+export type PaginationView<T> = {
   results: T[];
+  offset: number;
   limit: number;
-  from: number;
-  next: number;
   total: number;
 };
 

--- a/src/types/task-and-batch.ts
+++ b/src/types/task-and-batch.ts
@@ -1,5 +1,4 @@
 import type { Settings, MeiliSearchErrorResponse } from "./types.js";
-import type { PaginationView } from "./shared.js";
 import type { SwapIndexesPayload } from "./indexes.js";
 
 /** Options for awaiting {@link EnqueuedTask}. */
@@ -139,18 +138,20 @@ export type EnqueuedTaskPromise = Promise<EnqueuedTask> & {
   waitTask: (waitOptions?: WaitOptions) => Promise<Task>;
 };
 
-/**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#response}
- *
- * @see `meilisearch::routes::tasks::AllTasks` at {@link https://github.com/meilisearch/meilisearch}
- */
-export type TasksResults = {
-  results: Task[];
+type Results<T> = {
+  results: T[];
   total: number;
   limit: number;
   from: number | null;
   next: number | null;
 };
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/tasks#response}
+ *
+ * @see `meilisearch::routes::tasks::AllTasks` at {@link https://github.com/meilisearch/meilisearch}
+ */
+export type TasksResults = Results<Task>;
 
 /** {@link https://www.meilisearch.com/docs/reference/api/batches#steps} */
 type BatchProgressStep = {
@@ -193,4 +194,4 @@ export type Batch = {
  *
  * @see `meilisearch::routes::batches::AllBatches` at {@link https://github.com/meilisearch/meilisearch}
  */
-export type BatchesResults = PaginationView<Batch>;
+export type BatchesResults = Results<Batch>;

--- a/src/types/task_and_batch.ts
+++ b/src/types/task_and_batch.ts
@@ -1,6 +1,6 @@
-import type { Settings } from "./types.js";
-import type { CursorResults } from "./shared.js";
-import type { MeiliSearchErrorResponse } from "./types.js";
+import type { Settings, MeiliSearchErrorResponse } from "./types.js";
+import type { PaginationView } from "./shared.js";
+import type { SwapIndexesPayload } from "./indexes.js";
 
 /** Options for awaiting {@link EnqueuedTask}. */
 export type WaitOptions = {
@@ -93,9 +93,6 @@ export type EnqueuedTask = {
 /** Either a number or an {@link EnqueuedTask}. */
 export type TaskUidOrEnqueuedTask = EnqueuedTask["taskUid"] | EnqueuedTask;
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#indexswap} */
-export type IndexSwap = { indexes: [string, string] };
-
 /** {@link https://www.meilisearch.com/docs/reference/api/tasks#details} */
 export type TaskDetails = Settings & {
   receivedDocuments?: number;
@@ -111,7 +108,7 @@ export type TaskDetails = Settings & {
   dumpUid?: string | null;
   context?: Record<string, unknown> | null;
   function?: string;
-  swaps?: IndexSwap[];
+  swaps?: SwapIndexesPayload[];
 };
 
 /**
@@ -147,7 +144,7 @@ export type EnqueuedTaskPromise = Promise<EnqueuedTask> & {
  *
  * @see `meilisearch::routes::tasks::AllTasks` at {@link https://github.com/meilisearch/meilisearch}
  */
-export type TasksResults = CursorResults<Task>;
+export type TasksResults = PaginationView<Task>;
 
 /** {@link https://www.meilisearch.com/docs/reference/api/batches#steps} */
 type BatchProgressStep = {
@@ -190,4 +187,4 @@ export type Batch = {
  *
  * @see `meilisearch::routes::batches::AllBatches` at {@link https://github.com/meilisearch/meilisearch}
  */
-export type BatchesResults = CursorResults<Batch>;
+export type BatchesResults = PaginationView<Batch>;

--- a/src/types/task_and_batch.ts
+++ b/src/types/task_and_batch.ts
@@ -144,7 +144,13 @@ export type EnqueuedTaskPromise = Promise<EnqueuedTask> & {
  *
  * @see `meilisearch::routes::tasks::AllTasks` at {@link https://github.com/meilisearch/meilisearch}
  */
-export type TasksResults = PaginationView<Task>;
+export type TasksResults = {
+  results: Task[];
+  total: number;
+  limit: number;
+  from: number | null;
+  next: number | null;
+};
 
 /** {@link https://www.meilisearch.com/docs/reference/api/batches#steps} */
 type BatchProgressStep = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/meilisearch/meilisearch-js
 // TypeScript Version: ^5.8.2
 
-import type { WaitOptions } from "./task_and_batch.js";
+import type { WaitOptions } from "./task-and-batch.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RecordAny = Record<string, any>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -130,25 +130,6 @@ export type ResourceResults<T> = Pagination & {
   total: number;
 };
 
-///
-/// Indexes
-///
-
-export type IndexOptions = {
-  primaryKey?: string;
-};
-
-export type IndexObject = {
-  uid: string;
-  primaryKey?: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export type IndexesQuery = ResourceQuery & {};
-
-export type IndexesResults<T> = ResourceResults<T> & {};
-
 /*
  * SEARCH PARAMETERS
  */

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -5,9 +5,7 @@ import {
   clearAllIndexes,
 } from "./utils/meilisearch-test-utils.js";
 
-const index = {
-  uid: "batch-test",
-};
+const index = { uid: "batch-test" };
 
 afterAll(() => {
   return clearAllIndexes(config);
@@ -18,7 +16,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex(index).waitTask();
     });
 
     test(`${permission} key: Get all batches`, async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -8,7 +8,7 @@ import {
   type MockInstance,
   beforeAll,
 } from "vitest";
-import type { Health, Version, Stats, IndexSwap } from "../src/index.js";
+import type { Health, Version, Stats, SwapIndexesPayload } from "../src/index.js";
 import { ErrorStatusCode, MeiliSearchRequestError } from "../src/index.js";
 import { PACKAGE_VERSION } from "../src/package-version.js";
 import {
@@ -519,7 +519,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
           .index(index2.uid)
           .addDocuments([{ id: 1, title: "index_2" }])
           .waitTask();
-        const swaps: IndexSwap[] = [{ indexes: [index.uid, index2.uid] }];
+        const swaps: SwapIndexesPayload[] = [{ indexes: [index.uid, index2.uid] }];
 
         const resolvedTask = await client.swapIndexes(swaps).waitTask();
         const docIndex1 = await client.index(index.uid).getDocument(1);
@@ -539,7 +539,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
           .addDocuments([{ id: 1, title: "index_2" }])
           .waitTask();
 
-        const swaps: IndexSwap[] = [
+        const swaps: SwapIndexesPayload[] = [
           { indexes: ["does_not_exist", index2.uid] },
         ];
 
@@ -556,7 +556,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       test(`${permission} key: Swap two one index with itself`, async () => {
         const client = await getClient(permission);
 
-        const swaps: IndexSwap[] = [{ indexes: [index.uid, index.uid] }];
+        const swaps: SwapIndexesPayload[] = [{ indexes: [index.uid, index.uid] }];
 
         await expect(client.swapIndexes(swaps)).rejects.toHaveProperty(
           "cause.code",

--- a/tests/displayed_attributes.test.ts
+++ b/tests/displayed_attributes.test.ts
@@ -74,7 +74,7 @@ describe.each([{ permission: "Search" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {
@@ -106,7 +106,7 @@ describe.each([{ permission: "No" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get displayed attributes and be denied`, async () => {

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -32,9 +32,10 @@ describe("Documents tests", () => {
       beforeEach(async () => {
         await clearAllIndexes(config);
         const client = await getClient("Master");
-        await client.createIndex(indexNoPk.uid).waitTask();
+        await client.createIndex({ uid: indexNoPk.uid }).waitTask();
         await client
-          .createIndex(indexPk.uid, {
+          .createIndex({
+            uid: indexPk.uid,
             primaryKey: indexPk.primaryKey,
           })
           .waitTask();
@@ -398,7 +399,7 @@ describe("Documents tests", () => {
         };
         await client.index(indexNoPk.uid).addDocuments([doc]).waitTask();
 
-        const index = await client.index(indexNoPk.uid).fetchInfo();
+        const index = await client.getIndex(indexNoPk.uid);
 
         expect(index).toHaveProperty("primaryKey", "_id");
       });
@@ -411,7 +412,7 @@ describe("Documents tests", () => {
         };
         await client.index(indexNoPk.uid).addDocuments([doc]).waitTask();
 
-        const index = await client.index(indexNoPk.uid).fetchInfo();
+        const index = await client.getIndex(indexNoPk.uid);
 
         expect(index).toHaveProperty("primaryKey", "findmeid");
       });
@@ -427,7 +428,7 @@ describe("Documents tests", () => {
           .index(indexNoPk.uid)
           .addDocuments([doc])
           .waitTask();
-        const index = await client.index(indexNoPk.uid).fetchInfo();
+        const index = await client.getIndex(indexNoPk.uid);
 
         expect(task.error?.code).toEqual(
           "index_primary_key_multiple_candidates_found",
@@ -445,7 +446,7 @@ describe("Documents tests", () => {
           .index(indexNoPk.uid)
           .addDocuments([doc])
           .waitTask();
-        const index = await client.index(indexNoPk.uid).fetchInfo();
+        const index = await client.getIndex(indexNoPk.uid);
 
         expect(task.error?.code).toEqual(
           "index_primary_key_no_candidate_found",
@@ -547,7 +548,7 @@ describe("Documents tests", () => {
 
       test(`${permission} key: Delete some documents should trigger error with a hint on a MeilisearchApiError`, async () => {
         const client = await getClient(permission);
-        await client.createIndex(indexPk.uid).waitTask();
+        await client.createIndex({ uid: indexPk.uid }).waitTask();
 
         await assert.rejects(
           client.index(indexPk.uid).deleteDocuments({ filter: "" }),
@@ -615,14 +616,14 @@ describe("Documents tests", () => {
           },
         ];
         const pkIndex = "update_pk";
-        await client.createIndex(pkIndex).waitTask();
+        await client.createIndex({ uid: pkIndex }).waitTask();
 
         await client
           .index(pkIndex)
           .addDocuments(docs, { primaryKey: "unique" })
           .waitTask();
 
-        const response = await client.index(pkIndex).getRawInfo();
+        const response = await client.getIndex(pkIndex);
         expect(response).toHaveProperty("uid", pkIndex);
         expect(response).toHaveProperty("primaryKey", "unique");
       });
@@ -658,7 +659,7 @@ describe("Documents tests", () => {
           ])
           .waitTask();
 
-        const index = await client.index(indexNoPk.uid).getRawInfo();
+        const index = await client.getIndex(indexNoPk.uid);
 
         expect(index.uid).toEqual(indexNoPk.uid);
         expect(index.primaryKey).toEqual(null);

--- a/tests/embedders.test.ts
+++ b/tests/embedders.test.ts
@@ -56,7 +56,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       await clearAllIndexes(config);
       const client = await getClient(permission);
 
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: Get default embedders`, async () => {

--- a/tests/env/typescript-browser/src/index.ts
+++ b/tests/env/typescript-browser/src/index.ts
@@ -1,4 +1,4 @@
-import { MeiliSearch, type IndexObject } from '../../../../src/index.js'
+import { MeiliSearch } from '../../../../src/index.js'
 import { generateTenantToken } from '../../../../src/token.js'
 
 const config = {
@@ -14,9 +14,9 @@ function greeter(person: string) {
 }
 
 ;(async () => {
-  const indexes = await client.getRawIndexes()
+  const indexes = await client.getIndexes()
   console.log({ indexes }, 'hello')
-  const uids = indexes.results.map((index: IndexObject) => index.uid)
+  const uids = indexes.results.map((index) => index.uid)
   document.body.innerHTML = `${greeter(
     user
   )} this is the list of all your indexes: \n ${uids.join(', ')}`

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -2,7 +2,6 @@ import {
   MeiliSearch,
 } from '../../../../src/index.js'
 import type {
-  IndexObject,
   SearchResponse,
   Hits,
   Hit,
@@ -29,11 +28,11 @@ const indexUid = "movies"
 
 ;(async () => {
   await client.deleteIndex(indexUid).waitTask()
-  await client.createIndex(indexUid).waitTask()
+  await client.createIndex({uid:indexUid}).waitTask()
 
   const index = client.index(indexUid)
-  const indexes = await client.getRawIndexes()
-  indexes.results.map((index: IndexObject) => {
+  const indexes = await client.getIndexes()
+  indexes.results.map((index) => {
     console.log(index.uid)
     // console.log(index.something) -> ERROR
   })
@@ -44,7 +43,7 @@ const indexUid = "movies"
     attributesToHighlight: ['title'],
     // test: true -> ERROR Test does not exist on type SearchParams
   }
-  indexes.results.map((index: IndexObject) => index.uid)
+  indexes.results.map((index) => index.uid)
   const res: SearchResponse<Movie> = await index.search(
     'avenger',
     searchParams

--- a/tests/env/typescript-node/src/index.ts
+++ b/tests/env/typescript-node/src/index.ts
@@ -28,7 +28,7 @@ const indexUid = "movies"
 
 ;(async () => {
   await client.deleteIndex(indexUid).waitTask()
-  await client.createIndex({uid:indexUid}).waitTask()
+  await client.createIndex({ uid:indexUid }).waitTask()
 
   const index = client.index(indexUid)
   const indexes = await client.getIndexes()
@@ -62,5 +62,5 @@ const indexUid = "movies"
 
   console.log(await generateTenantToken({ apiKey: config.apiKey, apiKeyUid: 'e489fe16-3381-431b-bee3-00430192915d' }))
 
-  await index.delete()
+  await client.deleteIndex(indexUid).waitTask()
 })()

--- a/tests/facet_search.test.ts
+++ b/tests/facet_search.test.ts
@@ -41,7 +41,7 @@ describe.each([
     await clearAllIndexes(config);
     const client = await getClient("Master");
     const newFilterableAttributes = ["genres", "title"];
-    await client.createIndex(index.uid);
+    await client.createIndex({ uid: index.uid });
     await client.index(index.uid).updateSettings({
       filterableAttributes: newFilterableAttributes,
     });

--- a/tests/facet_search_settings.test.ts
+++ b/tests/facet_search_settings.test.ts
@@ -59,7 +59,7 @@ describe.each([{ permission: "Search" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get facet search settings and be denied`, async () => {
@@ -91,7 +91,7 @@ describe.each([{ permission: "No" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get facet search settings and be denied`, async () => {

--- a/tests/faceting.test.ts
+++ b/tests/faceting.test.ts
@@ -30,7 +30,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
 
       await client.index(index.uid).addDocuments(dataset).waitTask();
     });
@@ -89,7 +89,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get faceting and be denied`, async () => {
@@ -118,7 +118,7 @@ describe.each([{ permission: "Search" }])(
 describe.each([{ permission: "No" }])("Test on faceting", ({ permission }) => {
   beforeAll(async () => {
     const client = await getClient("Master");
-    await client.createIndex(index.uid).waitTask();
+    await client.createIndex({ uid: index.uid }).waitTask();
   });
 
   test(`${permission} key: try to get faceting and be denied`, async () => {

--- a/tests/filterable_attributes.test.ts
+++ b/tests/filterable_attributes.test.ts
@@ -69,7 +69,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {
@@ -100,7 +100,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get attributes for filtering and be denied`, async () => {

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -84,8 +84,8 @@ describe.each([
   beforeAll(async () => {
     await clearAllIndexes(config);
     const client = await getClient("Master");
-    await client.createIndex(index.uid).waitTask();
-    await client.createIndex(emptyIndex.uid).waitTask();
+    await client.createIndex({ uid: index.uid }).waitTask();
+    await client.createIndex({ uid: emptyIndex.uid }).waitTask();
 
     const newFilterableAttributes = ["genre", "title", "id", "author"];
     await client
@@ -546,7 +546,7 @@ describe.each([
   test(`${permission} key: Try to search on deleted index and fail`, async () => {
     const client = await getClient(permission);
     const masterClient = await getClient("Master");
-    await masterClient.index(index.uid).delete().waitTask();
+    await masterClient.deleteIndex(index.uid).waitTask();
     await expect(
       client.index(index.uid).searchGet("prince"),
     ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INDEX_NOT_FOUND);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,544 +1,83 @@
-import { expect, test, describe, beforeEach, afterAll } from "vitest";
-import { ErrorStatusCode } from "../src/types/index.js";
-import {
-  clearAllIndexes,
-  config,
-  BAD_HOST,
-  MeiliSearch,
-  getClient,
-} from "./utils/meilisearch-test-utils.js";
-
-const indexNoPk = {
-  uid: "movies_test",
-};
-const indexPk = {
-  uid: "movies_test2",
-  primaryKey: "id",
-};
-
-afterAll(() => clearAllIndexes(config));
-
-describe.each([{ permission: "Master" }, { permission: "Admin" }])(
-  "Test on indexes w/ master and admin key",
-  ({ permission }) => {
-    beforeEach(() => {
-      return clearAllIndexes(config);
-    });
-
-    test(`${permission} key: create index with NO primary key`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const newIndex = await client.getIndex(indexNoPk.uid);
-
-      expect(newIndex).toHaveProperty("uid", indexNoPk.uid);
-      expect(newIndex).toHaveProperty("primaryKey", null);
-
-      const rawIndex = await client.index(indexNoPk.uid).getRawInfo();
-
-      expect(rawIndex).toHaveProperty("uid", indexNoPk.uid);
-      expect(rawIndex).toHaveProperty("primaryKey", null);
-      expect(rawIndex).toHaveProperty("createdAt", expect.any(String));
-      expect(rawIndex).toHaveProperty("updatedAt", expect.any(String));
-    });
-
-    test(`${permission} key: create index with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-
-      const newIndex = await client.getIndex(indexPk.uid);
-
-      expect(newIndex).toHaveProperty("uid", indexPk.uid);
-      expect(newIndex).toHaveProperty("primaryKey", indexPk.primaryKey);
-
-      const rawIndex = await client.index(indexPk.uid).getRawInfo();
-
-      expect(rawIndex).toHaveProperty("uid", indexPk.uid);
-      expect(rawIndex).toHaveProperty("primaryKey", indexPk.primaryKey);
-      expect(rawIndex).toHaveProperty("createdAt", expect.any(String));
-      expect(rawIndex).toHaveProperty("updatedAt", expect.any(String));
-    });
-
-    test(`${permission} key: Get raw index that exists`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const response = await client.getRawIndex(indexPk.uid);
-
-      expect(response).toHaveProperty("uid", indexPk.uid);
-    });
-
-    test(`${permission} key: Get all indexes in Index instances`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const { results } = await client.getRawIndexes();
-
-      expect(results.length).toEqual(1);
-      expect(results[0].uid).toEqual(indexPk.uid);
-    });
-
-    test(`${permission} key: Get index that does not exist`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getIndex("does_not_exist")).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INDEX_NOT_FOUND,
-      );
-    });
-
-    test(`${permission} key: Get raw index that does not exist`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getRawIndex("does_not_exist")).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INDEX_NOT_FOUND,
-      );
-    });
-
-    test(`${permission} key: Get raw index info through client with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, { primaryKey: indexPk.primaryKey })
-        .waitTask();
-
-      const response = await client.getRawIndex(indexPk.uid);
-
-      expect(response).toHaveProperty("uid", indexPk.uid);
-      expect(response).toHaveProperty("primaryKey", indexPk.primaryKey);
-    });
-
-    test(`${permission} key: Get raw index info through client with NO primary key`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const response = await client.getRawIndex(indexNoPk.uid);
-
-      expect(response).toHaveProperty("uid", indexNoPk.uid);
-      expect(response).toHaveProperty("primaryKey", null);
-    });
-
-    test(`${permission} key: Get raw index info with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, { primaryKey: indexPk.primaryKey })
-        .waitTask();
-
-      const response = await client.index(indexPk.uid).getRawInfo();
-
-      expect(response).toHaveProperty("uid", indexPk.uid);
-      expect(response).toHaveProperty("primaryKey", indexPk.primaryKey);
-    });
-
-    test(`${permission} key: Get raw index info with NO primary key`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const response = await client.index(indexNoPk.uid).getRawInfo();
-
-      expect(response).toHaveProperty("uid", indexNoPk.uid);
-      expect(response).toHaveProperty("primaryKey", null);
-    });
-
-    test(`${permission} key: fetch index with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-
-      const index = client.index(indexPk.uid);
-      const response = await index.fetchInfo();
-
-      expect(response).toHaveProperty("uid", indexPk.uid);
-      expect(response).toHaveProperty("primaryKey", indexPk.primaryKey);
-    });
-
-    test(`${permission} key: fetch primary key on an index with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-
-      const index = client.index(indexPk.uid);
-      const response: string | undefined = await index.fetchPrimaryKey();
-
-      expect(response).toBe(indexPk.primaryKey);
-    });
-
-    test(`${permission} key: fetch primary key on an index with NO primary key`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const index = client.index(indexNoPk.uid);
-      const response: string | undefined = await index.fetchPrimaryKey();
-
-      expect(response).toBe(null);
-    });
-
-    test(`${permission} key: fetch index with primary key`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-
-      const index = client.index(indexPk.uid);
-      const response = await index.fetchInfo();
-
-      expect(response).toHaveProperty("uid", indexPk.uid);
-      expect(response).toHaveProperty("primaryKey", indexPk.primaryKey);
-    });
-
-    test(`${permission} key: fetch index with NO primary key`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const index = client.index(indexNoPk.uid);
-      const response = await index.fetchInfo();
-
-      expect(response).toHaveProperty("uid", indexNoPk.uid);
-      expect(response).toHaveProperty("primaryKey", null);
-    });
-
-    test(`${permission} key: get all indexes`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const indexes = await client.getIndexes();
-
-      expect(indexes.results.length).toEqual(2);
-    });
-
-    test(`${permission} key: get all indexes with filters`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const indexes = await client.getIndexes({ limit: 1, offset: 1 });
-
-      expect(indexes.results.length).toEqual(1);
-      expect(indexes.results[0].uid).toEqual(indexPk.uid);
-    });
-
-    test(`${permission} key: update primary key on an index that has no primary key already`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-      await client
-        .index(indexNoPk.uid)
-        .update({ primaryKey: "newPrimaryKey" })
-        .waitTask();
-
-      const index = await client.getIndex(indexNoPk.uid);
-
-      expect(index).toHaveProperty("uid", indexNoPk.uid);
-      expect(index).toHaveProperty("primaryKey", "newPrimaryKey");
-    });
-
-    test(`${permission} key: update primary key on an index that has NO primary key already through client`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-      await client
-        .updateIndex(indexNoPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-
-      const index = await client.getIndex(indexNoPk.uid);
-
-      expect(index).toHaveProperty("uid", indexNoPk.uid);
-      expect(index).toHaveProperty("primaryKey", indexPk.primaryKey);
-    });
-
-    test(`${permission} key: update primary key on an index that has already a primary key and fail through client`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, {
-          primaryKey: indexPk.primaryKey,
-        })
-        .waitTask();
-      await client
-        .updateIndex(indexPk.uid, {
-          primaryKey: "newPrimaryKey",
-        })
-        .waitTask();
-
-      const index = await client.getIndex(indexPk.uid);
-
-      expect(index).toHaveProperty("uid", indexPk.uid);
-      expect(index).toHaveProperty("primaryKey", "newPrimaryKey");
-    });
-
-    test(`${permission} key: update primary key on an index that has already a primary key and fail`, async () => {
-      const client = await getClient(permission);
-      await client
-        .createIndex(indexPk.uid, { primaryKey: indexPk.primaryKey })
-        .waitTask();
-      await client
-        .index(indexPk.uid)
-        .update({ primaryKey: "newPrimaryKey" })
-        .waitTask();
-
-      const index = await client.getIndex(indexPk.uid);
-
-      expect(index).toHaveProperty("uid", indexPk.uid);
-      expect(index).toHaveProperty("primaryKey", "newPrimaryKey");
-    });
-
-    test(`${permission} key: delete index`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-      await client.index(indexNoPk.uid).delete().waitTask();
-
-      const { results } = await client.getIndexes();
-
-      expect(results).toHaveLength(0);
-    });
-
-    test(`${permission} key: delete index using client`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexPk.uid);
-      await client.deleteIndex(indexPk.uid).waitTask();
-
-      const { results } = await client.getIndexes();
-
-      expect(results).toHaveLength(0);
-    });
-
-    test(`${permission} key: fetch deleted index should fail`, async () => {
-      const client = await getClient(permission);
-      const index = client.index(indexNoPk.uid);
-      await expect(index.getRawInfo()).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INDEX_NOT_FOUND,
-      );
-    });
-
-    test(`${permission} key: get deleted raw index should fail through client`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getRawIndex(indexNoPk.uid)).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INDEX_NOT_FOUND,
-      );
-    });
-
-    test(`${permission} key: delete index with uid that does not exist should fail`, async () => {
-      const client = await getClient(permission);
-      const index = client.index(indexNoPk.uid);
-      const task = await index.delete().waitTask();
-
-      expect(task.status).toBe("failed");
-    });
-
-    test(`${permission} key: get stats of an index`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexNoPk.uid).waitTask();
-
-      const response = await client.index(indexNoPk.uid).getStats();
-
-      expect(response).toHaveProperty("numberOfDocuments", 0);
-      expect(response).toHaveProperty("isIndexing", false);
-      expect(response).toHaveProperty("fieldDistribution", {});
-      expect(response).toHaveProperty("numberOfEmbeddedDocuments", 0);
-      expect(response).toHaveProperty("numberOfEmbeddings", 0);
-      expect(response).toHaveProperty("rawDocumentDbSize", 0);
-      expect(response).toHaveProperty("avgDocumentSize", 0);
-    });
-
-    test(`${permission} key: Get updatedAt and createdAt through fetch info`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const index = await client.index(indexPk.uid).fetchInfo();
-
-      expect(index.createdAt).toBeInstanceOf(Date);
-      expect(index.updatedAt).toBeInstanceOf(Date);
-    });
-
-    test(`${permission} key: Get updatedAt and createdAt index through getRawInfo`, async () => {
-      const client = await getClient(permission);
-      await client.createIndex(indexPk.uid).waitTask();
-
-      const index = client.index(indexPk.uid);
-
-      expect(index.createdAt).toBe(undefined);
-      expect(index.updatedAt).toBe(undefined);
-
-      await index.getRawInfo();
-
-      expect(index.createdAt).toBeInstanceOf(Date);
-      expect(index.updatedAt).toBeInstanceOf(Date);
-    });
-  },
-);
-
-describe.each([{ permission: "Search" }])(
-  "Test on routes with search key",
-  ({ permission }) => {
-    beforeEach(() => {
-      return clearAllIndexes(config);
-    });
-
-    test(`${permission} key: try to get index info and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(
-        client.index(indexNoPk.uid).getRawInfo(),
-      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
-    });
-
-    test(`${permission} key: try to get raw index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getRawIndex(indexNoPk.uid)).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INVALID_API_KEY,
-      );
-    });
-
-    test(`${permission} key: try to delete index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.index(indexPk.uid).delete()).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INVALID_API_KEY,
-      );
-    });
-
-    test(`${permission} key: try to update index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(
-        client.index(indexPk.uid).update({ primaryKey: indexPk.primaryKey }),
-      ).rejects.toHaveProperty("cause.code", ErrorStatusCode.INVALID_API_KEY);
-    });
-
-    test(`${permission} key: try to get stats and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.index(indexPk.uid).getStats()).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.INVALID_API_KEY,
-      );
-    });
-  },
-);
-
-describe.each([{ permission: "No" }])(
-  "Test on routes without an API key",
-  ({ permission }) => {
-    beforeEach(() => {
-      return clearAllIndexes(config);
-    });
-
-    test(`${permission} key: try to get all indexes and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getIndexes()).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
-      );
-    });
-
-    test(`${permission} key: try to get index info and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(
-        client.index(indexNoPk.uid).getRawInfo(),
-      ).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
-      );
-    });
-
-    test(`${permission} key: try to get raw index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.getRawIndex(indexNoPk.uid)).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
-      );
-    });
-
-    test(`${permission} key: try to delete index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(client.index(indexPk.uid).delete()).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
-      );
-    });
-
-    test(`${permission} key: try to update index and be denied`, async () => {
-      const client = await getClient(permission);
-      await expect(
-        client.index(indexPk.uid).update({ primaryKey: indexPk.primaryKey }),
-      ).rejects.toHaveProperty(
-        "cause.code",
-        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
-      );
-    });
-  },
-);
-
-describe.each([
-  { host: BAD_HOST, trailing: false },
-  { host: `${BAD_HOST}/api`, trailing: false },
-  { host: `${BAD_HOST}/trailing/`, trailing: true },
-])("Tests on url construction", ({ host, trailing }) => {
-  test(`getStats route`, async () => {
-    const route = `indexes/${indexPk.uid}/stats`;
-    const client = new MeiliSearch({ host });
-    const strippedHost = trailing ? host.slice(0, -1) : host;
-    await expect(client.index(indexPk.uid).getStats()).rejects.toHaveProperty(
-      "message",
-      `Request to ${strippedHost}/${route} has failed`,
-    );
+import { test, afterAll } from "vitest";
+import { getClient, assert } from "./utils/meilisearch-test-utils.js";
+import { Index, type SwapIndexesPayload } from "../src/index.js";
+
+const MY_INDEX_ONE = "my-index-one";
+const MY_INDEX_TWO = "my-index-two";
+const client = await getClient("Master");
+
+test.concurrent("index method", () => {
+  const myIndex = client.index(MY_INDEX_ONE);
+  assert.instanceOf(myIndex, Index);
+});
+
+afterAll(async () => {
+  await Promise.all([
+    client.deleteIndexIfExists(MY_INDEX_ONE),
+    client.deleteIndexIfExists(MY_INDEX_TWO),
+  ]);
+});
+
+test("createIndex and getIndex method", async () => {
+  const primaryKey = "objectID";
+  await client.createIndex({ uid: MY_INDEX_ONE, primaryKey }).waitTask();
+
+  const { createdAt, updatedAt, ...myIndex } =
+    await client.getIndex(MY_INDEX_ONE);
+
+  assert.deepEqual(myIndex, {
+    primaryKey,
+    uid: MY_INDEX_ONE,
   });
+  assert.typeOf(createdAt, "string");
+  assert.typeOf(updatedAt, "string");
+});
 
-  test(`getRawInfo route`, async () => {
-    const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
-    const strippedHost = trailing ? host.slice(0, -1) : host;
-    await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
-      "message",
-      `Request to ${strippedHost}/${route} has failed`,
-    );
-    await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
-      "name",
-      "MeiliSearchRequestError",
-    );
-  });
+test("updateIndex method", async () => {
+  const primaryKey = "id";
+  await client.updateIndex(MY_INDEX_ONE, { primaryKey }).waitTask();
 
-  test(`getRawIndex route`, async () => {
-    const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
-    const strippedHost = trailing ? host.slice(0, -1) : host;
-    await expect(client.getRawIndex(indexPk.uid)).rejects.toHaveProperty(
-      "message",
-      `Request to ${strippedHost}/${route} has failed`,
-    );
-    await expect(client.getRawIndex(indexPk.uid)).rejects.toHaveProperty(
-      "name",
-      "MeiliSearchRequestError",
-    );
-  });
+  const {
+    createdAt: _ca,
+    updatedAt: _ua,
+    ...myIndex
+  } = await client.getIndex(MY_INDEX_ONE);
 
-  test(`updateIndex route`, async () => {
-    const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
-    const strippedHost = trailing ? host.slice(0, -1) : host;
-    await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
-      "message",
-      `Request to ${strippedHost}/${route} has failed`,
-    );
+  assert.deepEqual(myIndex, {
+    primaryKey,
+    uid: MY_INDEX_ONE,
   });
+});
 
-  test(`delete index route`, async () => {
-    const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
-    const strippedHost = trailing ? host.slice(0, -1) : host;
-    await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
-      "message",
-      `Request to ${strippedHost}/${route} has failed`,
-    );
-  });
+test("deleteIndex method", async () => {
+  const task = await client.deleteIndex(MY_INDEX_ONE).waitTask();
+  assert.strictEqual(task.status, "succeeded");
+});
+
+test("swapIndexes method", async () => {
+  const indexOne = client.index(MY_INDEX_ONE);
+  const indexTwo = client.index(MY_INDEX_TWO);
+
+  const doc1 = { id: 1, title: "index_1" };
+  const doc2 = { id: 1, title: "index_2" };
+
+  await indexOne.addDocuments([doc1]).waitTask();
+  await indexTwo.addDocuments([doc2]).waitTask();
+
+  const swaps: SwapIndexesPayload[] = [
+    { indexes: [MY_INDEX_ONE, MY_INDEX_TWO] },
+  ];
+
+  const task = await client.swapIndexes(swaps).waitTask();
+  const docIndex1 = await indexOne.getDocument(doc2.id);
+  const docIndex2 = await indexTwo.getDocument(doc1.id);
+
+  assert.deepEqual(doc1, docIndex2);
+  assert.deepEqual(doc2, docIndex1);
+
+  const { type, details } = task;
+  assert.deepEqual(
+    { type, details },
+    { details: { swaps }, type: "indexSwap" },
+  );
 });

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -136,7 +136,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       });
 
       const newClient = new MeiliSearch({ host: HOST, apiKey: key.key });
-      await newClient.createIndex("wildcard_keys_permission"); // test index creation
+      await newClient.createIndex({ uid: "wildcard_keys_permission" }); // test index creation
       const task = await newClient
         .index("wildcard_keys_permission")
         .addDocuments([{ id: 1 }])

--- a/tests/localized_attributes.test.ts
+++ b/tests/localized_attributes.test.ts
@@ -108,7 +108,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get localizedAttributes and be denied`, async () => {
@@ -139,7 +139,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get localizedAttributes and be denied`, async () => {

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -84,7 +84,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get pagination and be denied`, async () => {
@@ -115,7 +115,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get pagination and be denied`, async () => {

--- a/tests/prefix_search_settings.test.ts
+++ b/tests/prefix_search_settings.test.ts
@@ -59,7 +59,7 @@ describe.each([{ permission: "Search" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get prefix search settings and be denied`, async () => {
@@ -91,7 +91,7 @@ describe.each([{ permission: "No" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get prefix search settings and be denied`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -126,8 +126,8 @@ describe.each([
   beforeAll(async () => {
     await clearAllIndexes(config);
     const client = await getClient("Master");
-    await client.createIndex(index.uid);
-    await client.createIndex(emptyIndex.uid);
+    await client.createIndex({ uid: index.uid });
+    await client.createIndex({ uid: emptyIndex.uid });
 
     const newFilterableAttributes = ["genre", "title", "id", "author"];
     await client
@@ -292,7 +292,7 @@ describe.each([
     const masterClient = await getClient("Master");
 
     // Setup to have a new "movies" index
-    await masterClient.createIndex("movies");
+    await masterClient.createIndex({ uid: "movies" });
     const newFilterableAttributes = ["title", "id"];
     await masterClient
       .index("movies")
@@ -370,7 +370,7 @@ describe.each([
     const masterClient = await getClient("Master");
 
     // Setup to have a new "movies" index
-    await masterClient.createIndex("movies");
+    await masterClient.createIndex({ uid: "movies" });
     const newFilterableAttributes = ["title", "id"];
     await masterClient
       .index("movies")
@@ -1247,7 +1247,7 @@ describe.each([
   test(`${permission} key: Try to search on deleted index and fail`, async () => {
     const client = await getClient(permission);
     const masterClient = await getClient("Master");
-    await masterClient.index(index.uid).delete().waitTask();
+    await masterClient.deleteIndex(index.uid).waitTask();
 
     await expect(
       client.index(index.uid).search("prince", {}),
@@ -1260,7 +1260,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: Try Basic search and be denied`, async () => {
@@ -1289,7 +1289,7 @@ describe.each([{ permission: "Master" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid);
+      await client.createIndex({ uid: index.uid });
 
       await client.index(index.uid).addDocuments(datasetWithNests).waitTask();
     });
@@ -1363,7 +1363,7 @@ describe.each([
   beforeAll(async () => {
     const client = await getClient("Master");
     await clearAllIndexes(config);
-    await client.createIndex(index.uid).waitTask();
+    await client.createIndex({ uid: index.uid }).waitTask();
   });
 
   test(`${permission} key: search on index and abort`, async () => {

--- a/tests/search_cutoff_ms.test.ts
+++ b/tests/search_cutoff_ms.test.ts
@@ -101,7 +101,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get searchCutoffMs and be denied`, async () => {
@@ -132,7 +132,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get searchCutoffMs and be denied`, async () => {

--- a/tests/searchable_attributes.test.ts
+++ b/tests/searchable_attributes.test.ts
@@ -78,7 +78,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {
@@ -109,7 +109,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get searchable attributes and be denied`, async () => {

--- a/tests/sortable_attributes.test.ts
+++ b/tests/sortable_attributes.test.ts
@@ -29,7 +29,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
 
       await client.index(index.uid).addDocuments(dataset).waitTask();
     });
@@ -79,7 +79,7 @@ describe.each([{ permission: "Search" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get sortable attributes and be denied`, async () => {
@@ -110,7 +110,7 @@ describe.each([{ permission: "No" }])(
   ({ permission }) => {
     beforeAll(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: try to get sortable attributes and be denied`, async () => {

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -31,7 +31,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     test(`${permission} key: Get one enqueued task`, async () => {
@@ -92,7 +92,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       const client = await getClient(permission);
       await client.index(index.uid).addDocuments([{ id: 1 }]);
       await client.index(index.uid).deleteDocument(1);
-      await client.createIndex(index2.uid);
+      await client.createIndex({ uid: index2.uid });
 
       const tasks = await client.tasks.getTasks({
         types: ["documentAdditionOrUpdate", "documentDeletion"],

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -83,7 +83,7 @@ describe.each([{ permission: "Admin" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.index(UID).delete();
+      await client.deleteIndex(UID).waitTask();
       await client.index(UID).addDocuments(dataset).waitTask();
 
       const keys = await client.getKeys();

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -113,8 +113,8 @@ describe.each([
     const client = await getClient("Master");
     await clearAllIndexes(config);
 
-    await client.createIndex(index.uid).waitTask();
-    await client.createIndex(emptyIndex.uid).waitTask();
+    await client.createIndex({ uid: index.uid }).waitTask();
+    await client.createIndex({ uid: emptyIndex.uid }).waitTask();
 
     const newFilterableAttributes = ["genre", "title"];
     await client
@@ -393,7 +393,7 @@ describe.each([
   test(`${permission} key: Try to Search on deleted index and fail`, async () => {
     const client = await getClient(permission);
     const masterClient = await getClient("Master");
-    await masterClient.index<Movie>(index.uid).delete().waitTask();
+    await masterClient.deleteIndex(index.uid).waitTask();
 
     await expect(
       client.index<Movie>(index.uid).search("prince"),
@@ -407,7 +407,7 @@ describe.each([{ permission: "Master" }])(
     beforeEach(async () => {
       await clearAllIndexes(config);
       const client = await getClient("Master");
-      await client.createIndex(index.uid);
+      await client.createIndex({ uid: index.uid });
 
       await client.index(index.uid).addDocuments(datasetWithNests).waitTask();
     });

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -79,12 +79,10 @@ async function getClient(permission: string): Promise<MeiliSearch> {
 
 const clearAllIndexes = async (config: Config): Promise<void> => {
   const client = new MeiliSearch(config);
-  const { results } = await client.getRawIndexes();
+  const { results } = await client.getIndexes();
 
   await Promise.all(
-    results.map((v) =>
-      client.index(v.uid).delete().waitTask({ timeout: 60_000 }),
-    ),
+    results.map((v) => client.deleteIndex(v.uid).waitTask({ timeout: 60_000 })),
   );
 };
 

--- a/tests/wait_for_task.test.ts
+++ b/tests/wait_for_task.test.ts
@@ -19,7 +19,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
   ({ permission }) => {
     beforeEach(async () => {
       const client = await getClient("Master");
-      await client.createIndex(index.uid).waitTask();
+      await client.createIndex({ uid: index.uid }).waitTask();
     });
 
     // Client Wait for task


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- refactors index types so that they match the `meilisearch` rust source code model as much as possible
- removes index manipulating methods from `Index` class to avoid duplicate code
  - to compensate for this, make index manipulating methods accept `Index` instances as well as string UIDs
- remove methods that query and then create `Index` instances from queried data
- refactor tests for these methods
  - TODO: Explain why the tests are so short

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
