### PR TITLE
Disable publish git protections

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm build
       - name: Publish with latest tag
         if: github.event.release.prerelease == false
-        run: pnpm publish --provenance --access public
+        run: pnpm publish --no-git-checks --provenance --access public
       - name: Publish with beta tag
         if: github.event.release.prerelease
-        run: pnpm publish --provenance --access public --tag beta
+        run: pnpm publish --no-git-checks --provenance --access public --tag beta


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- removes safety checks from pnpm publish regarding git (https://stackoverflow.com/a/62675843)

I'm really not sure why this happens, because we git ignore every build artifact. I suspect it's because of how `actions/checkout` works, initially everything is uncommitted. I'll have to investigate more. Sorry @Strift for the trouble.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the automated package release workflow with configuration updates to improve consistency and reliability across all version distributions, including both standard and beta releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->