### PR TITLE
Implement webhooks API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch
+    # TODO: the prototype tag needs to be removed before merging on `main`
+    image: getmeili/meilisearch:prototype-webhooks-0
     ports:
       - "7700:7700"
     environment:

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -29,6 +29,9 @@ import type {
   Network,
   RecordAny,
   RuntimeTogglableFeatures,
+  Webhook,
+  ResultsWrapper,
+  WebhookCreation,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -272,6 +275,32 @@ export class MeiliSearch {
       body: queries,
       extraRequestInit,
     });
+  }
+
+  ///
+  /// WEBHOOKS
+  ///
+
+  async listWebhooks(): Promise<ResultsWrapper<Webhook[]>> {
+    return await this.httpRequest.get({ path: "webhooks" });
+  }
+
+  async createWebhook(webhook: WebhookCreation): Promise<Webhook> {
+    return await this.httpRequest.post({ path: "webhooks", body: webhook });
+  }
+
+  async updateWebhook(
+    uuid: string,
+    webhook: WebhookCreation,
+  ): Promise<Webhook> {
+    return await this.httpRequest.patch({
+      path: `webhooks/${uuid}`,
+      body: webhook,
+    });
+  }
+
+  async deleteWebhook(uuid: string): Promise<void> {
+    await this.httpRequest.delete({ path: `webhooks/${uuid}` });
   }
 
   ///

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./experimental-features.js";
 export * from "./task_and_batch.js";
 export * from "./token.js";
 export * from "./types.js";
+export * from "./webhooks.js";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -131,6 +131,10 @@ export type ResourceResults<T> = Pagination & {
   total: number;
 };
 
+export type ResultsWrapper<T> = {
+  results: T;
+};
+
 ///
 /// Indexes
 ///

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,0 +1,8 @@
+export type Webhook = {
+  uuid: string;
+  url: string;
+  headers?: Record<string, string>;
+  isEditable: boolean;
+};
+
+export type WebhookCreation = Omit<Webhook, "uuid" | "isEditable">;

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,0 +1,79 @@
+import { expect, it, describe, beforeAll, afterAll } from "vitest";
+import { getClient } from "./utils/meilisearch-test-utils.js";
+import { Meilisearch, type WebhookCreation } from "../src/index.js";
+
+let adminClient: Meilisearch;
+
+beforeAll(async () => {
+  adminClient = await getClient("Admin");
+});
+
+afterAll(async () => {
+  const response = await adminClient.listWebhooks();
+  for (const webhook of response.results) {
+    await adminClient.deleteWebhook(webhook.uuid);
+  }
+});
+
+describe("webhooks", () => {
+  it("can list webhooks", async () => {
+    const response = await adminClient.listWebhooks();
+    expect(response).toHaveProperty("results");
+    expect(response.results).toBeInstanceOf(Array);
+  });
+
+  it("can create a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+    const response = await adminClient.createWebhook(webhook);
+    expect(response).toHaveProperty("uuid");
+    expect(response).toHaveProperty("url", webhook.url);
+    expect(response).toHaveProperty("headers", webhook.headers);
+    expect(response).toHaveProperty("isEditable", true);
+  });
+
+  it("can update a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+    const updatedWebhook = {
+      ...webhook,
+      url: "https://example.com/updated",
+      headers: {
+        authorization: "UPDATED TOKEN",
+      },
+    } satisfies WebhookCreation;
+
+    const createdWebhook = await adminClient.createWebhook(webhook);
+    const response = await adminClient.updateWebhook(
+      createdWebhook.uuid,
+      updatedWebhook,
+    );
+
+    expect(response).toHaveProperty("url", updatedWebhook.url);
+    expect(response).toHaveProperty("headers", updatedWebhook.headers);
+  });
+
+  it("can delete a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+
+    const createdWebhook = await adminClient.createWebhook(webhook);
+    const deleteResponse = await adminClient.deleteWebhook(createdWebhook.uuid);
+    expect(deleteResponse).toBeUndefined();
+
+    const listResponse = await adminClient.listWebhooks();
+    expect(listResponse.results).not.toContainEqual(createdWebhook);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1991 

## What does this PR do?
- Add methods to interact with the `/wehbooks` API routes
- Add tests

## Testing
Until v1.17.0 is released, you can run the tests locally by using the `get/meilisearch:prototype-webhooks-0` Docker image.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced webhook management capabilities, allowing users to list, create, update, and delete webhooks.
* **Tests**
  * Added comprehensive tests to ensure reliable webhook operations.
* **Chores**
  * Updated service configuration to use a specific image tag for Meilisearch in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->