### PR TITLE
Remove unused code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -309,68 +309,6 @@ filtering_guide_nested_1: |-
   client.index('movie_ratings').search('thriller', {
     filter: 'rating.users >= 90'
   })
-search_parameter_guide_query_1: |-
-  client.index('movies').search('shifu')
-search_parameter_guide_offset_1: |-
-  client.index('movies').search('shifu', {
-    offset: 1
-  })
-search_parameter_guide_limit_1: |-
-  client.index('movies').search('shifu', {
-    limit: 2
-  })
-search_parameter_guide_retrieve_1: |-
-  client.index('movies').search('shifu', {
-    attributesToRetrieve: ['overview', 'title']
-  })
-search_parameter_guide_crop_1: |-
-  client.index('movies').search('shifu', {
-    attributesToCrop: ['overview'],
-    cropLength: 5
-  })
-search_parameter_guide_crop_marker_1: |-
-  client.index('movies').search('shifu', {
-    attributesToCrop: ['overview'],
-    cropMarker: '[…]'
-  })
-search_parameter_guide_highlight_1: |-
-  client.index('movies').search('winter feast', {
-    attributesToHighlight: ['overview']
-  })
-search_parameter_guide_highlight_tag_1: |-
-  client.index('movies').search('winter feast', {
-    attributesToHighlight: ['overview'],
-    highlightPreTag: '<span class="highlight">',
-    highlightPostTag: '</span>'
-  })
-search_parameter_guide_show_matches_position_1: |-
-  client.index('movies').search('winter feast', {
-    showMatchesPosition: true
-  })
-search_parameter_guide_matching_strategy_1: |-
-  client.index('movies').search('big fat liar', {
-    matchingStrategy: 'last'
-  })
-search_parameter_guide_matching_strategy_2: |-
-  client.index('movies').search('big fat liar', {
-    matchingStrategy: 'all'
-  })
-search_parameter_guide_hitsperpage_1: |-
-  client.index('movies').search('', {
-    hitsPerPage: 15
-  })
-search_parameter_guide_page_1: |-
-  client.index('movies').search('', {
-    page: 2
-  })
-search_parameter_guide_show_ranking_score_1: |-
-  client.index('movies').search('dragon', {
-    showRankingScore: true
-  })
-search_parameter_guide_attributes_to_search_on_1: |-
-  client.index('movies').search('adventure', {
-    attributesToSearchOn: ['overview']
-  })
 typo_tolerance_guide_1: |-
   client.index('movies').updateTypoTolerance({
     enabled: false
@@ -456,11 +394,6 @@ filtering_update_settings_1: |-
       'director',
       'genres'
     ])
-faceted_search_walkthrough_filter_1: |-
-  client.index('movies')
-    .search('thriller', {
-      filter: [['genres = Horror', 'genres = Mystery'], 'director = "Jordan Peele"']
-    })
 faceted_search_update_settings_1: |-
   client.index('movie_ratings').updateFilterableAttributes(['genres', 'rating', 'language'])
 faceted_search_1: |-
@@ -469,9 +402,6 @@ post_dump_1: |-
   client.createDump()
 create_snapshot_1: |-
   client.createSnapshot()
