### PR TITLE
Use package.json directly for version in `src` files, bundle ESM too with Vite

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -10,12 +10,5 @@ if [ "$current_tag" != "$package_json_version" ]; then
   exit 1
 fi
 
-package_version_ts=$(grep "PACKAGE_VERSION =" src/package-version.ts | cut -d "=" -f 2- | tr -d ';' | tr -d " " | tr -d '"')
-if [ "$current_tag" != "$package_version_ts" ]; then
-  echo "Error: the current tag does not match the version in src/package-version.ts."
-  echo "$current_tag vs $package_version_ts"
-  exit 1
-fi
-
 echo 'OK'
 exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,12 +125,6 @@ Make a PR modifying the following files with the right version:
 "version": "X.X.X",
 ```
 
-[`src/package-version`](/src/package-version.ts)
-
-```javascript
-export const PACKAGE_VERSION = 'X.X.X'
-```
-
 #### Github publish
 
 Once the changes are merged on `main`, you can publish the current draft release via the [GitHub interface](https://github.com/meilisearch/meilisearch-js/releases): on this page, click on `Edit` (related to the draft release) > update the description (be sure you apply [these recommendations](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md#writting-the-release-description)) > when you are ready, click on `Publish release`.

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -6,7 +6,7 @@ import type {
   URLSearchParamsRecord,
   MeiliSearchErrorResponse,
 } from "./types/index.js";
-import { PACKAGE_VERSION } from "./package-version.js";
+import pkg from "../package.json" with { type: "json" };
 import {
   MeiliSearchError,
   MeiliSearchApiError,
@@ -42,7 +42,7 @@ function appendRecordToURLSearchParams(
  */
 function getHeaders(config: Config, headersInit?: HeadersInit): Headers {
   const agentHeader = "X-Meilisearch-Client";
-  const packageAgent = `Meilisearch JavaScript (v${PACKAGE_VERSION})`;
+  const packageAgent = `Meilisearch JavaScript (v${pkg.version})`;
   const contentType = "Content-Type";
   const authorization = "Authorization";
 

--- a/src/package-version.ts
+++ b/src/package-version.ts
@@ -1,1 +1,0 @@
-export const PACKAGE_VERSION = "0.52.0";

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -10,7 +10,7 @@ import {
 } from "vitest";
 import type { Health, Version, Stats, IndexSwap } from "../src/index.js";
 import { ErrorStatusCode, MeiliSearchRequestError } from "../src/index.js";
-import { PACKAGE_VERSION } from "../src/package-version.js";
+import pkg from "../package.json" with { type: "json" };
 import {
   clearAllIndexes,
   getKey,
@@ -320,7 +320,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         assert.instanceOf(requestInit.headers, Headers);
         assert.strictEqual(
           requestInit.headers.get("X-Meilisearch-Client"),
-          `Meilisearch JavaScript (v${PACKAGE_VERSION})`,
+          `Meilisearch JavaScript (v${pkg.version})`,
         );
       });
 
@@ -341,7 +341,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         assert.instanceOf(requestInit.headers, Headers);
         assert.strictEqual(
           requestInit.headers.get("X-Meilisearch-Client"),
-          `Meilisearch JavaScript (v${PACKAGE_VERSION})`,
+          `Meilisearch JavaScript (v${pkg.version})`,
         );
       });
 
@@ -362,7 +362,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         assert.instanceOf(requestInit.headers, Headers);
         assert.strictEqual(
           requestInit.headers.get("X-Meilisearch-Client"),
-          `random plugin 1 ; random plugin 2 ; Meilisearch JavaScript (v${PACKAGE_VERSION})`,
+          `random plugin 1 ; random plugin 2 ; Meilisearch JavaScript (v${pkg.version})`,
         );
       });
     });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,10 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "declarationMap": true,
-    "declarationDir": "./dist/types",
-    "sourceMap": true,
-    "outDir": "./dist/esm"
+    "declarationDir": "./dist/types"
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- removes the need for updating separately a version file within `src/`
  - this requires bundling ESM too with Vite rather than building it with TypeScript