### PR TITLE
Migrate to ESM-only exports, remove deprecated exports

### DIFF
--- a/.github/workflows/meilisearch-prototype-tests.yml
+++ b/.github/workflows/meilisearch-prototype-tests.yml
@@ -47,7 +47,7 @@ jobs:
           - "7700:7700"
     strategy:
       matrix:
-        node-version: ["20", "22"]
+        node-version: ["20", "22", "24"]
     name: integration-tests (Node.js ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -44,7 +44,7 @@ jobs:
           - "7700:7700"
     strategy:
       matrix:
-        node-version: ["20", "22"]
+        node-version: ["20", "22", "24"]
     name: integration-tests (Node.js ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20", "22"]
+        node-version: ["20", "22", "24"]
     name: integration-tests (Node.js ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -84,16 +84,6 @@ After installing `meilisearch-js`, you must import it into your application. The
 
 </details>
 
-> [!WARNING]
->
-> - [default export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#using_the_default_export)
->   is deprecated and will be removed in a future version |
->   [Issue](https://github.com/meilisearch/meilisearch-js/issues/1789)
-> - regarding usage of package's UMD version via `script src`, exports will stop
->   being directly available on the
->   [global object](https://developer.mozilla.org/en-US/docs/Glossary/Global_object)
->   | [Issue](https://github.com/meilisearch/meilisearch-js/issues/1806)
-
 #### `import` syntax <!-- omit in toc -->
 
 Usage in an ES module environment:
@@ -109,20 +99,15 @@ const client = new Meilisearch({
 
 #### `<script>` tag <!-- omit in toc -->
 
-This package also contains a [UMD](https://stackoverflow.com/a/77284527) bundled
-version, which in this case is meant to be used in a
-[`script src`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#src)
-tag:
-
 ```html
-<script src="https://www.unpkg.com/meilisearch/dist/umd/index.min.js"></script>
-<script>
-  const client = new meilisearch.Meilisearch(/* ... */);
+<script type="module">
+  import { Meilisearch } from "https://www.unpkg.com/meilisearch";
+  const client = new Meilisearch(/* ... */);
   // ...
 </script>
 ```
 
-But keep in mind that each CDN ([JSDELIVR](https://www.jsdelivr.com),
+Keep in mind that each CDN ([JSDELIVR](https://www.jsdelivr.com),
 [ESM.SH](https://esm.sh/), etc.) provide more ways to import packages, make sure
 to read their documentation.
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
-  ignorePatterns: ["dist/", "tests/env/", "coverage/", "playgrounds/", "docs/"],
-
   env: { browser: true },
 
   // default rules

--- a/package.json
+++ b/package.json
@@ -17,23 +17,26 @@
   ],
   "license": "MIT",
   "type": "module",
-  "types": "./dist/types/index.d.ts",
-  "main": "./dist/umd/index.min.js",
   "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs",
-      "default": "./dist/umd/index.min.js"
-    },
-    "./token": {
-      "types": "./dist/types/token.d.ts",
-      "import": "./dist/esm/token.js",
-      "require": "./dist/cjs/token.cjs",
-      "default": "./dist/cjs/token.cjs"
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./token": "./dist/token.js",
+      "./package.json": "./package.json"
     }
   },
   "sideEffects": false,
+  "files": [
+    "src",
+    "dist",
+    "CONTRIBUTING.md"
+  ],
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/meilisearch/meilisearch-js.git"
@@ -41,8 +44,7 @@
   "scripts": {
     "playground:javascript": "vite serve playgrounds/javascript --open",
     "build:docs": "typedoc",
-    "build": "vite build && tsc -p tsconfig.build.json && vite --mode production-umd build",
-    "postbuild": "node scripts/build.js",
+    "build": "vite build && tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "types": "tsc -p tsconfig.json --noEmit",
@@ -55,14 +57,9 @@
     "style:fix": "pnpm fmt:fix && pnpm lint:fix",
     "prepare": "husky"
   },
-  "files": [
-    "src",
-    "dist",
-    "CONTRIBUTING.md"
-  ],
   "devDependencies": {
     "@types/node": "24.10.13",
-    "@vitest/coverage-v8": "4.0.18",
+    "@vitest/coverage-v8": "4.1.0",
     "eslint-plugin-tsdoc": "0.5.0",
     "globals": "^16.5.0",
     "husky": "^9.1.7",
@@ -72,9 +69,9 @@
     "prettier": "^3.8.1",
     "prettier-plugin-jsdoc": "^1.8.0",
     "typedoc": "^0.28.14",
-    "typescript": "^5.9.3",
-    "vite": "7.3.0",
-    "vitest": "4.0.18"
+    "typescript": "5.9.3",
+    "vite": "8.0.0",
+    "vitest": "4.1.0"
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/playgrounds/javascript/package.json
+++ b/playgrounds/javascript/package.json
@@ -9,6 +9,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^6.0.11"
+    "meilisearch": "workspace:*"
   }
 }

--- a/playgrounds/javascript/src/meilisearch.ts
+++ b/playgrounds/javascript/src/meilisearch.ts
@@ -1,4 +1,4 @@
-import { Index, Meilisearch } from "../../../src/index.js";
+import { Index, Meilisearch } from "meilisearch";
 
 const client = new Meilisearch({
   host: "http://127.0.0.1:7700",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 24.10.13
         version: 24.10.13
       '@vitest/coverage-v8':
-        specifier: 4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(@types/node@24.10.13)(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)))
       eslint-plugin-tsdoc:
         specifier: 0.5.0
         version: 0.5.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -42,20 +42,20 @@ importers:
         specifier: ^0.28.14
         version: 0.28.15(typescript@5.9.3)
       typescript:
-        specifier: ^5.9.3
+        specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 7.3.0
-        version: 7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        specifier: 8.0.0
+        version: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vitest:
-        specifier: 4.0.18
-        version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@24.10.13)(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
 
   playgrounds/javascript:
     devDependencies:
-      vite:
-        specifier: ^6.0.11
-        version: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      meilisearch:
+        specifier: workspace:*
+        version: link:../..
 
 packages:
 
@@ -80,11 +80,14 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
+  '@emnapi/core@1.7.1':
+    resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
+
+  '@emnapi/runtime@1.7.1':
+    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -92,22 +95,10 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -116,34 +107,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -152,22 +125,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -176,22 +137,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -200,22 +149,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -224,22 +161,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -248,22 +173,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -272,34 +185,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -308,22 +203,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -332,23 +215,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -356,34 +227,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -477,6 +330,9 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -488,6 +344,13 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
   '@oxlint-tsgolint/darwin-arm64@0.14.2':
     resolution: {integrity: sha512-03WxIXguCXf1pTmoG2C6vqRcbrU9GaJCW6uTIiQdIQq4BrJnVWZv99KEUQQRkuHK78lOLa9g7B4K58NcVcB54g==}
@@ -641,126 +504,103 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
-    resolution: {integrity: sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.53.3':
-    resolution: {integrity: sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
-    resolution: {integrity: sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.53.3':
-    resolution: {integrity: sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
-    resolution: {integrity: sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.53.3':
-    resolution: {integrity: sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
-    resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
-    resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
-    resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
-    resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
-    resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
-    resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
-    resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
-    resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
-    resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    resolution: {integrity: sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    resolution: {integrity: sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    resolution: {integrity: sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@shikijs/engine-oniguruma@3.19.0':
     resolution: {integrity: sha512-1hRxtYIJfJSZeM5ivbUXv9hcJP3PWRo5prG/V2sWwiubUKTa+7P62d2qxCW8jiVFX4pgRHhnHNp+qeR7Xl+6kg==}
@@ -779,6 +619,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -806,9 +649,6 @@ packages:
 
   '@types/node@24.10.13':
     resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
-
-  '@types/node@25.0.3':
-    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
   '@types/unist@3.0.2':
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
@@ -860,43 +700,43 @@ packages:
     resolution: {integrity: sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -937,8 +777,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@0.3.11:
-    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1006,6 +846,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1029,6 +872,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -1043,13 +890,8 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -1287,6 +1129,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -1500,8 +1416,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1554,9 +1470,9 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.53.3:
-    resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -1600,8 +1516,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1661,6 +1577,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1689,55 +1608,16 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@7.3.0:
-    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -1748,11 +1628,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -1769,20 +1651,21 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1847,157 +1730,95 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@esbuild/aix-ppc64@0.25.12':
+  '@emnapi/core@1.7.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm64@0.25.12':
-    optional: true
-
   '@esbuild/android-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.2':
     optional: true
 
-  '@esbuild/android-x64@0.25.12':
-    optional: true
-
   '@esbuild/android-x64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.12':
-    optional: true
-
   '@esbuild/darwin-x64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/freebsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm@0.25.12':
-    optional: true
-
   '@esbuild/linux-arm@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.12':
-    optional: true
-
   '@esbuild/linux-loong64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.12':
-    optional: true
-
   '@esbuild/linux-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.12':
-    optional: true
-
   '@esbuild/linux-s390x@0.27.2':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.12':
-    optional: true
-
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -2103,6 +1924,13 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.7.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2114,6 +1942,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
 
   '@oxlint-tsgolint/darwin-arm64@0.14.2':
     optional: true
@@ -2190,71 +2022,54 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.50.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.53.3':
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.53.3':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.53.3':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.53.3':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.53.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.53.3':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.53.3':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.53.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.53.3':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.53.3':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.53.3':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.53.3':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.53.3':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.53.3':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.53.3':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.53.3':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.53.3':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.53.3':
-    optional: true
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@shikijs/engine-oniguruma@3.19.0':
     dependencies:
@@ -2277,6 +2092,11 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2306,11 +2126,6 @@ snapshots:
   '@types/node@24.10.13':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/node@25.0.3':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
 
   '@types/unist@3.0.2': {}
 
@@ -2372,57 +2187,59 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@24.10.13)(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.11
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.1.0(@types/node@24.10.13)(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.0': {}
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
       tinyrainbow: 3.0.3
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -2461,7 +2278,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@0.3.11:
+  ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -2524,6 +2341,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2542,6 +2361,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-libc@2.1.2: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -2552,36 +2373,7 @@ snapshots:
 
   environment@1.1.0: {}
 
-  es-module-lexer@1.7.0: {}
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -2611,6 +2403,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+    optional: true
 
   escape-string-regexp@4.0.0: {}
 
@@ -2840,6 +2633,55 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   linkify-it@5.0.0:
     dependencies:
@@ -3159,7 +3001,7 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3203,33 +3045,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.53.3:
+  rolldown@1.0.0-rc.9:
     dependencies:
-      '@types/estree': 1.0.8
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.53.3
-      '@rollup/rollup-android-arm64': 4.53.3
-      '@rollup/rollup-darwin-arm64': 4.53.3
-      '@rollup/rollup-darwin-x64': 4.53.3
-      '@rollup/rollup-freebsd-arm64': 4.53.3
-      '@rollup/rollup-freebsd-x64': 4.53.3
-      '@rollup/rollup-linux-arm-gnueabihf': 4.53.3
-      '@rollup/rollup-linux-arm-musleabihf': 4.53.3
-      '@rollup/rollup-linux-arm64-gnu': 4.53.3
-      '@rollup/rollup-linux-arm64-musl': 4.53.3
-      '@rollup/rollup-linux-loong64-gnu': 4.53.3
-      '@rollup/rollup-linux-ppc64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-gnu': 4.53.3
-      '@rollup/rollup-linux-riscv64-musl': 4.53.3
-      '@rollup/rollup-linux-s390x-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-gnu': 4.53.3
-      '@rollup/rollup-linux-x64-musl': 4.53.3
-      '@rollup/rollup-openharmony-arm64': 4.53.3
-      '@rollup/rollup-win32-arm64-msvc': 4.53.3
-      '@rollup/rollup-win32-ia32-msvc': 4.53.3
-      '@rollup/rollup-win32-x64-gnu': 4.53.3
-      '@rollup/rollup-win32-x64-msvc': 4.53.3
-      fsevents: 2.3.3
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
 
   run-parallel@1.2.0:
     dependencies:
@@ -3265,7 +3100,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.0.0: {}
 
   string-argv@0.3.2: {}
 
@@ -3319,6 +3154,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tslib@2.8.1:
+    optional: true
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -3346,72 +3184,48 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
       picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.0.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.44.1
-      yaml: 2.8.2
-
-  vite@7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.10.13
+      esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
+  vitest@4.1.0(@types/node@24.10.13)(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.10.13)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   which@2.0.2:
     dependencies:

--- a/src/errors/meilisearch-api-error.ts
+++ b/src/errors/meilisearch-api-error.ts
@@ -1,12 +1,12 @@
-import type { MeiliSearchErrorResponse } from "../types/index.js";
-import { MeiliSearchError } from "./meilisearch-error.js";
+import type { MeilisearchErrorResponse } from "../types/index.js";
+import { MeilisearchError } from "./meilisearch-error.js";
 
-export class MeiliSearchApiError extends MeiliSearchError {
-  override name = "MeiliSearchApiError";
-  override cause?: MeiliSearchErrorResponse;
+export class MeilisearchApiError extends MeilisearchError {
+  override name = "MeilisearchApiError";
+  override cause?: MeilisearchErrorResponse;
   readonly response: Response;
 
-  constructor(response: Response, responseBody?: MeiliSearchErrorResponse) {
+  constructor(response: Response, responseBody?: MeilisearchErrorResponse) {
     super(
       responseBody?.message ?? `${response.status}: ${response.statusText}`,
     );

--- a/src/errors/meilisearch-error.ts
+++ b/src/errors/meilisearch-error.ts
@@ -1,3 +1,3 @@
-export class MeiliSearchError extends Error {
-  override name = "MeiliSearchError";
+export class MeilisearchError extends Error {
+  override name = "MeilisearchError";
 }

--- a/src/errors/meilisearch-request-error.ts
+++ b/src/errors/meilisearch-request-error.ts
@@ -1,7 +1,7 @@
-import { MeiliSearchError } from "./meilisearch-error.js";
+import { MeilisearchError } from "./meilisearch-error.js";
 
-export class MeiliSearchRequestError extends MeiliSearchError {
-  override name = "MeiliSearchRequestError";
+export class MeilisearchRequestError extends MeilisearchError {
+  override name = "MeilisearchRequestError";
 
   constructor(url: string, cause: unknown) {
     super(`Request to ${url} has failed`, { cause });

--- a/src/errors/meilisearch-request-timeout-error.ts
+++ b/src/errors/meilisearch-request-timeout-error.ts
@@ -1,8 +1,8 @@
-import { MeiliSearchError } from "./meilisearch-error.js";
+import { MeilisearchError } from "./meilisearch-error.js";
 
 /** Error thrown when a HTTP request times out. */
-export class MeiliSearchRequestTimeOutError extends MeiliSearchError {
-  override name = "MeiliSearchRequestTimeOutError";
+export class MeilisearchRequestTimeOutError extends MeilisearchError {
+  override name = "MeilisearchRequestTimeOutError";
   override cause: { timeout: number; requestInit: RequestInit };
 
   constructor(timeout: number, requestInit: RequestInit) {

--- a/src/errors/meilisearch-task-timeout-error.ts
+++ b/src/errors/meilisearch-task-timeout-error.ts
@@ -1,8 +1,8 @@
-import { MeiliSearchError } from "./meilisearch-error.js";
+import { MeilisearchError } from "./meilisearch-error.js";
 
 /** Error thrown when a waiting for a task times out. */
-export class MeiliSearchTaskTimeOutError extends MeiliSearchError {
-  override name = "MeiliSearchTaskTimeOutError";
+export class MeilisearchTaskTimeOutError extends MeilisearchError {
+  override name = "MeilisearchTaskTimeOutError";
   override cause: { taskUid: number; timeout: number };
 
   constructor(taskUid: number, timeout: number) {

--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -4,14 +4,14 @@ import type {
   RequestOptions,
   MainRequestOptions,
   URLSearchParamsRecord,
-  MeiliSearchErrorResponse,
+  MeilisearchErrorResponse,
 } from "./types/index.js";
 import pkg from "../package.json" with { type: "json" };
 import {
-  MeiliSearchError,
-  MeiliSearchApiError,
-  MeiliSearchRequestError,
-  MeiliSearchRequestTimeOutError,
+  MeilisearchError,
+  MeilisearchApiError,
+  MeilisearchRequestError,
+  MeilisearchRequestTimeOutError,
 } from "./errors/index.js";
 import { addProtocolIfNotPresent, addTrailingSlash } from "./utils.js";
 
@@ -148,7 +148,7 @@ export class HttpRequests {
     try {
       this.#url = new URL(host);
     } catch (error) {
-      throw new MeiliSearchError("The provided host is not valid", {
+      throw new MeilisearchError("The provided host is not valid", {
         cause: error,
       });
     }
@@ -248,10 +248,10 @@ export class HttpRequests {
       response = await fetch(url, init);
       responseBody = await response.text();
     } catch (error) {
-      throw new MeiliSearchRequestError(
+      throw new MeilisearchRequestError(
         url.toString(),
         Object.is(error, TIMEOUT_ID)
-          ? new MeiliSearchRequestTimeOutError(this.#requestTimeout!, init)
+          ? new MeilisearchRequestTimeOutError(this.#requestTimeout!, init)
           : error,
       );
     } finally {
@@ -261,12 +261,12 @@ export class HttpRequests {
     const parsedResponse =
       responseBody === ""
         ? undefined
-        : (JSON.parse(responseBody) as T | MeiliSearchErrorResponse);
+        : (JSON.parse(responseBody) as T | MeilisearchErrorResponse);
 
     if (!response.ok) {
-      throw new MeiliSearchApiError(
+      throw new MeilisearchApiError(
         response,
-        parsedResponse as MeiliSearchErrorResponse | undefined,
+        parsedResponse as MeilisearchErrorResponse | undefined,
       );
     }
 
@@ -325,7 +325,7 @@ export class HttpRequests {
       if (this.#customRequestFn !== undefined) {
         const result = await this.#customRequestFn(url, init);
         if (!(result instanceof ReadableStream)) {
-          throw new MeiliSearchError(
+          throw new MeilisearchError(
             "Custom HTTP client must return a ReadableStream for streaming requests",
           );
         }
@@ -334,10 +334,10 @@ export class HttpRequests {
 
       response = await fetch(url, init);
     } catch (error) {
-      throw new MeiliSearchRequestError(
+      throw new MeilisearchRequestError(
         url.toString(),
         Object.is(error, TIMEOUT_ID)
-          ? new MeiliSearchRequestTimeOutError(this.#requestTimeout!, init)
+          ? new MeilisearchRequestTimeOutError(this.#requestTimeout!, init)
           : error,
       );
     } finally {
@@ -350,13 +350,13 @@ export class HttpRequests {
       const parsedResponse =
         responseBody === ""
           ? undefined
-          : (JSON.parse(responseBody) as MeiliSearchErrorResponse);
+          : (JSON.parse(responseBody) as MeilisearchErrorResponse);
 
-      throw new MeiliSearchApiError(response, parsedResponse);
+      throw new MeilisearchApiError(response, parsedResponse);
     }
 
     if (!response.body) {
-      throw new MeiliSearchError(
+      throw new MeilisearchError(
         "Response body is null - server did not return a readable stream",
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,4 @@
 export * from "./types/index.js";
 export * from "./errors/index.js";
 export * from "./indexes.js";
-import { MeiliSearch } from "./meilisearch.js";
-
-/**
- * Default export of {@link MeiliSearch}.
- *
- * @deprecated The default export will be removed in a future version.
- *   {@link https://github.com/meilisearch/meilisearch-js/issues/1789 | Issue}.
- */
-const defaultExport = MeiliSearch;
-
-export { MeiliSearch, MeiliSearch as Meilisearch };
-export default defaultExport;
+export * from "./meilisearch.js";

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -1,11 +1,11 @@
 /*
- * Bundle: MeiliSearch / Indexes
- * Project: MeiliSearch - Javascript API
+ * Bundle: Meilisearch / Indexes
+ * Project: Meilisearch - Javascript API
  * Author: Quentin de Quelen <quentin@meilisearch.com>
- * Copyright: 2019, MeiliSearch
+ * Copyright: 2019, Meilisearch
  */
 
-import { MeiliSearchError } from "./errors/index.js";
+import { MeilisearchError } from "./errors/index.js";
 import type {
   Config,
   SearchResponse,
@@ -132,7 +132,7 @@ export class Index<T extends RecordAny = RecordAny> {
     const parseFilter = (filter?: Filter): string | undefined => {
       if (typeof filter === "string") return filter;
       else if (Array.isArray(filter))
-        throw new MeiliSearchError(
+        throw new MeilisearchError(
           "The filter query parameter should be in string format when using searchGet",
         );
       else return undefined;

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -1,8 +1,8 @@
 /*
- * Bundle: MeiliSearch
- * Project: MeiliSearch - Javascript API
+ * Bundle: Meilisearch
+ * Project: Meilisearch - Javascript API
  * Author: Quentin de Quelen <quentin@meilisearch.com>
- * Copyright: 2019, MeiliSearch
+ * Copyright: 2019, Meilisearch
  */
 
 import { Index } from "./indexes.js";
@@ -50,9 +50,9 @@ import {
 } from "./task.js";
 import { BatchClient } from "./batch.js";
 import { ChatWorkspace } from "./chat-workspace.js";
-import type { MeiliSearchApiError } from "./errors/index.js";
+import type { MeilisearchApiError } from "./errors/index.js";
 
-export class MeiliSearch {
+export class Meilisearch {
   config: Config;
   httpRequest: HttpRequests;
 
@@ -69,7 +69,7 @@ export class MeiliSearch {
   readonly #httpRequestsWithTask: HttpRequestsWithEnqueuedTaskPromise;
 
   /**
-   * Creates new MeiliSearch instance
+   * Creates new Meilisearch instance
    *
    * @param config - Configuration object
    */
@@ -100,7 +100,7 @@ export class MeiliSearch {
   }
 
   /**
-   * Gather information about an index by calling MeiliSearch and return an
+   * Gather information about an index by calling Meilisearch and return an
    * Index instance with the gathered information
    *
    * @param indexUid - The index UID
@@ -113,7 +113,7 @@ export class MeiliSearch {
   }
 
   /**
-   * Gather information about an index by calling MeiliSearch and return the raw
+   * Gather information about an index by calling Meilisearch and return the raw
    * JSON response
    *
    * @param indexUid - The index UID
@@ -199,7 +199,7 @@ export class MeiliSearch {
       return true;
     } catch (e) {
       if (
-        (e as MeiliSearchApiError)?.cause?.code ===
+        (e as MeilisearchApiError)?.cause?.code ===
         ErrorStatusCode.INDEX_NOT_FOUND
       ) {
         return false;
@@ -648,7 +648,7 @@ export class MeiliSearch {
   ///
 
   /**
-   * Get the version of MeiliSearch
+   * Get the version of Meilisearch
    *
    * @returns Promise returning object with version details
    */

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,4 +1,4 @@
-import { MeiliSearchTaskTimeOutError } from "./errors/index.js";
+import { MeilisearchTaskTimeOutError } from "./errors/index.js";
 import type {
   WaitOptions,
   TasksOrBatchesQuery,
@@ -123,7 +123,7 @@ export class TaskClient {
       }
     } catch (error) {
       throw Object.is((error as Error).cause, TIMEOUT_ID)
-        ? new MeiliSearchTaskTimeOutError(taskUid, timeout)
+        ? new MeilisearchTaskTimeOutError(taskUid, timeout)
         : error;
     }
   }

--- a/src/types/task-and-batch.ts
+++ b/src/types/task-and-batch.ts
@@ -5,7 +5,7 @@ import type {
   OptionStarOr,
   OptionStarOrList,
 } from "./shared.js";
-import type { MeiliSearchErrorResponse } from "./types.js";
+import type { MeilisearchErrorResponse } from "./types.js";
 
 /** Options for awaiting an {@link EnqueuedTask}. */
 export type WaitOptions = {
@@ -144,7 +144,7 @@ type Origin = { remoteName: string; taskUid: number };
 type NetworkOrigin = { origin: Origin };
 
 /** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
-type RemoteTask = { taskUid?: number; error: MeiliSearchErrorResponse | null };
+type RemoteTask = { taskUid?: number; error: MeilisearchErrorResponse | null };
 
 /** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
 type NetworkRemoteTasks = { remoteTasks: Record<string, RemoteTask> };
@@ -159,7 +159,7 @@ export type Task = SafeOmit<EnqueuedTask, "taskUid"> & {
   batchUid: number | null;
   canceledBy: number | null;
   details?: TaskDetails;
-  error: MeiliSearchErrorResponse | null;
+  error: MeilisearchErrorResponse | null;
   duration: string | null;
   startedAt: string | null;
   finishedAt: string | null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -853,7 +853,7 @@ export type Version = {
  ** ERROR HANDLER
  */
 
-export type MeiliSearchErrorResponse = {
+export type MeilisearchErrorResponse = {
   message: string;
   // https://www.meilisearch.com/docs/reference/errors/error_codes
   code: string;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -15,7 +15,7 @@ import type {
   IndexSwap,
   InitializeNetworkOptions,
 } from "../src/index.js";
-import { ErrorStatusCode, MeiliSearchRequestError } from "../src/index.js";
+import { ErrorStatusCode, MeilisearchRequestError } from "../src/index.js";
 import { HttpRequests } from "../src/http-requests.js";
 import pkg from "../package.json" with { type: "json" };
 import {
@@ -23,7 +23,7 @@ import {
   getKey,
   getClient,
   config,
-  MeiliSearch,
+  Meilisearch,
   BAD_HOST,
   HOST,
   assert,
@@ -60,7 +60,7 @@ describe.each([
 
   test(`${permission} key: Create client with api key`, async () => {
     const key = await getKey(permission);
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       ...config,
       apiKey: key,
     });
@@ -79,7 +79,7 @@ describe.each([
 
     test(`${permission} key: Create client with custom headers (object)`, async () => {
       const key = await getKey(permission);
-      const client = new MeiliSearch({
+      const client = new Meilisearch({
         ...config,
         apiKey: key,
         requestInit: {
@@ -108,7 +108,7 @@ describe.each([
 
     test(`${permission} key: Create client with custom headers (array)`, async () => {
       const key = await getKey(permission);
-      const client = new MeiliSearch({
+      const client = new Meilisearch({
         ...config,
         apiKey: key,
         requestInit: {
@@ -133,7 +133,7 @@ describe.each([
       const key = await getKey(permission);
       const headers = new Headers();
       headers.set("Hello-There!", "General Kenobi");
-      const client = new MeiliSearch({
+      const client = new Meilisearch({
         ...config,
         apiKey: key,
         requestInit: { headers },
@@ -156,14 +156,14 @@ describe.each([
   test(`${permission} key: No double slash when on host with domain and path and trailing slash`, async () => {
     const key = await getKey(permission);
     const customHost = `${BAD_HOST}/api/`;
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       host: customHost,
       apiKey: key,
     });
 
     await assert.rejects(
       client.health(),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
       `Request to ${BAD_HOST}/api/health has failed`,
     );
   });
@@ -171,14 +171,14 @@ describe.each([
   test(`${permission} key: No double slash when on host with domain and path and no trailing slash`, async () => {
     const key = await getKey(permission);
     const customHost = `${BAD_HOST}/api`;
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       host: customHost,
       apiKey: key,
     });
 
     await assert.rejects(
       client.health(),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
       `Request to ${BAD_HOST}/api/health has failed`,
     );
   });
@@ -186,14 +186,14 @@ describe.each([
   test(`${permission} key: host with double slash should keep double slash`, async () => {
     const key = await getKey(permission);
     const customHost = `${BAD_HOST}//`;
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       host: customHost,
       apiKey: key,
     });
 
     await assert.rejects(
       client.health(),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
       `Request to ${BAD_HOST}//health has failed`,
     );
   });
@@ -201,40 +201,40 @@ describe.each([
   test(`${permission} key: host with one slash should not double slash`, async () => {
     const key = await getKey(permission);
     const customHost = `${BAD_HOST}/`;
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       host: customHost,
       apiKey: key,
     });
 
     await assert.rejects(
       client.health(),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
       `Request to ${BAD_HOST}/health has failed`,
     );
   });
 
   test(`${permission} key: bad host raise CommunicationError`, async () => {
-    const client = new MeiliSearch({ host: "http://localhost:9345" });
-    await assert.rejects(client.health(), MeiliSearchRequestError);
+    const client = new Meilisearch({ host: "http://localhost:9345" });
+    await assert.rejects(client.health(), MeilisearchRequestError);
   });
 
   test(`${permission} key: host without HTTP should not throw Invalid URL Error`, () => {
     const strippedHost = HOST.replace("http://", "");
     expect(() => {
-      new MeiliSearch({ host: strippedHost });
+      new Meilisearch({ host: strippedHost });
     }).not.toThrow("The provided host is not valid.");
   });
 
   test(`${permission} key: host without HTTP and port should not throw Invalid URL Error`, () => {
     const strippedHost = HOST.replace("http://", "").replace(":7700", "");
     expect(() => {
-      new MeiliSearch({ host: strippedHost });
+      new Meilisearch({ host: strippedHost });
     }).not.toThrow("The provided host is not valid.");
   });
 
   test(`${permission} key: Empty string host should throw an error`, () => {
     expect(() => {
-      new MeiliSearch({ host: "" });
+      new Meilisearch({ host: "" });
     }).toThrow("The provided host is not valid");
   });
 });
@@ -248,7 +248,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
     test(`${permission} key: Create client with custom headers`, async () => {
       const key = await getKey(permission);
-      const client = new MeiliSearch({
+      const client = new Meilisearch({
         ...config,
         apiKey: key,
         requestInit: {
@@ -273,7 +273,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
     test(`${permission} key: Create client with custom http client`, async () => {
       const key = await getKey(permission);
-      const client = new MeiliSearch({
+      const client = new Meilisearch({
         ...config,
         apiKey: key,
         async httpClient(...params: Parameters<typeof fetch>) {
@@ -310,7 +310,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       test(`${permission} key: Create client with no custom client agents`, async () => {
         const key = await getKey(permission);
-        const client = new MeiliSearch({
+        const client = new Meilisearch({
           ...config,
           apiKey: key,
           requestInit: {
@@ -333,7 +333,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       test(`${permission} key: Create client with empty custom client agents`, async () => {
         const key = await getKey(permission);
-        const client = new MeiliSearch({
+        const client = new Meilisearch({
           ...config,
           apiKey: key,
           clientAgents: [],
@@ -354,7 +354,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       test(`${permission} key: Create client with custom client agents`, async () => {
         const key = await getKey(permission);
-        const client = new MeiliSearch({
+        const client = new Meilisearch({
           ...config,
           apiKey: key,
           clientAgents: ["random plugin 1", "random plugin 2"],
@@ -621,7 +621,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       });
 
       test(`${permission} key: is healthy return false on bad host`, async () => {
-        const client = new MeiliSearch({ host: "http://localhost:9345" });
+        const client = new Meilisearch({ host: "http://localhost:9345" });
         const response: boolean = await client.isHealthy();
         expect(response).toBe(false);
       });
@@ -819,7 +819,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getIndex route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getIndex(indexPk.uid)).rejects.toHaveProperty(
       "message",
@@ -829,7 +829,7 @@ describe.each([
 
   test(`createIndex route`, async () => {
     const route = `indexes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.createIndex(indexPk.uid)).rejects.toHaveProperty(
       "message",
@@ -839,7 +839,7 @@ describe.each([
 
   test(`updateIndex route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.updateIndex(indexPk.uid)).rejects.toHaveProperty(
       "message",
@@ -849,7 +849,7 @@ describe.each([
 
   test(`deleteIndex route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.deleteIndex(indexPk.uid)).rejects.toHaveProperty(
       "message",
@@ -859,7 +859,7 @@ describe.each([
 
   test(`get indexes route`, async () => {
     const route = `indexes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getIndexes()).rejects.toHaveProperty(
       "message",
@@ -869,7 +869,7 @@ describe.each([
 
   test(`getKeys route`, async () => {
     const route = `keys`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getKeys()).rejects.toHaveProperty(
       "message",
@@ -879,7 +879,7 @@ describe.each([
 
   test(`health route`, async () => {
     const route = `health`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.health()).rejects.toHaveProperty(
       "message",
@@ -889,7 +889,7 @@ describe.each([
 
   test(`stats route`, async () => {
     const route = `stats`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getStats()).rejects.toHaveProperty(
       "message",
@@ -899,7 +899,7 @@ describe.each([
 
   test(`version route`, async () => {
     const route = `version`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getVersion()).rejects.toHaveProperty(
       "message",

--- a/tests/dictionary.test.ts
+++ b/tests/dictionary.test.ts
@@ -3,7 +3,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -69,7 +69,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getDictionary route`, async () => {
     const route = `indexes/${index.uid}/settings/dictionary`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getDictionary(),
@@ -81,7 +81,7 @@ describe.each([
 
   test(`updateDictionary route`, async () => {
     const route = `indexes/${index.uid}/settings/dictionary`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateDictionary([]),
@@ -93,7 +93,7 @@ describe.each([
 
   test(`resetDictionary route`, async () => {
     const route = `indexes/${index.uid}/settings/dictionary`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetDictionary(),

--- a/tests/displayed_attributes.test.ts
+++ b/tests/displayed_attributes.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -148,7 +148,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getDisplayedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/displayed-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getDisplayedAttributes(),
@@ -160,7 +160,7 @@ describe.each([
 
   test(`updateDisplayedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/displayed-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateDisplayedAttributes([]),
@@ -172,7 +172,7 @@ describe.each([
 
   test(`resetDisplayedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/displayed-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetDisplayedAttributes(),

--- a/tests/distinct_attribute.test.ts
+++ b/tests/distinct_attribute.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -142,7 +142,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getDistinctAttribute route`, async () => {
     const route = `indexes/${index.uid}/settings/distinct-attribute`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getDistinctAttribute(),
@@ -154,7 +154,7 @@ describe.each([
 
   test(`updateDistinctAttribute route`, async () => {
     const route = `indexes/${index.uid}/settings/distinct-attribute`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateDistinctAttribute("a"),
@@ -166,7 +166,7 @@ describe.each([
 
   test(`resetDistinctAttribute route`, async () => {
     const route = `indexes/${index.uid}/settings/distinct-attribute`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetDistinctAttribute(),

--- a/tests/documents.test.ts
+++ b/tests/documents.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
   type Book,
@@ -156,7 +156,7 @@ describe("Documents tests", () => {
 
       test(`${permission} key: Get documents should trigger error with a MeilisearchRequestError`, async () => {
         const apiKey = await getKey(permission);
-        const client = new MeiliSearch({ host: `${HOST}/indexes`, apiKey });
+        const client = new Meilisearch({ host: `${HOST}/indexes`, apiKey });
 
         await assert.rejects(
           client.index(indexPk.uid).getDocuments({ filter: "" }),
@@ -167,7 +167,7 @@ describe("Documents tests", () => {
 
       test(`${permission} key: Get documents should trigger error with a hint on a MeilisearchApiError`, async () => {
         const apiKey = await getKey(permission);
-        const client = new MeiliSearch({ host: `${HOST}`, apiKey });
+        const client = new Meilisearch({ host: `${HOST}`, apiKey });
 
         await assert.rejects(
           client.index(indexPk.uid).getDocuments({ filter: "id = 1" }),
@@ -653,7 +653,7 @@ describe("Documents tests", () => {
 
       test(`${permission} key: Delete some documents should trigger error with a hint on a MeilisearchRequestError`, async () => {
         const apiKey = await getKey(permission);
-        const client = new MeiliSearch({ host: `${HOST}/indexes`, apiKey });
+        const client = new Meilisearch({ host: `${HOST}/indexes`, apiKey });
 
         await assert.rejects(
           client.index(indexPk.uid).deleteDocuments({ filter: "id = 1" }),
@@ -1032,7 +1032,7 @@ describe("Documents tests", () => {
   ])("Tests on url construction", ({ host, trailing }) => {
     test(`getDocument route`, async () => {
       const route = `indexes/${indexPk.uid}/documents/1`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).getDocument(1),
@@ -1044,7 +1044,7 @@ describe("Documents tests", () => {
 
     test(`getDocuments route`, async () => {
       const route = `indexes/${indexPk.uid}/documents`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).getDocuments<Book>(),
@@ -1056,7 +1056,7 @@ describe("Documents tests", () => {
 
     test(`addDocuments route`, async () => {
       const route = `indexes/${indexPk.uid}/documents`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).addDocuments([]),
@@ -1068,7 +1068,7 @@ describe("Documents tests", () => {
 
     test(`updateDocuments route`, async () => {
       const route = `indexes/${indexPk.uid}/documents`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).updateDocuments([]),
@@ -1080,7 +1080,7 @@ describe("Documents tests", () => {
 
     test(`deleteDocument route`, async () => {
       const route = `indexes/${indexPk.uid}/documents/1`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).deleteDocument("1"),
@@ -1092,7 +1092,7 @@ describe("Documents tests", () => {
 
     test(`deleteDocuments route`, async () => {
       const route = `indexes/${indexPk.uid}/documents/delete-batch`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).deleteDocuments([]),
@@ -1104,7 +1104,7 @@ describe("Documents tests", () => {
 
     test(`deleteAllDocuments route`, async () => {
       const route = `indexes/${indexPk.uid}/documents`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
       await expect(
         client.index(indexPk.uid).deleteAllDocuments(),
@@ -1116,7 +1116,7 @@ describe("Documents tests", () => {
 
     test(`updateDocumentsByFunction route`, async () => {
       const route = `indexes/${indexPk.uid}/documents/edit`;
-      const client = new MeiliSearch({ host });
+      const client = new Meilisearch({ host });
       const strippedHost = trailing ? host.slice(0, -1) : host;
 
       await (

--- a/tests/dump.test.ts
+++ b/tests/dump.test.ts
@@ -3,7 +3,7 @@ import { ErrorStatusCode } from "../src/types/index.js";
 import {
   clearAllIndexes,
   config,
-  MeiliSearch,
+  Meilisearch,
   BAD_HOST,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
@@ -57,7 +57,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`createDump route`, async () => {
     const route = `dumps`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
 
     await expect(client.createDump()).rejects.toHaveProperty(

--- a/tests/embedders.test.ts
+++ b/tests/embedders.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   masterClient,
 } from "./utils/meilisearch-test-utils.js";
@@ -404,7 +404,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getEmbedders route`, async () => {
     const route = `indexes/${index.uid}/settings/embedders`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getEmbedders()).rejects.toHaveProperty(
       "message",
@@ -414,7 +414,7 @@ describe.each([
 
   test(`updateEmbedders route`, async () => {
     const route = `indexes/${index.uid}/settings/embedders`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateEmbedders({}),
@@ -426,7 +426,7 @@ describe.each([
 
   test(`resetEmbedders route`, async () => {
     const route = `indexes/${index.uid}/settings/embedders`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetEmbedders(),

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, vi } from "vitest";
-import { MeiliSearch, assert } from "./utils/meilisearch-test-utils.js";
-import { MeiliSearchRequestError } from "../src/index.js";
+import { Meilisearch, assert } from "./utils/meilisearch-test-utils.js";
+import { MeilisearchRequestError } from "../src/index.js";
 
 const mockedFetch = vi.fn();
 globalThis.fetch = mockedFetch;
@@ -10,10 +10,10 @@ describe("Test on updates", () => {
     mockedFetch.mockReset();
   });
 
-  test(`Throw MeilisearchRequestError when thrown error is not MeiliSearchApiError`, async () => {
+  test(`Throw MeilisearchRequestError when thrown error is not MeilisearchApiError`, async () => {
     mockedFetch.mockRejectedValue(new Error("fake error message"));
 
-    const client = new MeiliSearch({ host: "http://localhost:9345" });
-    await assert.rejects(client.health(), MeiliSearchRequestError);
+    const client = new Meilisearch({ host: "http://localhost:9345" });
+    await assert.rejects(client.health(), MeilisearchRequestError);
   });
 });

--- a/tests/facet_search_settings.test.ts
+++ b/tests/facet_search_settings.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -133,7 +133,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getFacetSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/facet-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getFacetSearch(),
@@ -145,7 +145,7 @@ describe.each([
 
   test(`updateFacetSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/facet-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateFacetSearch(false),
@@ -157,7 +157,7 @@ describe.each([
 
   test(`resetFacetSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/facet-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetFacetSearch(),

--- a/tests/faceting.test.ts
+++ b/tests/faceting.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -157,7 +157,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getFaceting route`, async () => {
     const route = `indexes/${index.uid}/settings/faceting`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getFaceting()).rejects.toHaveProperty(
       "message",
@@ -167,7 +167,7 @@ describe.each([
 
   test(`updateFaceting route`, async () => {
     const route = `indexes/${index.uid}/settings/faceting`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateFaceting({ maxValuesPerFacet: undefined }),
@@ -179,7 +179,7 @@ describe.each([
 
   test(`resetFaceting route`, async () => {
     const route = `indexes/${index.uid}/settings/faceting`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetFaceting(),

--- a/tests/fields.test.ts
+++ b/tests/fields.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
 
@@ -301,7 +301,7 @@ describe.each([
 ])("Tests on url construction for fields endpoint", ({ host, trailing }) => {
   test(`getFields route construction`, async () => {
     const route = `indexes/${index.uid}/fields`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getFields()).rejects.toHaveProperty(
       "message",

--- a/tests/filterable_attributes.test.ts
+++ b/tests/filterable_attributes.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -163,7 +163,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getFilterableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/filterable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getFilterableAttributes(),
@@ -175,7 +175,7 @@ describe.each([
 
   test(`updateFilterableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/filterable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateFilterableAttributes([]),
@@ -187,7 +187,7 @@ describe.each([
 
   test(`resetFilterableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/filterable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetFilterableAttributes(),

--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
 
@@ -568,7 +568,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`get search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).searchGet()).rejects.toHaveProperty(
       "message",
@@ -578,7 +578,7 @@ describe.each([
 
   test(`post search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).searchGet()).rejects.toHaveProperty(
       "message",

--- a/tests/http-requests.test.ts
+++ b/tests/http-requests.test.ts
@@ -10,9 +10,9 @@ import {
 import { HttpRequests } from "../src/http-requests.js";
 import type { Config } from "../src/types/index.js";
 import {
-  MeiliSearchError,
-  MeiliSearchRequestError,
-  MeiliSearchApiError,
+  MeilisearchError,
+  MeilisearchRequestError,
+  MeilisearchApiError,
 } from "../src/errors/index.js";
 
 describe("HttpRequests", () => {
@@ -39,7 +39,7 @@ describe("HttpRequests", () => {
 
     await expect(
       httpRequests.postStream({ path: "chat", body: {} }),
-    ).rejects.toThrow(MeiliSearchRequestError);
+    ).rejects.toThrow(MeilisearchRequestError);
   });
 
   test("should return stream from custom http client", async () => {
@@ -68,7 +68,7 @@ describe("HttpRequests", () => {
 
     await expect(
       httpRequests.postStream({ path: "chat", body: {} }),
-    ).rejects.toThrow(MeiliSearchApiError);
+    ).rejects.toThrow(MeilisearchApiError);
   });
 
   test("should handle stream error response with empty body", async () => {
@@ -84,7 +84,7 @@ describe("HttpRequests", () => {
 
     await expect(
       httpRequests.postStream({ path: "chat", body: {} }),
-    ).rejects.toThrow(MeiliSearchApiError);
+    ).rejects.toThrow(MeilisearchApiError);
   });
 
   test("should handle null response body for stream", async () => {
@@ -100,7 +100,7 @@ describe("HttpRequests", () => {
 
     await expect(
       httpRequests.postStream({ path: "chat", body: {} }),
-    ).rejects.toThrow(MeiliSearchError);
+    ).rejects.toThrow(MeilisearchError);
     await expect(
       httpRequests.postStream({ path: "chat", body: {} }),
     ).rejects.toThrow(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
 
@@ -507,7 +507,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getStats route`, async () => {
     const route = `indexes/${indexPk.uid}/stats`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(indexPk.uid).getStats()).rejects.toHaveProperty(
       "message",
@@ -517,7 +517,7 @@ describe.each([
 
   test(`getRawInfo route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
       "message",
@@ -525,13 +525,13 @@ describe.each([
     );
     await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
       "name",
-      "MeiliSearchRequestError",
+      "MeilisearchRequestError",
     );
   });
 
   test(`getRawIndex route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.getRawIndex(indexPk.uid)).rejects.toHaveProperty(
       "message",
@@ -539,13 +539,13 @@ describe.each([
     );
     await expect(client.getRawIndex(indexPk.uid)).rejects.toHaveProperty(
       "name",
-      "MeiliSearchRequestError",
+      "MeilisearchRequestError",
     );
   });
 
   test(`updateIndex route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
       "message",
@@ -555,7 +555,7 @@ describe.each([
 
   test(`delete index route`, async () => {
     const route = `indexes/${indexPk.uid}`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(indexPk.uid).getRawInfo()).rejects.toHaveProperty(
       "message",

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe, beforeEach, afterAll } from "vitest";
-import { MeiliSearch } from "../src/index.js";
+import { Meilisearch } from "../src/index.js";
 import { ErrorStatusCode } from "../src/types/index.js";
 import {
   clearAllIndexes,
@@ -135,7 +135,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
         expiresAt: null,
       });
 
-      const newClient = new MeiliSearch({ host: HOST, apiKey: key.key });
+      const newClient = new Meilisearch({ host: HOST, apiKey: key.key });
       await newClient.createIndex("wildcard_keys_permission"); // test index creation
       const task = await newClient
         .index("wildcard_keys_permission")

--- a/tests/localized_attributes.test.ts
+++ b/tests/localized_attributes.test.ts
@@ -14,7 +14,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -181,7 +181,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getLocalizedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/localized-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getLocalizedAttributes(),
@@ -193,7 +193,7 @@ describe.each([
 
   test(`updateLocalizedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/localized-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateLocalizedAttributes(null),
@@ -205,7 +205,7 @@ describe.each([
 
   test(`resetLocalizedAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/localized-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetLocalizedAttributes(),

--- a/tests/multi_modal_search.test.ts
+++ b/tests/multi_modal_search.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { getClient } from "./utils/meilisearch-test-utils.js";
 import type { Embedder } from "../src/types/types.js";
-import movies from "./fixtures/movies.json" assert { type: "json" };
+import movies from "./fixtures/movies.json" with { type: "json" };
 import type { Meilisearch } from "../src/index.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/tests/non_separator_tokens.test.ts
+++ b/tests/non_separator_tokens.test.ts
@@ -3,7 +3,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -75,7 +75,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getNonSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/non-separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getNonSeparatorTokens(),
@@ -87,7 +87,7 @@ describe.each([
 
   test(`updateNonSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/non-separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateNonSeparatorTokens([]),
@@ -99,7 +99,7 @@ describe.each([
 
   test(`resetNonSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/non-separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetNonSeparatorTokens(),

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -157,7 +157,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getPagination route`, async () => {
     const route = `indexes/${index.uid}/settings/pagination`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getPagination(),
@@ -169,7 +169,7 @@ describe.each([
 
   test(`updatePagination route`, async () => {
     const route = `indexes/${index.uid}/settings/pagination`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updatePagination({ maxTotalHits: null }),
@@ -181,7 +181,7 @@ describe.each([
 
   test(`resetPagination route`, async () => {
     const route = `indexes/${index.uid}/settings/pagination`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetPagination(),

--- a/tests/prefix_search_settings.test.ts
+++ b/tests/prefix_search_settings.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -133,7 +133,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getPrefixSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/prefix-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getPrefixSearch(),
@@ -145,7 +145,7 @@ describe.each([
 
   test(`updatePrefixSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/prefix-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updatePrefixSearch("disabled"),
@@ -157,7 +157,7 @@ describe.each([
 
   test(`resetPrefixSearch route`, async () => {
     const route = `indexes/${index.uid}/settings/prefix-search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetPrefixSearch(),

--- a/tests/proximity_precision.test.ts
+++ b/tests/proximity_precision.test.ts
@@ -3,7 +3,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -75,7 +75,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getProximityPrecision route`, async () => {
     const route = `indexes/${index.uid}/settings/proximity-precision`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getProximityPrecision(),
@@ -87,7 +87,7 @@ describe.each([
 
   test(`updateProximityPrecision route`, async () => {
     const route = `indexes/${index.uid}/settings/proximity-precision`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateProximityPrecision("byAttribute"),
@@ -99,7 +99,7 @@ describe.each([
 
   test(`resetProximityPrecision route`, async () => {
     const route = `indexes/${index.uid}/settings/proximity-precision`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetProximityPrecision(),

--- a/tests/ranking_rules.test.ts
+++ b/tests/ranking_rules.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -151,7 +151,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getRankingRules route`, async () => {
     const route = `indexes/${index.uid}/settings/ranking-rules`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getRankingRules(),
@@ -163,7 +163,7 @@ describe.each([
 
   test(`updateRankingRules route`, async () => {
     const route = `indexes/${index.uid}/settings/ranking-rules`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateRankingRules([]),
@@ -175,7 +175,7 @@ describe.each([
 
   test(`resetRankingRules route`, async () => {
     const route = `indexes/${index.uid}/settings/ranking-rules`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetRankingRules(),

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -16,14 +16,14 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   datasetWithNests,
   getKey,
   HOST,
   assert,
 } from "./utils/meilisearch-test-utils.js";
-import { MeiliSearchRequestError } from "../src/index.js";
+import { MeilisearchRequestError } from "../src/index.js";
 
 const index = {
   uid: "books",
@@ -1502,7 +1502,7 @@ describe.each([
 
   test(`${permission} key: search should be aborted when reaching timeout`, async () => {
     const key = await getKey(permission);
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       ...config,
       apiKey: key,
       timeout: 1,
@@ -1510,7 +1510,7 @@ describe.each([
 
     const error = await assert.rejects(
       client.health(),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
     );
 
     assert.strictEqual(
@@ -1521,7 +1521,7 @@ describe.each([
 
   test(`${permission} key: search should be aborted on abort signal`, async () => {
     const key = await getKey(permission);
-    const client = new MeiliSearch({
+    const client = new Meilisearch({
       ...config,
       apiKey: key,
       timeout: 1_000,
@@ -1536,7 +1536,7 @@ describe.each([
         { queries: [{ indexUid: "doesn't matter" }] },
         { signal: ac.signal },
       ),
-      MeiliSearchRequestError,
+      MeilisearchRequestError,
     );
     assert.strictEqual(error.cause, someErrorObj);
 
@@ -1560,7 +1560,7 @@ describe.each([
         { signal: ac.signal },
       );
       setTimeout(() => ac.abort(someErrorObj), 1);
-      const error = await assert.rejects(promise, MeiliSearchRequestError);
+      const error = await assert.rejects(promise, MeilisearchRequestError);
       assert.strictEqual(error.cause, someErrorObj);
     } finally {
       vi.unstubAllGlobals();
@@ -1575,7 +1575,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`get search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).search()).rejects.toHaveProperty(
       "message",
@@ -1585,7 +1585,7 @@ describe.each([
 
   test(`post search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).search()).rejects.toHaveProperty(
       "message",

--- a/tests/search_cutoff_ms.test.ts
+++ b/tests/search_cutoff_ms.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -174,7 +174,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSearchCutoffMs route`, async () => {
     const route = `indexes/${index.uid}/settings/search-cutoff-ms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getSearchCutoffMs(),
@@ -186,7 +186,7 @@ describe.each([
 
   test(`updateSearchCutoffMs route`, async () => {
     const route = `indexes/${index.uid}/settings/search-cutoff-ms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSearchCutoffMs(null),
@@ -198,7 +198,7 @@ describe.each([
 
   test(`resetSearchCutoffMs route`, async () => {
     const route = `indexes/${index.uid}/settings/search-cutoff-ms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSearchCutoffMs(),

--- a/tests/searchable_attributes.test.ts
+++ b/tests/searchable_attributes.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -151,7 +151,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSearchableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/searchable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getSearchableAttributes(),
@@ -163,7 +163,7 @@ describe.each([
 
   test(`updateSearchableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/searchable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSearchableAttributes([]),
@@ -175,7 +175,7 @@ describe.each([
 
   test(`resetSearchableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/searchable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSearchableAttributes(),

--- a/tests/separator_tokens.test.ts
+++ b/tests/separator_tokens.test.ts
@@ -3,7 +3,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -75,7 +75,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getSeparatorTokens(),
@@ -87,7 +87,7 @@ describe.each([
 
   test(`updateSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSeparatorTokens([]),
@@ -99,7 +99,7 @@ describe.each([
 
   test(`resetSeparatorTokens route`, async () => {
     const route = `indexes/${index.uid}/settings/separator-tokens`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSeparatorTokens(),

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -325,7 +325,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSettings route`, async () => {
     const route = `indexes/${index.uid}/settings`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getSettings()).rejects.toHaveProperty(
       "message",
@@ -335,7 +335,7 @@ describe.each([
 
   test(`updateSettings route`, async () => {
     const route = `indexes/${index.uid}/settings`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSettings({}),
@@ -347,7 +347,7 @@ describe.each([
 
   test(`resetSettings route`, async () => {
     const route = `indexes/${index.uid}/settings`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSettings(),

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -3,7 +3,7 @@ import { ErrorStatusCode } from "../src/types/index.js";
 import {
   clearAllIndexes,
   config,
-  MeiliSearch,
+  Meilisearch,
   BAD_HOST,
   getClient,
 } from "./utils/meilisearch-test-utils.js";
@@ -57,7 +57,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`createSnapshot route`, async () => {
     const route = `snapshots`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
 
     await expect(client.createSnapshot()).rejects.toHaveProperty(

--- a/tests/sortable_attributes.test.ts
+++ b/tests/sortable_attributes.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -153,7 +153,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSortableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/sortable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getSortableAttributes(),
@@ -165,7 +165,7 @@ describe.each([
 
   test(`updateSortableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/sortable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSortableAttributes([]),
@@ -177,7 +177,7 @@ describe.each([
 
   test(`resetSortableAttributes route`, async () => {
     const route = `indexes/${index.uid}/settings/sortable-attributes`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSortableAttributes(),

--- a/tests/stop_words.test.ts
+++ b/tests/stop_words.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -139,7 +139,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getStopWords route`, async () => {
     const route = `indexes/${index.uid}/settings/stop-words`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getStopWords()).rejects.toHaveProperty(
       "message",
@@ -149,7 +149,7 @@ describe.each([
 
   test(`updateStopWords route`, async () => {
     const route = `indexes/${index.uid}/settings/stop-words`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateStopWords([]),
@@ -161,7 +161,7 @@ describe.each([
 
   test(`resetStopWords route`, async () => {
     const route = `indexes/${index.uid}/settings/stop-words`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetStopWords(),

--- a/tests/synonyms.test.ts
+++ b/tests/synonyms.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -136,7 +136,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`getSynonyms route`, async () => {
     const route = `indexes/${index.uid}/settings/synonyms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(client.index(index.uid).getSynonyms()).rejects.toHaveProperty(
       "message",
@@ -146,7 +146,7 @@ describe.each([
 
   test(`updateSynonyms route`, async () => {
     const route = `indexes/${index.uid}/settings/synonyms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateSynonyms({}),
@@ -158,7 +158,7 @@ describe.each([
 
   test(`resetSynonyms route`, async () => {
     const route = `indexes/${index.uid}/settings/synonyms`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetSynonyms(),

--- a/tests/task.test.ts
+++ b/tests/task.test.ts
@@ -7,7 +7,7 @@ import {
   config,
   dataset,
   getClient,
-  MeiliSearch,
+  Meilisearch,
 } from "./utils/meilisearch-test-utils.js";
 
 const index = {
@@ -756,7 +756,7 @@ describe.each([
 ])("Tests on task url construction", ({ host, trailing }) => {
   test(`on getTask route`, async () => {
     const route = `tasks/1`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
 
     await expect(client.tasks.getTask(1)).rejects.toHaveProperty(
@@ -767,7 +767,7 @@ describe.each([
 
   test(`on getTasks route`, async () => {
     const route = `tasks?indexUids=movies_test`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
 
     await expect(

--- a/tests/token.test.ts
+++ b/tests/token.test.ts
@@ -20,8 +20,8 @@ import {
 import { createHmac } from "node:crypto";
 import { generateTenantToken } from "../src/token.js";
 import {
-  MeiliSearch,
-  MeiliSearchApiError,
+  Meilisearch,
+  MeilisearchApiError,
   type TenantTokenHeader,
   type TokenClaims,
 } from "../src/index.js";
@@ -206,7 +206,7 @@ describe.each([{ permission: "Admin" }])(
         apiKeyUid: uid,
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(
@@ -227,7 +227,7 @@ describe.each([{ permission: "Admin" }])(
         apiKeyUid: uid,
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(searchClient.index(UID).search()).resolves.toBeDefined();
@@ -245,7 +245,7 @@ describe.each([{ permission: "Admin" }])(
       });
 
       const [_, payload] = token.split(".");
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       expect((JSON.parse(decode64(payload)) as TokenClaims).exp).toEqual(
         Math.floor(date.getTime() / 1000),
@@ -267,11 +267,11 @@ describe.each([{ permission: "Admin" }])(
         expiresAt: date,
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       await assert.rejects(
         searchClient.index(UID).search(),
-        MeiliSearchApiError,
+        MeilisearchApiError,
         /^Tenant token expired\. Was valid up to `\d+` and we're now `\d+`\.$/,
       );
     });
@@ -286,7 +286,7 @@ describe.each([{ permission: "Admin" }])(
         searchRules: { [UID]: null },
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(
@@ -310,7 +310,7 @@ describe.each([{ permission: "Admin" }])(
         searchRules: { [UID]: { filter: "id = 2" } },
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(
@@ -328,7 +328,7 @@ describe.each([{ permission: "Admin" }])(
         searchRules: [],
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(
@@ -346,7 +346,7 @@ describe.each([{ permission: "Admin" }])(
         searchRules: { misc: null },
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       // search
       await expect(
@@ -369,11 +369,11 @@ describe.each([{ permission: "Admin" }])(
         expiresAt: date,
       });
 
-      const searchClient = new MeiliSearch({ host: HOST, apiKey: token });
+      const searchClient = new Meilisearch({ host: HOST, apiKey: token });
 
       await assert.rejects(
         searchClient.index(UID).search(),
-        MeiliSearchApiError,
+        MeilisearchApiError,
         /^Tenant token expired\. Was valid up to `\d+` and we're now `\d+`\.$/,
       );
     });

--- a/tests/typed_search.test.ts
+++ b/tests/typed_search.test.ts
@@ -11,7 +11,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   datasetWithNests,
 } from "./utils/meilisearch-test-utils.js";
@@ -487,7 +487,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`get search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index<Movie>(index.uid).search(),
@@ -499,7 +499,7 @@ describe.each([
 
   test(`post search route`, async () => {
     const route = `indexes/${index.uid}/search`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index<Movie>(index.uid).search(),

--- a/tests/typo_tolerance.test.ts
+++ b/tests/typo_tolerance.test.ts
@@ -4,7 +4,7 @@ import {
   clearAllIndexes,
   config,
   BAD_HOST,
-  MeiliSearch,
+  Meilisearch,
   getClient,
   dataset,
 } from "./utils/meilisearch-test-utils.js";
@@ -149,7 +149,7 @@ describe.each([
 ])("Tests on url construction", ({ host, trailing }) => {
   test(`get typo tolerance route`, async () => {
     const route = `indexes/${index.uid}/settings/typo-tolerance`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).getTypoTolerance(),
@@ -161,7 +161,7 @@ describe.each([
 
   test(`update typo tolerance route`, async () => {
     const route = `indexes/${index.uid}/settings/typo-tolerance`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).updateTypoTolerance({}),
@@ -173,7 +173,7 @@ describe.each([
 
   test(`reset typo tolerance route`, async () => {
     const route = `indexes/${index.uid}/settings/typo-tolerance`;
-    const client = new MeiliSearch({ host });
+    const client = new Meilisearch({ host });
     const strippedHost = trailing ? host.slice(0, -1) : host;
     await expect(
       client.index(index.uid).resetTypoTolerance(),

--- a/tests/unit.test.ts
+++ b/tests/unit.test.ts
@@ -9,7 +9,7 @@ import {
 import {
   clearAllIndexes,
   config,
-  MeiliSearch,
+  Meilisearch,
 } from "./utils/meilisearch-test-utils.js";
 
 let fetchSpy: MockInstance<typeof fetch>;
@@ -25,7 +25,7 @@ afterAll(async () => {
 
 test(`Client handles host URL with domain and path, and adds trailing slash`, async () => {
   const customHost = `${config.host}/api`;
-  const client = new MeiliSearch({ host: customHost });
+  const client = new Meilisearch({ host: customHost });
 
   assert.strictEqual(client.config.host, customHost);
 

--- a/tests/utils/assertions/error.ts
+++ b/tests/utils/assertions/error.ts
@@ -1,8 +1,8 @@
 import { assert } from "vitest";
-import type { MeiliSearchErrorResponse } from "../../../src/index.js";
+import type { MeilisearchErrorResponse } from "../../../src/index.js";
 
 export const errorAssertions = {
-  isErrorResponse(error: MeiliSearchErrorResponse) {
+  isErrorResponse(error: MeilisearchErrorResponse) {
     assert.lengthOf(Object.keys(error), 4);
     const { message, code, type, link } = error;
     for (const val of Object.values({ message, code, type, link })) {

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -1,4 +1,4 @@
-import { type Config, MeiliSearch, Index } from "../../src/index.js";
+import { type Config, Meilisearch, Index } from "../../src/index.js";
 
 // testing
 const MASTER_KEY = "masterKey";
@@ -11,17 +11,17 @@ const config: Config = {
   apiKey: MASTER_KEY,
   defaultWaitOptions: { interval: 10 },
 };
-const badHostClient = new MeiliSearch({
+const badHostClient = new Meilisearch({
   host: BAD_HOST,
   apiKey: MASTER_KEY,
 });
-const masterClient = new MeiliSearch({
+const masterClient = new Meilisearch({
   host: HOST,
   apiKey: MASTER_KEY,
   defaultWaitOptions: { interval: 10 },
 });
 
-const anonymousClient = new MeiliSearch({
+const anonymousClient = new Meilisearch({
   host: HOST,
   defaultWaitOptions: { interval: 10 },
 });
@@ -49,9 +49,9 @@ async function getKey(permission: string): Promise<string> {
   return MASTER_KEY;
 }
 
-async function getClient(permission: string): Promise<MeiliSearch> {
+async function getClient(permission: string): Promise<Meilisearch> {
   if (permission === "No") {
-    const anonymousClient = new MeiliSearch({
+    const anonymousClient = new Meilisearch({
       host: HOST,
       defaultWaitOptions: { interval: 10 },
     });
@@ -60,7 +60,7 @@ async function getClient(permission: string): Promise<MeiliSearch> {
 
   if (permission === "Search") {
     const searchKey = await getKey(permission);
-    const searchClient = new MeiliSearch({
+    const searchClient = new Meilisearch({
       host: HOST,
       apiKey: searchKey,
       defaultWaitOptions: { interval: 10 },
@@ -70,7 +70,7 @@ async function getClient(permission: string): Promise<MeiliSearch> {
 
   if (permission === "Admin") {
     const adminKey = await getKey(permission);
-    const adminClient = new MeiliSearch({
+    const adminClient = new Meilisearch({
       host: HOST,
       apiKey: adminKey,
       defaultWaitOptions: { interval: 10 },
@@ -82,7 +82,7 @@ async function getClient(permission: string): Promise<MeiliSearch> {
 }
 
 const clearAllIndexes = async (config: Config): Promise<void> => {
-  const client = new MeiliSearch(config);
+  const client = new Meilisearch(config);
   const { results } = await client.getRawIndexes();
 
   await Promise.all(
@@ -219,7 +219,7 @@ export {
   HOST,
   HOST2,
   MASTER_KEY,
-  MeiliSearch,
+  Meilisearch,
   Index,
   getClient,
   getKey,

--- a/tests/wait_for_task.test.ts
+++ b/tests/wait_for_task.test.ts
@@ -64,7 +64,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       await expect(
         client.index(index.uid).addDocuments(dataset).waitTask({ timeout: 1 }),
-      ).rejects.toHaveProperty("name", "MeiliSearchTaskTimeOutError");
+      ).rejects.toHaveProperty("name", "MeilisearchTaskTimeOutError");
     });
 
     // Index Wait for task
@@ -129,7 +129,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       await expect(
         client.tasks.waitForTasks([task1, task2], { timeout: 1 }),
-      ).rejects.toHaveProperty("name", "MeiliSearchTaskTimeOutError");
+      ).rejects.toHaveProperty("name", "MeilisearchTaskTimeOutError");
     });
 
     test(`${permission} key: Tests to wait for task that doesn't exist`, async () => {
@@ -137,7 +137,7 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       await expect(
         client.tasks.waitForTask(424242424242),
-      ).rejects.toHaveProperty("name", "MeiliSearchApiError");
+      ).rejects.toHaveProperty("name", "MeilisearchApiError");
     });
   },
 );

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationMap": true,
-    "declarationDir": "./dist/types"
+    "declarationDir": "./dist/"
   },
   "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
-    // We don't want to check node_modules
     "skipLibCheck": true,
-    "module": "node18",
-    // Node.js 20 at https://node.green/#ES2023
+    "module": "node20",
     "target": "es2023",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "resolveJsonModule": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,65 +1,22 @@
+/// <reference types="vitest/config" />
 import { defineConfig, loadEnv } from "vite";
-import pkg from "./package.json" with { type: "json" };
+import tsconfig from "./tsconfig.json" with { type: "json" };
 
-const indexInput = "src/index.ts";
-const tokenInput = "src/token.ts";
-const globalVarName = pkg.name;
-
-export default defineConfig(({ mode }) => {
-  const isNotUMDBuild = mode === "production";
-
-  return {
-    build: {
-      // for UMD build we do not want to empty directory, so previous builds stay intact
-      emptyOutDir: isNotUMDBuild,
-      // don't minify CJS build, Node.js doesn't benefit from it
-      minify: !isNotUMDBuild,
-      sourcemap: true,
-      // UMD build should target the lowest level ES,
-      // while CJS the lowest Node.js LTS/Maintenance compatible version (https://node.green/#ES2023)
-      target: isNotUMDBuild ? "es2023" : "es6",
-      lib: {
-        // leave out token export from UMD build
-        entry: isNotUMDBuild ? [indexInput, tokenInput] : indexInput,
-        name: isNotUMDBuild ? undefined : globalVarName,
-        formats: isNotUMDBuild ? ["cjs", "es"] : ["umd"],
-        fileName: (format, entryName) => {
-          switch (format) {
-            case "umd":
-              return `umd/${entryName}.min.js`;
-            case "cjs":
-              return `cjs/${entryName}.cjs`;
-            case "es":
-              return `esm/${entryName}.js`;
-            default:
-              throw new Error(`unsupported format ${format}`);
-          }
-        },
-      },
-      rollupOptions: !isNotUMDBuild
-        ? // the following code enables Vite in UMD mode to extend the global object with all of
-          // the exports, and not just a property of it ( https://github.com/vitejs/vite/issues/11624 )
-          // TODO: Remove this in the future ( https://github.com/meilisearch/meilisearch-js/issues/1806 )
-          {
-            output: {
-              footer: `(function () {
-                           if (typeof self !== "undefined") {
-                             var clonedGlobal = Object.assign({}, self.${globalVarName});
-                             delete clonedGlobal.default;
-                             Object.assign(self, clonedGlobal);
-                           }
-                       })();`,
-            },
-          }
-        : undefined,
+export default defineConfig({
+  build: {
+    sourcemap: true,
+    target: tsconfig.compilerOptions.target,
+    lib: {
+      entry: ["src/index.ts", "src/token.ts"],
+      formats: ["es"],
     },
-    test: {
-      include: ["tests/**/*.test.ts"],
-      fileParallelism: false,
-      testTimeout: 100_000, // 100 seconds
-      coverage: { include: ["src/**/*.ts"] },
-      // Allow loading env variables from `.env.test`
-      env: loadEnv("test", process.cwd()),
-    },
-  };
+  },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    fileParallelism: false,
+    testTimeout: 100_000, // 100 seconds
+    coverage: { include: ["src/**/*.ts"] },
+    // Allow loading env variables from `.env.test`
+    env: loadEnv("test", process.cwd()),
+  },
 });


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1789 
Fixes #1870
Fixes #1806

## What does this PR do?
- Node.js ^20 can now `require(esm)`, so there's no point in bundling to commonjs anymore
  - https://vite.dev/blog/announcing-vite8#node-js-support
  - https://github.com/vitejs/vite/blob/main/packages/vite/package.json
- Remove UMD bundle, modern browsers support importing ESM from URLs and `type="module"` scripts for almost a decade now, even Node.js supports requiring ESM as stated above
- Only export `Meilisearch` without default, without upper case "Search", to avoid confusion regarding imports and to fix bundler warnings
- Remove any fields regarding exports outside of `"exports"` field, all supported Node.js versions support "exports" field, as do all modern bundlers and CDNs
- make use of [`publishConfig`](https://pnpm.io/package_json#publishconfig), so we can export to other workspace packages the TypeScript source files
- Put `package.json` into exports, mainly so bundlers can read it via directly importing it, and it seems to be the industry norm
- Add Node.js 24 LTS to the test matrix (at the end of April we should remove Node.js 20 support EOL)
- Remove post build script that adds some details about the project to `index.d.ts`
  - We can use [banner](https://rolldown.rs/reference/OutputOptions.postBanner#postbanner) instead if it's a desired functionality, however I'm not sure if it's necessary, let me know
- Misc: [remove ignored files/dirs from oxlint config as they're already ignored](https://oxc.rs/docs/guide/usage/linter/ignore-files.html#default-ignores)

## Migration

1. Default and uppercase "Search" exports are no longer available:

```diff
- import meili from "meilisearch";
- import { MeiliSearch } from "meilisearch";
- import { default as meili } from "meilisearch";
import { Meilisearch } from "meilisearch";
```

2. Renamed every symbol and string that contained the name "MeiliSearch" with uppercase "S" to "Meilisearch" with lowercase "s"

```diff
- import { MeiliSearchError } from "meilisearch";
+ import { MeilisearchError } from "meilisearch";
// ... same pattern for every other export
```

3.
  - CommonJS and UMD bundles aren't available anymore
  - `package.json` `"main"` and `"types"` fields aren't available anymore

If you relied on any of these outdated features, you will have to bundle for any target environment that requires them, or update the environment if that's possible.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Node.js 24 to test matrix alongside versions 20 and 22.

* **Documentation**
  * Updated README with modern ES module-based CDN import example.

* **Breaking Changes**
  * Renamed main client class `MeiliSearch` to `Meilisearch`.
  * Renamed error classes: `MeiliSearch*` → `Meilisearch*` (e.g., `MeiliSearchRequestError` → `MeilisearchRequestError`).
  * Removed UMD bundle; package now provides ES modules only.
  * Updated Node.js requirement to `^20.19.0 || >=22.12.0`.
  * Simplified exports configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->