### PR TITLE
feat: support Meilisearch v1.18.0 (queryVector + index renaming)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -31,6 +31,8 @@ create_an_index_1: |-
   client.createIndex('movies', { primaryKey: 'id' })
 update_an_index_1: |-
   client.updateIndex('movies', { primaryKey: 'id' })
+rename_an_index_1: |-
+  client.updateIndex('INDEX_A', { indexUid: 'INDEX_B' })
 delete_an_index_1: |-
   client.deleteIndex('movies')
 swap_indexes_1: |-

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -141,6 +141,7 @@ export type ResultsWrapper<T> = {
 
 export type IndexOptions = {
   primaryKey?: string;
+  indexUid?: string;
 };
 
 export type IndexObject = {
@@ -408,6 +409,7 @@ export type SearchResponse<
   facetDistribution?: FacetDistribution;
   facetStats?: FacetStats;
   facetsByIndex?: FacetsByIndex;
+  queryVector?: number[];
 } & (undefined extends S
   ? Partial<FinitePagination & InfinitePagination>
   : true extends IsFinitePagination<NonNullable<S>>

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -566,6 +566,46 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
           ErrorStatusCode.INVALID_SWAP_DUPLICATE_INDEX_FOUND,
         );
       });
+
+      test(`${permission} key: Swap two indexes with rename`, async () => {
+        const client = await getClient(permission);
+        const originalUid1 = index.uid;
+        const originalUid2 = index2.uid;
+
+        await client
+          .index(originalUid1)
+          .addDocuments([{ id: 1, title: "index_1" }])
+          .waitTask();
+        await client
+          .index(originalUid2)
+          .addDocuments([{ id: 1, title: "index_2" }])
+          .waitTask();
+
+        const swaps: IndexSwap[] = [
+          { indexes: [originalUid1, originalUid2], rename: true },
+        ];
+
+        const resolvedTask = await client.swapIndexes(swaps).waitTask();
+
+        // Verify the old indexes no longer exist
+        await expect(client.getIndex(originalUid1)).rejects.toHaveProperty(
+          "cause.code",
+          ErrorStatusCode.INDEX_NOT_FOUND,
+        );
+        await expect(client.getIndex(originalUid2)).rejects.toHaveProperty(
+          "cause.code",
+          ErrorStatusCode.INDEX_NOT_FOUND,
+        );
+
+        // Verify the new indexes exist with swapped content
+        const docIndex1 = await client.index(originalUid1).getDocument(1);
+        const docIndex2 = await client.index(originalUid2).getDocument(1);
+
+        expect(docIndex1.title).toEqual("index_2");
+        expect(docIndex2.title).toEqual("index_1");
+        expect(resolvedTask.type).toEqual("indexSwap");
+        expect(resolvedTask.details?.swaps).toEqual(swaps);
+      });
     });
 
     describe("Test on base routes", () => {

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -520,6 +520,7 @@ describe.each([
     expect(response).toHaveProperty("hits", expect.any(Array));
     expect(response).toHaveProperty("query", "prince");
     expect(response.hits[0]).toHaveProperty("_vectors");
+    expect(response).toHaveProperty("queryVector", expect.any(Array));
   });
 
   test(`${permission} key: search without retrieveVectors`, async () => {
@@ -530,6 +531,7 @@ describe.each([
     expect(response).toHaveProperty("hits", expect.any(Array));
     expect(response).toHaveProperty("query", "prince");
     expect(response.hits[0]).not.toHaveProperty("_vectors");
+    expect(response).not.toHaveProperty("queryVector");
   });
 
   test(`${permission} key: matches position contain indices`, async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -292,6 +292,29 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       expect(index).toHaveProperty("primaryKey", "newPrimaryKey");
     });
 
+    test(`${permission} key: rename index using update method`, async () => {
+      const client = await getClient(permission);
+      const originalUid = indexNoPk.uid;
+      const newUid = "renamed_index";
+
+      await client.createIndex(originalUid).waitTask();
+      await client
+        .updateIndex(originalUid, {
+          indexUid: newUid,
+        })
+        .waitTask();
+
+      // Verify the old index no longer exists
+      await expect(client.getIndex(originalUid)).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.INDEX_NOT_FOUND,
+      );
+
+      // Verify the new index exists
+      const index = await client.getIndex(newUid);
+      expect(index).toHaveProperty("uid", newUid);
+    });
+
     test(`${permission} key: delete index`, async () => {
       const client = await getClient(permission);
       await client.createIndex(indexNoPk.uid).waitTask();

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1196,6 +1196,7 @@ describe.each([
     expect(response).toHaveProperty("hits", expect.any(Array));
     expect(response).toHaveProperty("query", "prince");
     expect(response.hits[0]).toHaveProperty("_vectors");
+    expect(response).toHaveProperty("queryVector", expect.any(Array));
   });
 
   test(`${permission} key: search without retrieveVectors`, async () => {
@@ -1206,6 +1207,7 @@ describe.each([
     expect(response).toHaveProperty("hits", expect.any(Array));
     expect(response).toHaveProperty("query", "prince");
     expect(response.hits[0]).not.toHaveProperty("_vectors");
+    expect(response).not.toHaveProperty("queryVector");
   });
 
   test(`${permission} key: Search with locales`, async () => {


### PR DESCRIPTION
# Pull Request
## Related issue
Fixes #2013

## What does this PR do?
This PR updates the SDK to support the new features in Meilisearch **v1.18**:

- Added `queryVector` field in search responses when `retrieveVectors` is used  
- Added support for renaming indexes with the optional `indexUid` parameter in `updateIndex`  
- Extended tests to cover both `queryVector` and index renaming  
- Added an example for index renaming in `.code-samples.meilisearch.yaml`  

These changes keep everything backward compatible.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thanks a lot for reviewing this PR!
