### PR TITLE
Improve dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
     labels:
-      - 'dependencies'
-    rebase-strategy: disabled
+      - "dependencies"
 
   - package-ecosystem: npm
-    directory: '/'
-
+    directory: "/"
     schedule:
-      interval: 'monthly'
-      time: '04:00'
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - dependencies
     versioning-strategy: increase
-    rebase-strategy: disabled
     groups:
-      production-dependencies:
-        dependency-type: "production"
+      eslint:
+        patterns:
+          - "*eslint*"
+          - "globals"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/coverage-v8"
+      prettier:
+        patterns:
+          - "prettier"
+          - "prettier-plugin-jsdoc"


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- groups dependencies that belong together, so that dependabot will update them together
- re-enables rebase strategy, I believe this should be on (it's the default)
- get rid of "04:00" update time on npm dependencies so it aligns with the action dependencies strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized npm dependency grouping for automated updates, creating separate groups for development tools (eslint, vitest, prettier).
  * Updated dependency management configuration format and removed certain update constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->