### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -534,7 +534,7 @@ tenant_token_guide_search_sdk_1: |-
   const frontEndClient = new MeiliSearch({ host: 'MEILISEARCH_URL', apiKey: token })
   frontEndClient.index('patient_medical_records').search('blood test')
 authorization_header_1: |-
-  const client = new MeiliSearch({ host: 'MEILISEARCH_URL', apiKey: 'masterKey' })
+  const client = new MeiliSearch({ host: 'MEILISEARCH_URL', apiKey: 'MEILISEARCH_KEY' })
   client.getKeys()
 facet_search_1: |-
   client.index('books').searchForFacetValues({

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://dub.sh/meili-discord?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js">Roadmap</a> |
   <a href="https://www.meilisearch.com?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js">FAQ</a>
 </h4>
 
 <p align="center">
@@ -195,7 +195,7 @@ import { Meilisearch } from "meilisearch";
 })();
 ```
 
-Tasks such as document addition always return a unique identifier. You can use this identifier `taskUid` to check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of a [task](https://www.meilisearch.com/docs/reference/api/tasks).
+Tasks such as document addition always return a unique identifier. You can use this identifier `taskUid` to check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of a [task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks).
 
 ### Basic search <!-- omit in toc -->
 
@@ -226,7 +226,7 @@ Output:
 
 ### Using search parameters <!-- omit in toc -->
 
-`meilisearch-js` supports all [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) described in our main documentation website.
+`meilisearch-js` supports all [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters) described in our main documentation website.
 
 ```javascript
 await index.search("wonder", {
@@ -258,7 +258,7 @@ await index.search("wonder", {
 
 ### Custom search with filters <!-- omit in toc -->
 
-To enable filtering, you must first add your attributes to the [`filterableAttributes` index setting](https://www.meilisearch.com/docs/reference/api/settings#filterable-attributes).
+To enable filtering, you must first add your attributes to the [`filterableAttributes` index setting](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#filterable-attributes).
 
 ```js
 await index.updateFilterableAttributes(["id", "genres"]);
@@ -266,9 +266,9 @@ await index.updateFilterableAttributes(["id", "genres"]);
 
 You only need to perform this operation once per index.
 
-Note that Meilisearch rebuilds your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take considerable time. You can track the process using the [tasks API](https://www.meilisearch.com/docs/reference/api/tasks)).
+Note that Meilisearch rebuilds your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take considerable time. You can track the process using the [tasks API](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks)).
 
-After you configured `filterableAttributes`, you can use the [`filter` search parameter](https://www.meilisearch.com/docs/reference/api/search#filter) to refine your search:
+After you configured `filterableAttributes`, you can use the [`filter` search parameter](https://www.meilisearch.com/docs/reference/api/search/search-with-post#filter) to refine your search:
 
 ```js
 await index.search("wonder", {
@@ -333,7 +333,7 @@ await index.search("", {
 }
 ```
 
-Note that to enable faceted search on your dataset you need to add `genres` to the `filterableAttributes` index setting. For more information on filtering and faceting, [consult our documentation settings](https://www.meilisearch.com/docs/learn/fine_tuning_results/faceted_search).
+Note that to enable faceted search on your dataset you need to add `genres` to the `filterableAttributes` index setting. For more information on filtering and faceting, [consult our documentation settings](https://www.meilisearch.com/docs/learn/filtering_and_sorting/search_with_facet_filters).
 
 #### Abortable search <!-- omit in toc -->
 
@@ -407,10 +407,10 @@ This package guarantees compatibility with [version v1.x of Meilisearch](https:/
 
 The following sections in our main documentation website may interest you:
 
-- **Managing documents**: see the [API reference](https://www.meilisearch.com/docs/reference/api/documents?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or read more about [documents](https://www.meilisearch.com/docs/learn/core_concepts/documents).
-- **Searching**: see the [API reference](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js#search-parameters).
-- **Managing indexes**: see the [API reference](https://www.meilisearch.com/docs/reference/api/indexes?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or read more about [indexes](https://www.meilisearch.com/docs/learn/core_concepts/indexes?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js).
-- **Configuring indexes**: see the [API reference](https://www.meilisearch.com/docs/reference/api/settings?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/reference/api/settings?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js#settings_parameters).
+- **Managing documents**: see the [API reference](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or read more about [documents](https://www.meilisearch.com/docs/learn/getting_started/documents).
+- **Searching**: see the [API reference](https://www.meilisearch.com/docs/reference/api/search/search-with-post?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js#search-parameters).
+- **Managing indexes**: see the [API reference](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or read more about [indexes](https://www.meilisearch.com/docs/learn/getting_started/indexes?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js).
+- **Configuring indexes**: see the [API reference](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings?utm_campaign=oss&utm_source=github&utm_medium=meilisearch-js#settings_parameters).
 
 Check out the [playgrounds](./playgrounds/) for examples of implementation.
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -8,7 +8,7 @@ import type { HttpRequests } from "./http-requests.js";
 /**
  * Class for handling batches.
  *
- * @see {@link https://www.meilisearch.com/docs/reference/api/batches}
+ * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches
  */
 export class BatchClient {
   readonly #httpRequest: HttpRequests;
@@ -17,12 +17,12 @@ export class BatchClient {
     this.#httpRequest = httpRequests;
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/batches#get-one-batch} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#get-one-batch */
   async getBatch(uid: number): Promise<Batch> {
     return await this.#httpRequest.get({ path: `batches/${uid}` });
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/batches#get-batches} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#get-batches */
   async getBatches(params?: TasksOrBatchesQuery): Promise<BatchesResults> {
     return await this.#httpRequest.get({ path: "batches", params });
   }

--- a/src/chat-workspace.ts
+++ b/src/chat-workspace.ts
@@ -7,7 +7,7 @@ import type {
 /**
  * Class for handling chat workspaces.
  *
- * @see {@link https://www.meilisearch.com/docs/reference/api/chats}
+ * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces
  */
 export class ChatWorkspace {
   readonly #httpRequest: HttpRequests;
@@ -22,7 +22,7 @@ export class ChatWorkspace {
    * Get the settings of a chat workspace.
    *
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#get-chat-workspace-settings}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces#get-chat-workspace-settings
    */
   async get(): Promise<ChatWorkspaceSettings> {
     return await this.#httpRequest.get({
@@ -34,7 +34,7 @@ export class ChatWorkspace {
    * Update the settings of a chat workspace.
    *
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#update-chat-workspace-settings}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces#update-chat-workspace-settings
    */
   async update(
     settings: Partial<ChatWorkspaceSettings>,
@@ -49,7 +49,7 @@ export class ChatWorkspace {
    * Reset the settings of a chat workspace.
    *
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#reset-chat-workspace-settings}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces#reset-chat-workspace-settings
    */
   async reset(): Promise<void> {
     await this.#httpRequest.delete({
@@ -61,7 +61,7 @@ export class ChatWorkspace {
    * Create a chat completion using an OpenAI-compatible interface.
    *
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#chat-completions}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces#chat-completions
    */
   async streamCompletion(
     completion: ChatCompletionRequest,

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -546,7 +546,7 @@ export class Index<T extends RecordAny = RecordAny> {
    * More info about the feature:
    * https://github.com/orgs/meilisearch/discussions/762 More info about
    * experimental features in general:
-   * https://www.meilisearch.com/docs/reference/api/experimental-features
+   * https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features
    *
    * @param options - Object containing the function string and related options
    * @returns Promise containing an EnqueuedTask

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -268,7 +268,7 @@ export class MeiliSearch {
    * @param queries - Search queries
    * @param extraRequestInit - Additional request configuration options
    * @returns Promise containing the search responses
-   * @see {@link https://www.meilisearch.com/docs/learn/multi_search/implement_sharding#perform-a-search}
+   * @see {@link https://www.meilisearch.com/docs/learn/multi_search/implement_sharding#perform-a-search
    */
   async multiSearch<
     T1 extends MultiSearchParams | FederatedMultiSearchParams,
@@ -424,7 +424,7 @@ export class MeiliSearch {
   /**
    * Get the current network configuration.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#get-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#get-the-network-object
    *
    * @experimental
    */
@@ -436,7 +436,7 @@ export class MeiliSearch {
    * Initialize a network with sharding enabled. This sets up the current
    * instance as the leader and configures the initial set of remotes.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#update-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#update-the-network-object
    *
    * @param options - Network initialization options
    * @returns Promise returning the enqueued task
@@ -459,7 +459,7 @@ export class MeiliSearch {
   /**
    * Add a remote to the network. Must be called on the leader instance.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#update-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#update-the-network-object
    *
    * @param options - Options containing the remote name and configuration
    * @returns Promise returning the enqueued task
@@ -476,7 +476,7 @@ export class MeiliSearch {
   /**
    * Remove a remote from the network. Must be called on the leader instance.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#update-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#update-the-network-object
    *
    * @param options - Options containing the remote name to remove
    * @returns Promise returning the enqueued task
@@ -493,7 +493,7 @@ export class MeiliSearch {
   /**
    * Add remotes to a shard. Must be called on the leader instance.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#update-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#update-the-network-object
    *
    * @param shardName - Name of the shard to update
    * @param remotes - Remotes to add
@@ -511,7 +511,7 @@ export class MeiliSearch {
   /**
    * Remove remotes from a shard. Must be called on the leader instance.
    *
-   * {@link https://www.meilisearch.com/docs/reference/api/network#update-the-network-object}
+   * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#update-the-network-object
    *
    * @param shardName - Name of the shard to update
    * @param remotes - Remotes to remove
@@ -690,14 +690,14 @@ export class MeiliSearch {
   /// EXPERIMENTAL-FEATURES
   ///
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/experimental_features#get-all-experimental-features} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features#get-all-experimental-features */
   async getExperimentalFeatures(): Promise<RuntimeTogglableFeatures> {
     return await this.httpRequest.get({
       path: "experimental-features",
     });
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/experimental_features#configure-experimental-features} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features#configure-experimental-features */
   async updateExperimentalFeatures(
     runtimeTogglableFeatures: RuntimeTogglableFeatures,
   ): Promise<RuntimeTogglableFeatures> {

--- a/src/task.ts
+++ b/src/task.ts
@@ -52,7 +52,7 @@ const getTaskUid = (taskUidOrEnqueuedTask: TaskUidOrEnqueuedTask): number =>
 /**
  * Class for handling tasks.
  *
- * @see {@link https://www.meilisearch.com/docs/reference/api/tasks}
+ * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks
  */
 export class TaskClient {
   readonly #httpRequest: HttpRequests;
@@ -67,7 +67,7 @@ export class TaskClient {
     this.#applyWaitTask = getWaitTaskApplier(this);
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/tasks#get-one-task} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-one-task */
   async getTask(
     uid: number,
     // TODO: Need to do this for all other methods: https://github.com/meilisearch/meilisearch-js/issues/1476
@@ -79,7 +79,7 @@ export class TaskClient {
     });
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/tasks#get-tasks} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks */
   async getTasks(params?: TasksOrBatchesQuery): Promise<TasksResults> {
     return await this.#httpRequest.get({ path: "tasks", params });
   }
@@ -159,14 +159,14 @@ export class TaskClient {
     return tasks;
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/tasks#cancel-tasks} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#cancel-tasks */
   cancelTasks(params: DeleteOrCancelTasksQuery): EnqueuedTaskPromise {
     return this.#applyWaitTask(
       this.#httpRequest.post({ path: "tasks/cancel", params }),
     );
   }
 
-  /** {@link https://www.meilisearch.com/docs/reference/api/tasks#delete-tasks} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#delete-tasks */
   deleteTasks(params: DeleteOrCancelTasksQuery): EnqueuedTaskPromise {
     return this.#applyWaitTask(
       this.#httpRequest.delete({ path: "tasks", params }),

--- a/src/types/experimental-features.ts
+++ b/src/types/experimental-features.ts
@@ -1,5 +1,5 @@
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/experimental_features#experimental-features-object}
+ * {@link https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features#experimental-features-object
  *
  * @see `meilisearch::routes::features::RuntimeTogglableFeatures`
  */

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -1,11 +1,11 @@
-/** {@link https://www.meilisearch.com/docs/reference/api/network#the-remote-object} */
+/** {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#the-remote-object */
 export type Remote = {
   url: string;
   searchApiKey?: string | null;
   writeApiKey?: string | null;
 };
 
-/** {@link https://www.meilisearch.com/docs/reference/api/network#the-network-object} */
+/** {@link https://www.meilisearch.com/docs/reference/api/experimental-features/network-control#the-network-object */
 export type Network = {
   self?: string | null;
   leader?: string | null;

--- a/src/types/task-and-batch.ts
+++ b/src/types/task-and-batch.ts
@@ -26,7 +26,7 @@ export type WaitOptions = {
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#status}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#status
  *
  * @see `meilisearch_types::tasks::Status`
  */
@@ -35,7 +35,7 @@ export type TaskStatus = PascalToCamelCase<
 >;
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#type}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#type
  *
  * @see `meilisearch_types::tasks::Kind`
  */
@@ -57,7 +57,7 @@ export type TaskType = PascalToCamelCase<
 >;
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#query-parameters}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters
  *
  * @see `meilisearch::routes::tasks::TasksFilterQuery`
  */
@@ -80,8 +80,8 @@ export type TasksOrBatchesQuery = Partial<{
 }>;
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#query-parameters-1}
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#query-parameters-2}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters-1
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#query-parameters-2
  *
  * @see `meilisearch::routes::tasks::TaskDeletionOrCancelationQuery`
  */
@@ -91,7 +91,7 @@ export type DeleteOrCancelTasksQuery = SafeOmit<
 >;
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#summarized-task-object}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#summarized-task-object
  *
  * @see `meilisearch::routes::SummarizedTaskView`
  */
@@ -106,14 +106,14 @@ export type EnqueuedTask = {
 /** Either a number or an {@link EnqueuedTask}. */
 export type TaskUidOrEnqueuedTask = EnqueuedTask["taskUid"] | EnqueuedTask;
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#indexswap} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#indexswap */
 export type IndexSwap = {
   indexes: [string, string];
   rename: boolean;
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#details}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#details
  *
  * @see `meilisearch_types::task_view::DetailsView`
  */
@@ -137,20 +137,20 @@ export type TaskDetails = Settings &
     upgradeTo: string;
   }>;
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#network */
 type Origin = { remoteName: string; taskUid: number };
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#network */
 type NetworkOrigin = { origin: Origin };
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#network */
 type RemoteTask = { taskUid?: number; error: MeiliSearchErrorResponse | null };
 
-/** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#network */
 type NetworkRemoteTasks = { remoteTasks: Record<string, RemoteTask> };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#task-object}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#task-object
  *
  * @see `meilisearch_types::task_view::TaskView`
  */
@@ -166,10 +166,10 @@ export type Task = SafeOmit<EnqueuedTask, "taskUid"> & {
   /**
    * Arbitrary metadata attached to the task at enqueue time.
    *
-   * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/get-task#response-custom-metadata-one-of-0}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/get-task#response-custom-metadata-one-of-0
    */
   customMetadata?: string;
-  /** {@link https://www.meilisearch.com/docs/reference/api/tasks#network} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#network */
   network?: NetworkOrigin | NetworkRemoteTasks;
 };
 
@@ -194,14 +194,14 @@ type Results<T> = {
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/tasks#response}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#response
  *
  * @see `meilisearch::routes::tasks::AllTasks`
  */
 export type TasksResults = Results<Task>;
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/batches#steps}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#steps
  *
  * @see `milli::progress::ProgressStepView`
  */
@@ -212,7 +212,7 @@ export type BatchProgressStep = {
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/batches#progress}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#progress
  *
  * @see `milli::progress::ProgressView`
  */
@@ -221,22 +221,22 @@ export type BatchProgress = {
   percentage: number;
 };
 
-/** {@link https://www.meilisearch.com/docs/reference/api/batches#stats} */
+/** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#stats */
 type BatchStats = {
   totalNbTasks: number;
   status: Record<TaskStatus, number>;
   types: Record<TaskType, number>;
   indexUids: Record<string, number>;
-  /** {@link https://www.meilisearch.com/docs/reference/api/batches#progresstrace} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#progresstrace */
   progressTrace?: RecordAny;
-  /** {@link https://www.meilisearch.com/docs/reference/api/batches#writechannelcongestion} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#writechannelcongestion */
   writeChannelCongestion?: RecordAny;
-  /** {@link https://www.meilisearch.com/docs/reference/api/batches#internaldatabasesizes} */
+  /** {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#internaldatabasesizes */
   internalDatabaseSizes?: RecordAny;
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/batches#batch-object}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#batch-object
  *
  * @see `meilisearch_types::batch_view::BatchView`
  */
@@ -253,7 +253,7 @@ export type Batch = {
 };
 
 /**
- * {@link https://www.meilisearch.com/docs/reference/api/batches#response}
+ * {@link https://www.meilisearch.com/docs/reference/api/async-task-management/list-batches#response
  *
  * @see `meilisearch::routes::batches::AllBatches`
  */

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -4,7 +4,7 @@ import type { Filter } from "./types.js";
 export type TokenIndexRules = { filter?: Filter };
 
 /**
- * {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#search-rules}
+ * {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#search-rules
  *
  * @remarks
  * Not well documented.
@@ -21,7 +21,7 @@ export type TenantTokenGeneratorOptions = {
   /**
    * The uid of the api key used as issuer of the token.
    *
-   * @see {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#api-key-uid}
+   * @see {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#api-key-uid
    */
   apiKeyUid: string;
   /**
@@ -34,7 +34,7 @@ export type TenantTokenGeneratorOptions = {
    * {@link https://en.wikipedia.org/wiki/Unix_time | UNIX timestamp} or
    * {@link Date} object at which the token expires.
    *
-   * @see {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#expiry-date}
+   * @see {@link https://www.meilisearch.com/docs/learn/security/tenant_token_reference#expiry-date
    */
   expiresAt?: number | Date;
   /**
@@ -42,7 +42,7 @@ export type TenantTokenGeneratorOptions = {
    * are HS256, HS384, HS512. (HS[number] means HMAC using SHA-[number])
    *
    * @defaultValue `"HS256"`
-   * @see {@link https://www.meilisearch.com/docs/learn/security/generate_tenant_token_scratch#prepare-token-header}
+   * @see {@link https://www.meilisearch.com/docs/learn/security/generate_tenant_token_scratch#prepare-token-header
    */
   algorithm?: `HS${256 | 384 | 512}`;
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -55,7 +55,7 @@ export type Config = {
   /**
    * API key for interacting with a meilisearch instance.
    *
-   * @see {@link https://www.meilisearch.com/docs/learn/security/basic_security}
+   * @see {@link https://www.meilisearch.com/docs/learn/security/basic_security
    */
   apiKey?: string;
   /**
@@ -234,7 +234,7 @@ export type MediaBinary = {
 /** Search request media payload with named search fragments */
 export type MediaPayload = Record<string, Record<string, string | MediaBinary>>;
 
-// https://www.meilisearch.com/docs/reference/api/settings#localized-attributes
+// https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#localized-attributes
 export type Locale = string;
 
 export type SearchParams = Query &
@@ -475,7 +475,7 @@ export type TaskEnqueueOptions = {
    * Arbitrary string attached to the enqueued task. Available on the task
    * object via the `customMetadata` field.
    *
-   * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/get-task#response-custom-metadata-one-of-0}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/async-task-management/get-task#response-custom-metadata-one-of-0
    */
   customMetadata?: string;
 };
@@ -768,7 +768,7 @@ export type Stats = {
  ** CHATS
  */
 
-/** @see https://www.meilisearch.com/docs/reference/api/chats#settings-parameters */
+/** @see https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces#settings-parameters */
 export type ChatWorkspaceSettings = {
   source: "openAi" | "azureOpenAi" | "mistral" | "gemini" | "vLlm";
   orgId?: string;

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -1,23 +1,23 @@
 import { type Config, MeiliSearch, Index } from "../../src/index.js";
 
 // testing
-const MEILISEARCH_KEY = "masterKey";
+const MASTER_KEY = "masterKey";
 const HOST = process.env.MEILISEARCH_URL || "http://127.0.0.1:7700";
 const HOST2 = process.env.MEILISEARCH_URL_2 || "http://127.0.0.1:7701";
 const BAD_HOST = "http://127.0.0.1:9999";
 
 const config: Config = {
   host: HOST,
-  apiKey: MEILISEARCH_KEY,
+  apiKey: MASTER_KEY,
   defaultWaitOptions: { interval: 10 },
 };
 const badHostClient = new MeiliSearch({
   host: BAD_HOST,
-  apiKey: MEILISEARCH_KEY,
+  apiKey: MASTER_KEY,
 });
 const masterClient = new MeiliSearch({
   host: HOST,
-  apiKey: MEILISEARCH_KEY,
+  apiKey: MASTER_KEY,
   defaultWaitOptions: { interval: 10 },
 });
 
@@ -46,7 +46,7 @@ async function getKey(permission: string): Promise<string> {
     const key = keys.find((key) => key.name === "Default Admin API Key")?.key;
     return key || "";
   }
-  return MEILISEARCH_KEY;
+  return MASTER_KEY;
 }
 
 async function getClient(permission: string): Promise<MeiliSearch> {
@@ -218,7 +218,7 @@ export {
   BAD_HOST,
   HOST,
   HOST2,
-  MEILISEARCH_KEY,
+  MASTER_KEY,
   MeiliSearch,
   Index,
   getClient,

--- a/tests/utils/meilisearch-test-utils.ts
+++ b/tests/utils/meilisearch-test-utils.ts
@@ -1,23 +1,23 @@
 import { type Config, MeiliSearch, Index } from "../../src/index.js";
 
 // testing
-const MASTER_KEY = "masterKey";
+const MEILISEARCH_KEY = "masterKey";
 const HOST = process.env.MEILISEARCH_URL || "http://127.0.0.1:7700";
 const HOST2 = process.env.MEILISEARCH_URL_2 || "http://127.0.0.1:7701";
 const BAD_HOST = "http://127.0.0.1:9999";
 
 const config: Config = {
   host: HOST,
-  apiKey: MASTER_KEY,
+  apiKey: MEILISEARCH_KEY,
   defaultWaitOptions: { interval: 10 },
 };
 const badHostClient = new MeiliSearch({
   host: BAD_HOST,
-  apiKey: MASTER_KEY,
+  apiKey: MEILISEARCH_KEY,
 });
 const masterClient = new MeiliSearch({
   host: HOST,
-  apiKey: MASTER_KEY,
+  apiKey: MEILISEARCH_KEY,
   defaultWaitOptions: { interval: 10 },
 });
 
@@ -46,7 +46,7 @@ async function getKey(permission: string): Promise<string> {
     const key = keys.find((key) => key.name === "Default Admin API Key")?.key;
     return key || "";
   }
-  return MASTER_KEY;
+  return MEILISEARCH_KEY;
 }
 
 async function getClient(permission: string): Promise<MeiliSearch> {
@@ -218,7 +218,7 @@ export {
   BAD_HOST,
   HOST,
   HOST2,
-  MASTER_KEY,
+  MEILISEARCH_KEY,
   MeiliSearch,
   Index,
   getClient,


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated all internal documentation references to point to the latest Meilisearch API documentation pages, ensuring users have access to current and accurate information when reviewing code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->