### PR TITLE
Fix tests for `attributesToSearchOn` set to null

### DIFF
--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -167,10 +167,10 @@ describe.each([
     const client = await getClient(permission);
 
     const response = await client.index(index.uid).searchGet("prince", {
-      attributesToSearchOn: null,
+      attributesToSearchOn: null, // same as without the option
     });
 
-    expect(response).toMatchSnapshot();
+    expect(response.hits.length).toEqual(2);
   });
 
   test(`${permission} key: search with options`, async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -652,10 +652,10 @@ describe.each([
     const client = await getClient(permission);
 
     const response = await client.index(index.uid).search("prince", {
-      attributesToSearchOn: null,
+      attributesToSearchOn: null, // same as without the option
     });
 
-    expect(response).toMatchSnapshot();
+    expect(response.hits.length).toEqual(2);
   });
 
   test(`${permission} key: search with array options`, async () => {


### PR DESCRIPTION
## why

Fix SDK tests breaking when running against a newer version of Meilisearch that introduces new fields in API responses.

In this example, adding `requestUid` to API responses should not break the SDK: https://github.com/meilisearch/meilisearch/actions/runs/18303698439/job/52122365050

## how 

Make tests more permissive by not asserting the API response against a snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to provide more explicit validation of search result counts instead of snapshot-based verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->