### PR TITLE
Make experimental features tests more permissive

### DIFF
--- a/tests/experimental-features.test.ts
+++ b/tests/experimental-features.test.ts
@@ -29,9 +29,22 @@ test(`${ms.updateExperimentalFeatures.name} and ${ms.getExperimentalFeatures.nam
     chatCompletions: true,
   };
 
-  const updateFeatures = await ms.updateExperimentalFeatures(features);
-  assert.deepEqual(updateFeatures, features);
+  const updateResponse = await ms.updateExperimentalFeatures(features);
+  const getResponse = await ms.getExperimentalFeatures();
 
-  const getFeatures = await ms.getExperimentalFeatures();
-  assert.deepEqual(getFeatures, features);
+  for (const [feature, expectedValue] of Object.entries(features)) {
+    assert.propertyVal(
+      updateResponse,
+      feature,
+      expectedValue,
+      `Failed on updateResponse for feature: ${feature}`,
+    );
+
+    assert.propertyVal(
+      getResponse,
+      feature,
+      expectedValue,
+      `Failed on getResponse for feature: ${feature}`,
+    );
+  }
 });


### PR DESCRIPTION
## Why

- Make Meilisearch CI run pass: https://github.com/meilisearch/meilisearch/actions/runs/16573762878/job/46872729296

## What does this PR do?

- Prevents tests from breaking when a new experimental feature is added



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for experimental features by adding more granular, feature-specific assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->