### PR TITLE
Update experimental features

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch:v1.15.0
+    image: getmeili/meilisearch
     ports:
       - "7700:7700"
     environment:

--- a/src/types/experimental-features.ts
+++ b/src/types/experimental-features.ts
@@ -11,4 +11,5 @@ export type RuntimeTogglableFeatures = {
   network?: boolean | null;
   getTaskDocumentsRoute?: boolean | null;
   compositeEmbedders?: boolean | null;
+  chatCompletions?: boolean | null;
 };

--- a/tests/experimental-features.test.ts
+++ b/tests/experimental-features.test.ts
@@ -13,6 +13,7 @@ afterAll(async () => {
     network: false,
     getTaskDocumentsRoute: false,
     compositeEmbedders: false,
+    chatCompletions: false,
   } satisfies { [TKey in keyof RuntimeTogglableFeatures]-?: false });
 });
 
@@ -25,6 +26,7 @@ test(`${ms.updateExperimentalFeatures.name} and ${ms.getExperimentalFeatures.nam
     network: true,
     getTaskDocumentsRoute: true,
     compositeEmbedders: true,
+    chatCompletions: true,
   };
 
   const updateFeatures = await ms.updateExperimentalFeatures(features);


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- updates experimental features with new `chatCompletions` property
- makes docker compose use latest meilisearch (workflow tests already use latest version!!) (will have to implement something for keeping library versions in sync with their supported meilisearch versions in a future issue + PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new experimental feature flag for "chat completions" that can be toggled at runtime.

* **Chores**
  * Updated Docker Compose configuration to use the latest Meilisearch image by default. 

* **Tests**
  * Enhanced experimental feature tests to include the new "chat completions" flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->