### PR TITLE
feat: add batchStrategy field to batches

### DIFF
--- a/src/types/task-and-batch.ts
+++ b/src/types/task-and-batch.ts
@@ -217,17 +217,35 @@ export type BatchProgress = {
 
 /** {@link https://www.meilisearch.com/docs/reference/api/batches#stats} */
 type BatchStats = {
+type BatchStats = {
+  totalNbTasks: number;
   totalNbTasks: number;
   status: Record<TaskStatus, number>;
+  status: Record<TaskStatus, number>;
+  types: Record<TaskType, number>;
   types: Record<TaskType, number>;
   indexUids: Record<string, number>;
+  indexUids: Record<string, number>;
+  /** {@link https://www.meilisearch.com/docs/reference/api/batches#progresstrace} */
   /** {@link https://www.meilisearch.com/docs/reference/api/batches#progresstrace} */
   progressTrace?: RecordAny;
+  progressTrace?: RecordAny;
+  /** {@link https://www.meilisearch.com/docs/reference/api/batches#writechannelcongestion} */
   /** {@link https://www.meilisearch.com/docs/reference/api/batches#writechannelcongestion} */
   writeChannelCongestion?: RecordAny;
+  writeChannelCongestion?: RecordAny;
+  /** {@link https://www.meilisearch.com/docs/reference/api/batches#internaldatabasesizes} */
   /** {@link https://www.meilisearch.com/docs/reference/api/batches#internaldatabasesizes} */
   internalDatabaseSizes?: RecordAny;
+  internalDatabaseSizes?: RecordAny;
 };
+
+/**
+ * {@link https://www.meilisearch.com/docs/reference/api/batches#batchstrategy}
+ *
+ * @see `meilisearch_types::batch_view::BatchStrategy`
+ */
+export type BatchStrategy = "auto" | "manual";
 
 /**
  * {@link https://www.meilisearch.com/docs/reference/api/batches#batch-object}
@@ -242,6 +260,7 @@ export type Batch = {
   duration: string | null;
   startedAt: string;
   finishedAt: string | null;
+  batchStrategy: BatchStrategy;
   // batcherStoppedBecause: unknown;
 };
 

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -44,6 +44,8 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       expect(batch.duration).toBeDefined();
       expect(batch.startedAt).toBeDefined();
       expect(batch.finishedAt).toBeDefined();
+      expect(batch.batchStrategy).toBeDefined();
+      expect(["auto", "manual"]).toContain(batch.batchStrategy);
       expect(batch.progress).toBeDefined();
     });
   },


### PR DESCRIPTION
## Summary

Implements the `batchStrategy` field for batches API responses as specified in Meilisearch v1.15.0.

Closes #1966

## Changes

### Type Definitions (`src/types/task-and-batch.ts`)
- Added `BatchStrategy` type with `"auto" | "manual"` values
- Added `batchStrategy: BatchStrategy` field to `Batch` type
- Includes JSDoc references to Meilisearch API documentation

### Tests (`tests/batch.test.ts`)
- Added test assertions to verify `batchStrategy` field is defined
- Added validation that `batchStrategy` value is either "auto" or "manual"

## Testing

The test suite validates:
- `batchStrategy` field is present in batch responses
- Field value is one of the expected enum values ("auto" or "manual")

## Related

- Meilisearch v1.15.0 mega issue: https://github.com/meilisearch/integration-guides/issues/316
- Meilisearch core issue: https://github.com/meilisearch/meilisearch/issues/5511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch strategy configuration, allowing selection between "auto" and "manual" processing modes to optimize batch handling.

* **Tests**
  * Enhanced test coverage for batch strategy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->