### PR TITLE
Add `compact()` method for index compaction

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -621,6 +621,8 @@ webhooks_patch_1: |-
   })
 webhooks_delete_1: |-
   client.deleteWebhook(WEBHOOK_UUID)
+compact_index_1: |-
+  client.index('movies').compact()
 get_network_1: |-
   client.getNetwork()
 update_network_1: |-

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -542,6 +542,17 @@ export class Index<T extends RecordAny = RecordAny> {
   }
 
   /**
+   * Compact the index database to reclaim space and improve read performance.
+   *
+   * @returns Promise containing an EnqueuedTask
+   */
+  compact(): EnqueuedTaskPromise {
+    return this.#httpRequestsWithTask.post({
+      path: `indexes/${this.uid}/compact`,
+    });
+  }
+
+  /**
    * This is an EXPERIMENTAL feature, which may break without a major version.
    * It's available after Meilisearch v1.10.
    *

--- a/tests/compact.test.ts
+++ b/tests/compact.test.ts
@@ -1,0 +1,69 @@
+import { expect, test, describe, beforeEach, assert } from "vitest";
+import { ErrorStatusCode } from "../src/types/index.js";
+import {
+  clearAllIndexes,
+  config,
+  MeiliSearch,
+  BAD_HOST,
+  getClient,
+} from "./utils/meilisearch-test-utils.js";
+
+beforeEach(async () => {
+  await clearAllIndexes(config);
+});
+
+describe.each([{ permission: "Master" }, { permission: "Admin" }])(
+  "Test on compact should succeed with right permission",
+  ({ permission }) => {
+    test(`${permission} key: compact an index`, async () => {
+      const client = await getClient(permission);
+      await client.createIndex("movies").waitTask();
+      const taskResult = await client.index("movies").compact().waitTask();
+
+      assert.strictEqual(taskResult.status, "succeeded");
+    });
+  },
+);
+
+describe.each([{ permission: "Search" }])(
+  "Test on compact with search api key should not have access",
+  ({ permission }) => {
+    test(`${permission} key: try to compact index with search key and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(client.index("movies").compact()).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.INVALID_API_KEY,
+      );
+    });
+  },
+);
+
+describe.each([{ permission: "No" }])(
+  "Test on compact without api key should not have access",
+  ({ permission }) => {
+    test(`${permission} key: try to compact index with no key and be denied`, async () => {
+      const client = await getClient(permission);
+      await expect(client.index("movies").compact()).rejects.toHaveProperty(
+        "cause.code",
+        ErrorStatusCode.MISSING_AUTHORIZATION_HEADER,
+      );
+    });
+  },
+);
+
+describe.each([
+  { host: BAD_HOST, trailing: false },
+  { host: `${BAD_HOST}/api`, trailing: false },
+  { host: `${BAD_HOST}/trailing/`, trailing: true },
+])("Tests on url construction", ({ host, trailing }) => {
+  test(`compact route`, async () => {
+    const route = `indexes/movies/compact`;
+    const client = new MeiliSearch({ host });
+    const strippedHost = trailing ? host.slice(0, -1) : host;
+
+    await expect(client.index("movies").compact()).rejects.toHaveProperty(
+      "message",
+      `Request to ${strippedHost}/${route} has failed`,
+    );
+  });
+});

--- a/tests/compact.test.ts
+++ b/tests/compact.test.ts
@@ -3,7 +3,7 @@ import { ErrorStatusCode } from "../src/types/index.js";
 import {
   clearAllIndexes,
   config,
-  MeiliSearch,
+  Meilisearch,
   BAD_HOST,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
@@ -58,7 +58,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`compact route`, async () => {
     const route = `indexes/movies/compact`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
 
     await expect(client.index("movies").compact()).rejects.toHaveProperty(


### PR DESCRIPTION
## Summary

Adds support for the index compaction API introduced in Meilisearch v1.23 ([reference](https://www.meilisearch.com/docs/reference/api/indexes/compact-index)).

## Changes

- Added `compact()` method to the `Index` class — calls `POST /indexes/{indexUid}/compact`
- Added `tests/compact.test.ts` with permission, auth denial, and URL construction test cases
- Added `compact_index_1` code sample to `.code-samples.meilisearch.yaml`

## Usage

```ts
// Trigger compaction and wait for it to complete
const task = await client.index('movies').compact().waitTask();
console.log(task.status); // 'succeeded'
```

## Closes

Closes #2066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Index.compact()` to enqueue index compaction tasks.
* **Documentation**
  * Added a new code sample demonstrating how to call index compaction.
* **Tests**
  * Added end-to-end tests covering successful compaction, invalid/missing API key handling, error propagation, and URL/host construction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->