### PR TITLE
Make tests compatible with Meilisearch v1.42.0

### DIFF
--- a/tests/get_search.test.ts
+++ b/tests/get_search.test.ts
@@ -193,15 +193,14 @@ describe.each([
       limit: 1,
       offset: 1,
     });
-    expect(response).toHaveProperty("hits", [
-      {
-        id: 4,
-        title: "Harry Potter and the Half-Blood Prince",
-        author: "J.K. Rowling",
-        comment: "The best book",
-        genre: ["fantasy", "adventure"],
-      },
-    ]);
+    expect(response).toHaveProperty("hits", expect.any(Array));
+    expect(response.hits[0]).toMatchObject({
+      id: 4,
+      title: "Harry Potter and the Half-Blood Prince",
+      author: "J.K. Rowling",
+      comment: "The best book",
+      genre: ["fantasy", "adventure"],
+    });
     expect(response).toHaveProperty("offset", 1);
     expect(response).toHaveProperty("limit", 1);
     expect(response).toHaveProperty("processingTimeMs", expect.any(Number));

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -701,9 +701,10 @@ describe.each([
     expect(response).toHaveProperty("hits");
     expect(Array.isArray(response.hits)).toBe(true);
     expect(response).toHaveProperty("query", "prince");
-    expect(Object.keys(hit).join(",")).toEqual(
-      Object.keys(dataset[1]).join(","),
-    );
+
+    Object.keys(dataset[1]).forEach((key) => {
+      expect(hit).toHaveProperty(key);
+    });
   });
 
   test(`${permission} key: search on attributesToSearchOn`, async () => {
@@ -737,9 +738,9 @@ describe.each([
     expect(response).toHaveProperty("hits");
     expect(Array.isArray(response.hits)).toBe(true);
     expect(response).toHaveProperty("query", "prince");
-    expect(Object.keys(hit).join(",")).toEqual(
-      Object.keys(dataset[1]).join(","),
-    );
+    Object.keys(dataset[1]).forEach((key) => {
+      expect(hit).toHaveProperty(key);
+    });
   });
 
   test(`${permission} key: search with options`, async () => {
@@ -778,15 +779,14 @@ describe.each([
       offset: 1,
     });
 
-    expect(response).toHaveProperty("hits", [
-      {
-        id: 4,
-        author: "J.K. Rowling",
-        title: "Harry Potter and the Half-Blood Prince",
-        comment: "The best book",
-        genre: ["fantasy", "adventure"],
-      },
-    ]);
+    expect(response).toHaveProperty("hits", expect.any(Array));
+    expect(response.hits[0]).toMatchObject({
+      id: 4,
+      author: "J.K. Rowling",
+      title: "Harry Potter and the Half-Blood Prince",
+      comment: "The best book",
+      genre: ["fantasy", "adventure"],
+    });
     expect(response).toHaveProperty("offset", 1);
     expect(response).toHaveProperty("limit", 1);
     expect(response.estimatedTotalHits).toEqual(2);
@@ -1372,7 +1372,8 @@ describe.each([{ permission: "Master" }])(
       const client = await getClient(permission);
       const response = await client.index(index.uid).search("An awesome", {});
 
-      expect(response.hits[0]).toEqual({
+      expect(response).toHaveProperty("hits", expect.any(Array));
+      expect(response.hits[0]).toMatchObject({
         id: 5,
         title: "The Hobbit",
         info: {
@@ -1393,7 +1394,8 @@ describe.each([{ permission: "Master" }])(
 
       const response = await client.index(index.uid).search("An awesome", {});
 
-      expect(response.hits[0]).toEqual({
+      expect(response).toHaveProperty("hits", expect.any(Array));
+      expect(response.hits[0]).toMatchObject({
         id: 5,
         title: "The Hobbit",
         info: {
@@ -1417,7 +1419,8 @@ describe.each([{ permission: "Master" }])(
         sort: ["info.reviewNb:desc"],
       });
 
-      expect(response.hits[0]).toEqual({
+      expect(response).toHaveProperty("hits", expect.any(Array));
+      expect(response.hits[0]).toMatchObject({
         id: 6,
         title: "Harry Potter and the Half-Blood Prince",
         info: {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes [broken SDK tests](https://github.com/meilisearch/meilisearch/actions/runs/24329899008/job/71033135646) in Meilisearch v1.42 test suite

## What does this PR do?
- Replace `toEqual()` assertions by `toMatchObject()` to avoid breaking on API fields addition

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated search functionality tests to validate presence of expected fields instead of requiring exact data structure matches. Tests now allow flexible result structures while confirming essential fields are present, improving robustness across different dataset configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->