-phrase_search_1: |-
-  client.index('movies')
-    .search('"african american" horror')
 sorting_guide_update_sortable_attributes_1: |-
   client.index('books').updateSortableAttributes([
       'author',
@@ -532,10 +462,6 @@ update_dictionary_1: |-
   client.index('books').updateDictionary(['J. R. R.', 'W. E. B.'])
 reset_dictionary_1: |-
   client.index('books').resetDictionary()
-search_parameter_guide_sort_1: |-
-  client.index('books').search('science fiction', {
-    sort: ['price:asc'],
-  })
 get_separator_tokens_1: |-
   client.index('books').getSeparatorTokens()
 update_separator_tokens_1: |-
@@ -560,8 +486,6 @@ update_search_cutoff_1: |-
   client.index('movies').updateSearchCutoffMs(150)
 reset_search_cutoff_1: |-
   client.index('movies').resetSearchCutoffMs()
-search_parameter_guide_facet_stats_1: |-
-  client.index('movie_ratings').search('Batman', { facets: ['genres', 'rating'] })
 geosearch_guide_filter_settings_1: |-
   client.index('restaurants')
   .updateFilterableAttributes([
@@ -629,54 +553,12 @@ facet_search_3: |-
   })
 search_parameter_guide_show_ranking_score_details_1: |-
   client.index('movies').search('dragon', { showRankingScoreDetails: true })
-negative_search_1: |-
-  client.index('movies').search('-escape')
-negative_search_2: |-
-  client.index('movies').search('-"escape"')
-search_parameter_reference_ranking_score_threshold_1: |-
-  client.index('INDEX_NAME').search('badman', { rankingScoreThreshold: 0.2 })
-search_parameter_reference_retrieve_vectors_1: |-
-  client.index('INDEX_NAME').search('kitchen utensils', {
-    retrieveVectors: true,
-    hybrid: {
-      embedder: 'EMBEDDER_NAME'
-    }
-  })
-search_parameter_guide_hybrid_1: |-
-  client.index('INDEX_NAME').search('kitchen utensils', {
-    hybrid: {
-      semanticRatio: 0.9,
-      embedder: 'EMBEDDER_NAME'
-    }
-  })
 get_similar_post_1: |-
   client.index('INDEX_NAME').searchSimilarDocuments({ id: 'TARGET_DOCUMENT_ID', embedder: 'default' })
-search_parameter_guide_matching_strategy_3: |-
-  client.index('movies').search('white shirt', {
-    matchingStrategy: 'frequency'
-  })
-search_parameter_reference_distinct_1: |-
-  client.index('INDEX_NAME').search('QUERY TERMS', { distinct: 'ATTRIBUTE_A' })
 distinct_attribute_guide_filterable_1: |-
   client.index('products').updateFilterableAttributes(['product_id', 'sku', 'url'])
 distinct_attribute_guide_distinct_parameter_1: |-
   client.index('products').search('white shirt', { distinct: 'sku' })
-multi_search_federated_1: |-
-  client.multiSearch({
-    federation: {},
-    queries: [
-      {
-        indexUid: 'movies',
-        q: 'batman',
-      },
-      {
-        indexUid: 'comics',
-        q: 'batman',
-      },
-    ]
-  })
-search_parameter_reference_locales_1: |-
-  client.index('INDEX_NAME').search('QUERY TEXT IN JAPANESE', { locales: ['jpn'] })
 get_localized_attribute_settings_1: |-
   client.index('INDEX_NAME').getLocalizedAttributes()
 update_localized_attribute_settings_1: |-


### PR DESCRIPTION
## Summary

This PR removes 28 code samples that were identified as unused by the CI in the [meilisearch/documentation](https://github.com/meilisearch/documentation) repository.

The unused samples were detected during this CI run: https://github.com/meilisearch/documentation/actions/runs/22537551064/job/65287625968

The following keys have been removed from `.code-samples.meilisearch.yaml`:

- `faceted_search_walkthrough_filter_1`
- `multi_search_federated_1`
- `negative_search_1`
- `negative_search_2`
- `phrase_search_1`
- `search_parameter_guide_attributes_to_search_on_1`
- `search_parameter_guide_crop_1`
- `search_parameter_guide_crop_marker_1`
- `search_parameter_guide_facet_stats_1`
- `search_parameter_guide_highlight_1`
- `search_parameter_guide_highlight_tag_1`
- `search_parameter_guide_hitsperpage_1`
- `search_parameter_guide_hybrid_1`
- `search_parameter_guide_limit_1`
- `search_parameter_guide_matching_strategy_1`
- `search_parameter_guide_matching_strategy_2`
- `search_parameter_guide_matching_strategy_3`
- `search_parameter_guide_offset_1`
- `search_parameter_guide_page_1`
- `search_parameter_guide_query_1`
- `search_parameter_guide_retrieve_1`
- `search_parameter_guide_show_matches_position_1`
- `search_parameter_guide_show_ranking_score_1`
- `search_parameter_guide_sort_1`
- `search_parameter_reference_distinct_1`
- `search_parameter_reference_locales_1`
- `search_parameter_reference_ranking_score_threshold_1`
- `search_parameter_reference_retrieve_vectors_1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified code sample documentation by removing redundant example blocks, while preserving core filtering, sorting, and faceting samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->