### PR TITLE
Add `disableOnNumbers` to typo tolerance settings

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -398,6 +398,10 @@ typo_tolerance_guide_4: |-
       twoTypos: 10
     }
   })
+typo_tolerance_guide_5: |-
+  client.index('movies').updateTypoTolerance({
+    disableOnNumbers: true
+  })
 add_movies_json_1: |-
   const movies = require('./movies.json')
   client.index('movies').addDocuments(movies).then((res) => console.log(res))

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -963,9 +963,7 @@ export class Index<T extends RecordAny = RecordAny> {
    *   settings.
    * @returns Promise containing object of the enqueued update
    */
-  updateTypoTolerance(
-    typoTolerance: Partial<TypoTolerance> | null,
-  ): EnqueuedTaskPromise {
+  updateTypoTolerance(typoTolerance: TypoTolerance): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
       path: `indexes/${this.uid}/settings/typo-tolerance`,
       body: typoTolerance,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -963,7 +963,9 @@ export class Index<T extends RecordAny = RecordAny> {
    *   settings.
    * @returns Promise containing object of the enqueued update
    */
-  updateTypoTolerance(typoTolerance: TypoTolerance): EnqueuedTaskPromise {
+  updateTypoTolerance(
+    typoTolerance: Partial<TypoTolerance> | null,
+  ): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.patch({
       path: `indexes/${this.uid}/settings/typo-tolerance`,
       body: typoTolerance,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -521,14 +521,15 @@ export type RankingRules = string[] | null;
 export type StopWords = string[] | null;
 export type Synonyms = Record<string, string[]> | null;
 export type TypoTolerance = {
-  enabled?: boolean | null;
-  disableOnAttributes?: string[] | null;
-  disableOnWords?: string[] | null;
-  minWordSizeForTypos?: {
-    oneTypo?: number | null;
-    twoTypos?: number | null;
+  enabled: boolean;
+  disableOnAttributes: string[];
+  disableOnNumbers: boolean;
+  disableOnWords: string[];
+  minWordSizeForTypos: {
+    oneTypo: number;
+    twoTypos: number;
   };
-} | null;
+};
 export type SeparatorTokens = string[] | null;
 export type NonSeparatorTokens = string[] | null;
 export type Dictionary = string[] | null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -521,15 +521,15 @@ export type RankingRules = string[] | null;
 export type StopWords = string[] | null;
 export type Synonyms = Record<string, string[]> | null;
 export type TypoTolerance = {
-  enabled: boolean;
-  disableOnAttributes: string[];
-  disableOnNumbers: boolean;
-  disableOnWords: string[];
-  minWordSizeForTypos: {
-    oneTypo: number;
-    twoTypos: number;
+  enabled?: boolean | null;
+  disableOnAttributes?: string[] | null;
+  disableOnNumbers?: boolean | null;
+  disableOnWords?: string[] | null;
+  minWordSizeForTypos?: {
+    oneTypo?: number | null;
+    twoTypos?: number | null;
   };
-};
+} | null;
 export type SeparatorTokens = string[] | null;
 export type NonSeparatorTokens = string[] | null;
 export type Dictionary = string[] | null;

--- a/tests/__snapshots__/settings.test.ts.snap
+++ b/tests/__snapshots__/settings.test.ts.snap
@@ -41,6 +41,7 @@ exports[`Test on settings > Admin key: Get default settings of an index 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -92,6 +93,7 @@ exports[`Test on settings > Admin key: Get default settings of empty index with 
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -143,6 +145,7 @@ exports[`Test on settings > Admin key: Reset embedders settings  1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -194,6 +197,7 @@ exports[`Test on settings > Admin key: Reset settings 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -245,6 +249,7 @@ exports[`Test on settings > Admin key: Reset settings of empty index 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -305,6 +310,7 @@ exports[`Test on settings > Admin key: Update embedders settings  1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -356,6 +362,7 @@ exports[`Test on settings > Admin key: Update facetSearch settings on empty inde
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -407,6 +414,7 @@ exports[`Test on settings > Admin key: Update prefixSearch settings on an empty 
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -458,6 +466,7 @@ exports[`Test on settings > Admin key: Update searchableAttributes settings on e
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -509,6 +518,7 @@ exports[`Test on settings > Admin key: Update searchableAttributes settings on e
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -579,6 +589,7 @@ exports[`Test on settings > Admin key: Update settings 1`] = `
     "disableOnAttributes": [
       "comment",
     ],
+    "disableOnNumbers": false,
     "disableOnWords": [
       "prince",
     ],
@@ -630,6 +641,7 @@ exports[`Test on settings > Admin key: Update settings on empty index with prima
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -681,6 +693,7 @@ exports[`Test on settings > Admin key: Update settings with all null values 1`] 
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -732,6 +745,7 @@ exports[`Test on settings > Master key: Get default settings of an index 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -783,6 +797,7 @@ exports[`Test on settings > Master key: Get default settings of empty index with
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -834,6 +849,7 @@ exports[`Test on settings > Master key: Reset embedders settings  1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -885,6 +901,7 @@ exports[`Test on settings > Master key: Reset settings 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -936,6 +953,7 @@ exports[`Test on settings > Master key: Reset settings of empty index 1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -996,6 +1014,7 @@ exports[`Test on settings > Master key: Update embedders settings  1`] = `
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1047,6 +1066,7 @@ exports[`Test on settings > Master key: Update facetSearch settings on empty ind
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1098,6 +1118,7 @@ exports[`Test on settings > Master key: Update prefixSearch settings on an empty
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1149,6 +1170,7 @@ exports[`Test on settings > Master key: Update searchableAttributes settings on 
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1200,6 +1222,7 @@ exports[`Test on settings > Master key: Update searchableAttributes settings on 
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1270,6 +1293,7 @@ exports[`Test on settings > Master key: Update settings 1`] = `
     "disableOnAttributes": [
       "comment",
     ],
+    "disableOnNumbers": false,
     "disableOnWords": [
       "prince",
     ],
@@ -1321,6 +1345,7 @@ exports[`Test on settings > Master key: Update settings on empty index with prim
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {
@@ -1372,6 +1397,7 @@ exports[`Test on settings > Master key: Update settings with all null values 1`]
   "synonyms": {},
   "typoTolerance": {
     "disableOnAttributes": [],
+    "disableOnNumbers": false,
     "disableOnWords": [],
     "enabled": true,
     "minWordSizeForTypos": {

--- a/tests/__snapshots__/typo_tolerance.test.ts.snap
+++ b/tests/__snapshots__/typo_tolerance.test.ts.snap
@@ -1,0 +1,79 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Tests on typo tolerance > Admin key: Get default typo tolerance settings 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;
+
+exports[`Tests on typo tolerance > Admin key: Reset typo tolerance settings 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;
+
+exports[`Tests on typo tolerance > Admin key: Update typo tolerance using null as value 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;
+
+exports[`Tests on typo tolerance > Master key: Get default typo tolerance settings 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;
+
+exports[`Tests on typo tolerance > Master key: Reset typo tolerance settings 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;
+
+exports[`Tests on typo tolerance > Master key: Update typo tolerance using null as value 1`] = `
+{
+  "disableOnAttributes": [],
+  "disableOnNumbers": false,
+  "disableOnWords": [],
+  "enabled": true,
+  "minWordSizeForTypos": {
+    "oneTypo": 5,
+    "twoTypos": 9,
+  },
+}
+`;

--- a/tests/typo_tolerance.test.ts
+++ b/tests/typo_tolerance.test.ts
@@ -13,16 +13,6 @@ const index = {
   uid: "movies_test",
 };
 
-const defaultTypoTolerance = {
-  enabled: true,
-  minWordSizeForTypos: {
-    oneTypo: 5,
-    twoTypos: 9,
-  },
-  disableOnWords: [],
-  disableOnAttributes: [],
-};
-
 afterAll(() => {
   return clearAllIndexes(config);
 });
@@ -39,7 +29,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
     test(`${permission} key: Get default typo tolerance settings`, async () => {
       const client = await getClient(permission);
       const response = await client.index(index.uid).getTypoTolerance();
-      expect(response).toEqual(defaultTypoTolerance);
+      expect(response).toMatchSnapshot();
     });
 
     test(`${permission} key: Update typo tolerance settings`, async () => {
@@ -52,6 +42,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         },
         disableOnWords: ["title"],
         disableOnAttributes: ["hello"],
+        disableOnNumbers: true,
       };
       await client
         .index(index.uid)
@@ -59,7 +50,6 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         .waitTask();
 
       const response = await client.index(index.uid).getTypoTolerance();
-
       expect(response).toEqual(newTypoTolerance);
     });
 
@@ -69,7 +59,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       const response = await client.index(index.uid).getTypoTolerance();
 
-      expect(response).toEqual(defaultTypoTolerance);
+      expect(response).toMatchSnapshot();
     });
 
     test(`${permission} key: Reset typo tolerance settings`, async () => {
@@ -78,7 +68,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       const response = await client.index(index.uid).getTypoTolerance();
 
-      expect(response).toEqual(defaultTypoTolerance);
+      expect(response).toMatchSnapshot();
     });
   },
 );


### PR DESCRIPTION
# Pull Request

This PR updates the typo tolerance settings to allow [deactivating typo tolerance on high entropy words](https://meilisearch.notion.site/Deactivate-typo-tolerance-on-specific-kinds-of-terms-1a44b06b651f809d9cb7db67b322a4b8).

Related engine issue: https://github.com/meilisearch/meilisearch/issues/5344

## What does this PR do?
- Update typo tolerance settings to accept and return `disableOnNumbers: bool` field
- Update tests to use `toMatchSnapshot()` instead of manually testing against a "default settings" object

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to control typo tolerance on numeric values.

- **Tests**
  - Updated tests to use snapshot testing for typo tolerance settings.
  - Added test coverage for the new numeric typo tolerance option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->