### PR TITLE
Implement webhooks API

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -823,3 +823,23 @@ update_embedders_1: |-
       documentTemplate: 'A document titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}'
     }
   });
+webhooks_get_1: |-
+  client.getWebhooks()
+webhooks_get_single_1: |-
+  client.getWebhook(WEBHOOK_UUID)
+webhooks_post_1: |-
+  client.createWebhook({
+    url: 'WEBHOOK_TARGET_URL',
+    headers: {
+      authorization: 'SECURITY_KEY',
+      referer: 'https://example.com'
+    }
+  })
+webhooks_patch_1: |-
+  client.updateWebhook(WEBHOOK_UUID, {
+    headers: {
+      referer: null
+    }
+  })
+webhooks_delete_1: |-
+  client.deleteWebhook(WEBHOOK_UUID)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch
+    # TODO: the prototype tag needs to be removed before merging on `main`
+    image: getmeili/meilisearch:prototype-webhooks-0
     ports:
       - "7700:7700"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    # TODO: the prototype tag needs to be removed before merging on `main`
-    image: getmeili/meilisearch:prototype-webhooks-0
+    image: getmeili/meilisearch
     ports:
       - "7700:7700"
     environment:

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -31,7 +31,7 @@ import type {
   RuntimeTogglableFeatures,
   Webhook,
   ResultsWrapper,
-  WebhookCreation,
+  WebhookPayload,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -281,24 +281,45 @@ export class MeiliSearch {
   /// WEBHOOKS
   ///
 
-  async listWebhooks(): Promise<ResultsWrapper<Webhook[]>> {
+  /**
+   * Get all webhooks
+   *
+   * @returns Promise returning an object with webhooks
+   */
+  async getWebhooks(): Promise<ResultsWrapper<Webhook[]>> {
     return await this.httpRequest.get({ path: "webhooks" });
   }
 
-  async createWebhook(webhook: WebhookCreation): Promise<Webhook> {
+  /**
+   * Create a webhook
+   *
+   * @param webhook - Webhook to create
+   * @returns Promise returning the created webhook
+   */
+  async createWebhook(webhook: WebhookPayload): Promise<Webhook> {
     return await this.httpRequest.post({ path: "webhooks", body: webhook });
   }
 
-  async updateWebhook(
-    uuid: string,
-    webhook: WebhookCreation,
-  ): Promise<Webhook> {
+  /**
+   * Update a webhook
+   *
+   * @param uuid - Webhook UUID
+   * @param webhook - Webhook to update
+   * @returns Promise returning the updated webhook
+   */
+  async updateWebhook(uuid: string, webhook: WebhookPayload): Promise<Webhook> {
     return await this.httpRequest.patch({
       path: `webhooks/${uuid}`,
       body: webhook,
     });
   }
 
+  /**
+   * Delete a webhook
+   *
+   * @param uuid - Webhook UUID
+   * @returns Promise returning void
+   */
   async deleteWebhook(uuid: string): Promise<void> {
     await this.httpRequest.delete({ path: `webhooks/${uuid}` });
   }

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -29,6 +29,9 @@ import type {
   Network,
   RecordAny,
   RuntimeTogglableFeatures,
+  Webhook,
+  ResultsWrapper,
+  WebhookCreation,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -272,6 +275,32 @@ export class MeiliSearch {
       body: queries,
       extraRequestInit,
     });
+  }
+
+  ///
+  /// WEBHOOKS
+  ///
+
+  async listWebhooks(): Promise<ResultsWrapper<Webhook[]>> {
+    return await this.httpRequest.get({ path: "webhooks" });
+  }
+
+  async createWebhook(webhook: WebhookCreation): Promise<Webhook> {
+    return await this.httpRequest.post({ path: "webhooks", body: webhook });
+  }
+
+  async updateWebhook(
+    uuid: string,
+    webhook: WebhookCreation,
+  ): Promise<Webhook> {
+    return await this.httpRequest.patch({
+      path: `webhooks/${uuid}`,
+      body: webhook,
+    });
+  }
+
+  async deleteWebhook(uuid: string): Promise<void> {
+    await this.httpRequest.delete({ path: `webhooks/${uuid}` });
   }
 
   ///

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -291,6 +291,16 @@ export class MeiliSearch {
   }
 
   /**
+   * Get a webhook
+   *
+   * @param uuid - Webhook UUID
+   * @returns Promise returning the webhook
+   */
+  async getWebhook(uuid: string): Promise<Webhook> {
+    return await this.httpRequest.get({ path: `webhooks/${uuid}` });
+  }
+
+  /**
    * Create a webhook
    *
    * @param webhook - Webhook to create

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -31,7 +31,8 @@ import type {
   RuntimeTogglableFeatures,
   Webhook,
   ResultsWrapper,
-  WebhookPayload,
+  WebhookCreatePayload,
+  WebhookUpdatePayload,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -306,7 +307,7 @@ export class MeiliSearch {
    * @param webhook - Webhook to create
    * @returns Promise returning the created webhook
    */
-  async createWebhook(webhook: WebhookPayload): Promise<Webhook> {
+  async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
     return await this.httpRequest.post({ path: "webhooks", body: webhook });
   }
 
@@ -317,7 +318,10 @@ export class MeiliSearch {
    * @param webhook - Webhook to update
    * @returns Promise returning the updated webhook
    */
-  async updateWebhook(uuid: string, webhook: WebhookPayload): Promise<Webhook> {
+  async updateWebhook(
+    uuid: string,
+    webhook: WebhookUpdatePayload,
+  ): Promise<Webhook> {
     return await this.httpRequest.patch({
       path: `webhooks/${uuid}`,
       body: webhook,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./experimental-features.js";
 export * from "./task_and_batch.js";
 export * from "./token.js";
 export * from "./types.js";
+export * from "./webhooks.js";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -131,6 +131,10 @@ export type ResourceResults<T> = Pagination & {
   total: number;
 };
 
+export type ResultsWrapper<T> = {
+  results: T;
+};
+
 ///
 /// Indexes
 ///

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,5 +1,3 @@
-import type { SafeOmit } from "./shared.js";
-
 export type Webhook = {
   uuid: string;
   url: string;
@@ -7,9 +5,7 @@ export type Webhook = {
   isEditable: boolean;
 };
 
-export type WebhookPayload = SafeOmit<
-  Webhook,
-  "uuid" | "isEditable" | "url"
-> & {
+export type WebhookPayload = {
   url?: string;
+  headers?: Record<string, string>;
 };

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,0 +1,8 @@
+export type Webhook = {
+  uuid: string;
+  url: string;
+  headers?: Record<string, string>;
+  isEditable: boolean;
+};
+
+export type WebhookCreation = Omit<Webhook, "uuid" | "isEditable">;

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -5,4 +5,4 @@ export type Webhook = {
   isEditable: boolean;
 };
 
-export type WebhookCreation = Omit<Webhook, "uuid" | "isEditable">;
+export type WebhookPayload = Omit<Webhook, "uuid" | "isEditable">;

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,3 +1,5 @@
+import type { SafeOmit } from "./shared.js";
+
 export type Webhook = {
   uuid: string;
   url: string;
@@ -5,4 +7,9 @@ export type Webhook = {
   isEditable: boolean;
 };
 
-export type WebhookPayload = Omit<Webhook, "uuid" | "isEditable">;
+export type WebhookPayload = SafeOmit<
+  Webhook,
+  "uuid" | "isEditable" | "url"
+> & {
+  url?: string;
+};

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,11 +1,20 @@
 export type Webhook = {
+  /** A v4 uuid Meilisearch automatically generates when you create a new webhook */
   uuid: string;
+  /** The URL Meilisearch should notify whenever it completes a task */
   url: string;
+  /** An object with HTTP headers and their values */
   headers?: Record<string, string>;
+  /**
+   * `true` for all webhooks created via the API and `false` for reserved
+   * webhooks
+   */
   isEditable: boolean;
 };
 
 export type WebhookPayload = {
+  /** The URL Meilisearch should notify whenever it completes a task */
   url?: string;
+  /** An object with HTTP headers and their values */
   headers?: Record<string, string>;
 };

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -12,7 +12,14 @@ export type Webhook = {
   isEditable: boolean;
 };
 
-export type WebhookPayload = {
+export type WebhookCreatePayload = {
+  /** The URL Meilisearch should notify whenever it completes a task */
+  url: string;
+  /** An object with HTTP headers and their values */
+  headers?: Record<string, string>;
+};
+
+export type WebhookUpdatePayload = {
   /** The URL Meilisearch should notify whenever it completes a task */
   url?: string;
   /** An object with HTTP headers and their values */

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -15,7 +15,9 @@ beforeAll(async () => {
 afterAll(async () => {
   const response = await adminClient.getWebhooks();
   for (const webhook of response.results) {
-    await adminClient.deleteWebhook(webhook.uuid);
+    if (webhook.isEditable) {
+      await adminClient.deleteWebhook(webhook.uuid);
+    }
   }
 });
 

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -15,6 +15,13 @@ afterAll(async () => {
   }
 });
 
+const WEBHOOK_PAYLOAD = {
+  url: "https://example.com",
+  headers: {
+    authorization: "TOKEN",
+  },
+} satisfies WebhookPayload;
+
 describe("webhooks", () => {
   it("can list webhooks", async () => {
     const response = await adminClient.getWebhooks();
@@ -23,35 +30,23 @@ describe("webhooks", () => {
   });
 
   it("can create a webhook", async () => {
-    const webhook = {
-      url: "https://example.com",
-      headers: {
-        authorization: "TOKEN",
-      },
-    } satisfies WebhookPayload;
-    const response = await adminClient.createWebhook(webhook);
+    const response = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
     expect(response).toHaveProperty("uuid");
-    expect(response).toHaveProperty("url", webhook.url);
-    expect(response).toHaveProperty("headers", webhook.headers);
+    expect(response).toHaveProperty("url", WEBHOOK_PAYLOAD.url);
+    expect(response).toHaveProperty("headers", WEBHOOK_PAYLOAD.headers);
     expect(response).toHaveProperty("isEditable", true);
   });
 
   it("can update a webhook", async () => {
-    const webhook = {
-      url: "https://example.com",
-      headers: {
-        authorization: "TOKEN",
-      },
-    } satisfies WebhookPayload;
     const updatedWebhook = {
-      ...webhook,
+      ...WEBHOOK_PAYLOAD,
       url: "https://example.com/updated",
       headers: {
         authorization: "UPDATED TOKEN",
       },
     } satisfies WebhookPayload;
 
-    const createdWebhook = await adminClient.createWebhook(webhook);
+    const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
     const response = await adminClient.updateWebhook(
       createdWebhook.uuid,
       updatedWebhook,
@@ -61,15 +56,26 @@ describe("webhooks", () => {
     expect(response).toHaveProperty("headers", updatedWebhook.headers);
   });
 
-  it("can delete a webhook", async () => {
-    const webhook = {
-      url: "https://example.com",
+  it("can update a webhook without updating the URL", async () => {
+    const updatedWebhook = {
+      ...WEBHOOK_PAYLOAD,
       headers: {
-        authorization: "TOKEN",
+        authorization: "UPDATED TOKEN",
       },
     } satisfies WebhookPayload;
 
-    const createdWebhook = await adminClient.createWebhook(webhook);
+    const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
+    const response = await adminClient.updateWebhook(
+      createdWebhook.uuid,
+      updatedWebhook,
+    );
+
+    expect(response).toHaveProperty("url", WEBHOOK_PAYLOAD.url);
+    expect(response).toHaveProperty("headers", updatedWebhook.headers);
+  });
+
+  it("can delete a webhook", async () => {
+    const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
     const deleteResponse = await adminClient.deleteWebhook(createdWebhook.uuid);
     expect(deleteResponse).toBeUndefined();
 

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe, beforeAll, afterAll } from "vitest";
 import { getClient } from "./utils/meilisearch-test-utils.js";
-import { Meilisearch, type WebhookCreation } from "../src/index.js";
+import { Meilisearch, type WebhookPayload } from "../src/index.js";
 
 let adminClient: Meilisearch;
 
@@ -9,7 +9,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  const response = await adminClient.listWebhooks();
+  const response = await adminClient.getWebhooks();
   for (const webhook of response.results) {
     await adminClient.deleteWebhook(webhook.uuid);
   }
@@ -17,7 +17,7 @@ afterAll(async () => {
 
 describe("webhooks", () => {
   it("can list webhooks", async () => {
-    const response = await adminClient.listWebhooks();
+    const response = await adminClient.getWebhooks();
     expect(response).toHaveProperty("results");
     expect(response.results).toBeInstanceOf(Array);
   });
@@ -28,7 +28,7 @@ describe("webhooks", () => {
       headers: {
         authorization: "TOKEN",
       },
-    } satisfies WebhookCreation;
+    } satisfies WebhookPayload;
     const response = await adminClient.createWebhook(webhook);
     expect(response).toHaveProperty("uuid");
     expect(response).toHaveProperty("url", webhook.url);
@@ -42,14 +42,14 @@ describe("webhooks", () => {
       headers: {
         authorization: "TOKEN",
       },
-    } satisfies WebhookCreation;
+    } satisfies WebhookPayload;
     const updatedWebhook = {
       ...webhook,
       url: "https://example.com/updated",
       headers: {
         authorization: "UPDATED TOKEN",
       },
-    } satisfies WebhookCreation;
+    } satisfies WebhookPayload;
 
     const createdWebhook = await adminClient.createWebhook(webhook);
     const response = await adminClient.updateWebhook(
@@ -67,13 +67,13 @@ describe("webhooks", () => {
       headers: {
         authorization: "TOKEN",
       },
-    } satisfies WebhookCreation;
+    } satisfies WebhookPayload;
 
     const createdWebhook = await adminClient.createWebhook(webhook);
     const deleteResponse = await adminClient.deleteWebhook(createdWebhook.uuid);
     expect(deleteResponse).toBeUndefined();
 
-    const listResponse = await adminClient.listWebhooks();
+    const listResponse = await adminClient.getWebhooks();
     expect(listResponse.results).not.toContainEqual(createdWebhook);
   });
 });

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -37,6 +37,14 @@ describe("webhooks", () => {
     expect(response).toHaveProperty("isEditable", true);
   });
 
+  it("can fetch a webhook", async () => {
+    const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
+    const response = await adminClient.getWebhook(createdWebhook.uuid);
+    expect(response).toHaveProperty("uuid", createdWebhook.uuid);
+    expect(response).toHaveProperty("url", WEBHOOK_PAYLOAD.url);
+    expect(response).toHaveProperty("headers", WEBHOOK_PAYLOAD.headers);
+  });
+
   it("can update a webhook", async () => {
     const updatedWebhook = {
       ...WEBHOOK_PAYLOAD,

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,0 +1,79 @@
+import { expect, it, describe, beforeAll, afterAll } from "vitest";
+import { getClient } from "./utils/meilisearch-test-utils.js";
+import { Meilisearch, type WebhookCreation } from "../src/index.js";
+
+let adminClient: Meilisearch;
+
+beforeAll(async () => {
+  adminClient = await getClient("Admin");
+});
+
+afterAll(async () => {
+  const response = await adminClient.listWebhooks();
+  for (const webhook of response.results) {
+    await adminClient.deleteWebhook(webhook.uuid);
+  }
+});
+
+describe("webhooks", () => {
+  it("can list webhooks", async () => {
+    const response = await adminClient.listWebhooks();
+    expect(response).toHaveProperty("results");
+    expect(response.results).toBeInstanceOf(Array);
+  });
+
+  it("can create a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+    const response = await adminClient.createWebhook(webhook);
+    expect(response).toHaveProperty("uuid");
+    expect(response).toHaveProperty("url", webhook.url);
+    expect(response).toHaveProperty("headers", webhook.headers);
+    expect(response).toHaveProperty("isEditable", true);
+  });
+
+  it("can update a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+    const updatedWebhook = {
+      ...webhook,
+      url: "https://example.com/updated",
+      headers: {
+        authorization: "UPDATED TOKEN",
+      },
+    } satisfies WebhookCreation;
+
+    const createdWebhook = await adminClient.createWebhook(webhook);
+    const response = await adminClient.updateWebhook(
+      createdWebhook.uuid,
+      updatedWebhook,
+    );
+
+    expect(response).toHaveProperty("url", updatedWebhook.url);
+    expect(response).toHaveProperty("headers", updatedWebhook.headers);
+  });
+
+  it("can delete a webhook", async () => {
+    const webhook = {
+      url: "https://example.com",
+      headers: {
+        authorization: "TOKEN",
+      },
+    } satisfies WebhookCreation;
+
+    const createdWebhook = await adminClient.createWebhook(webhook);
+    const deleteResponse = await adminClient.deleteWebhook(createdWebhook.uuid);
+    expect(deleteResponse).toBeUndefined();
+
+    const listResponse = await adminClient.listWebhooks();
+    expect(listResponse.results).not.toContainEqual(createdWebhook);
+  });
+});

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -1,6 +1,10 @@
 import { expect, it, describe, beforeAll, afterAll } from "vitest";
 import { getClient } from "./utils/meilisearch-test-utils.js";
-import { Meilisearch, type WebhookPayload } from "../src/index.js";
+import {
+  Meilisearch,
+  type WebhookCreatePayload,
+  type WebhookUpdatePayload,
+} from "../src/index.js";
 
 let adminClient: Meilisearch;
 
@@ -20,7 +24,7 @@ const WEBHOOK_PAYLOAD = {
   headers: {
     authorization: "TOKEN",
   },
-} satisfies WebhookPayload;
+} satisfies WebhookCreatePayload;
 
 describe("webhooks", () => {
   it("can list webhooks", async () => {
@@ -52,7 +56,7 @@ describe("webhooks", () => {
       headers: {
         authorization: "UPDATED TOKEN",
       },
-    } satisfies WebhookPayload;
+    } satisfies WebhookUpdatePayload;
 
     const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
     const response = await adminClient.updateWebhook(
@@ -70,7 +74,7 @@ describe("webhooks", () => {
       headers: {
         authorization: "UPDATED TOKEN",
       },
-    } satisfies WebhookPayload;
+    } satisfies WebhookUpdatePayload;
 
     const createdWebhook = await adminClient.createWebhook(WEBHOOK_PAYLOAD);
     const response = await adminClient.updateWebhook(


### PR DESCRIPTION
> [!warning]
> Do not merge before the release of **Meilisearch 1.17.0**

## Related issue
Fixes #1991 

## What does this PR do?
- Add methods to interact with the `/wehbooks` API routes
- Add tests

## Testing
Until v1.17.0 is released, you can run the tests locally by using the `get/meilisearch:prototype-webhooks-0` Docker image.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook management in the client: list, fetch single, create, update (including partial), and delete webhooks.
* **Types**
  * Introduced webhook-related types and a generic wrapper for list results to improve type safety and exports.
* **Tests**
  * Added end-to-end tests covering the full webhook lifecycle (list, create, fetch, update, partial update, delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->