### PR TITLE
Remove unused code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -38,8 +38,6 @@ swap_indexes_1: |-
     { 'indexes': ['indexA', 'indexB'] },
     { 'indexes': ['indexX', 'indexY'] }
   ])
-rename_an_index_1: |-
-  client.updateIndex('movies', { uid: 'films' })
 get_one_document_1: |-
   client
       .index('movies')
@@ -280,13 +278,6 @@ get_version_1: |-
   client.getVersion()
 distinct_attribute_guide_1: |-
   client.index('jackets').updateDistinctAttribute('product_id')
-field_properties_guide_searchable_1: |-
-  client.index('movies').updateSearchableAttributes([
-      'title',
-      'overview',
-      'genres',
-    ]
-  )
 field_properties_guide_displayed_1: |-
   client.index('movies').updateDisplayedAttributes([
       'title',
@@ -553,8 +544,6 @@ facet_search_3: |-
     facetQuery: 'c',
     facetName: 'genres'
   })
-search_parameter_guide_show_ranking_score_details_1: |-
-  client.index('movies').search('dragon', { showRankingScoreDetails: true })
 get_similar_post_1: |-
   client.index('INDEX_NAME').searchSimilarDocuments({ id: 'TARGET_DOCUMENT_ID', embedder: 'default' })
 distinct_attribute_guide_filterable_1: |-


### PR DESCRIPTION
## Summary

Reported by https://github.com/meilisearch/documentation/actions/runs/24176332506/job/70558505454

- Removes 3 unused code samples from `.code-samples.meilisearch.yaml` that are neither referenced in the docs nor in the local config:
  - `field_properties_guide_searchable_1`
  - `rename_an_index_1`
  - `search_parameter_guide_show_ranking_score_details_1`

These were flagged by the CI as unused samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed code examples for index renaming, searchable attributes configuration, and ranking score details in search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->