### PR TITLE
feat(stats): add StatsParams for Meilisearch v1.44 showInternalDatabaseSizes and sizeFormat

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -271,9 +271,9 @@ update_typo_tolerance_1: |-
 reset_typo_tolerance_1: |-
   client.index('books').resetTypoTolerance()
 get_index_stats_1: |-
-  client.index('movies').getStats()
+  client.index('movies').getStats({ showInternalDatabaseSizes: true, sizeFormat: 'human' })
 get_indexes_stats_1: |-
-  client.getStats()
+  client.getStats({ showInternalDatabaseSizes: true, sizeFormat: 'human' })
 get_health_1: |-
   client.health()
 get_version_1: |-

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -15,6 +15,7 @@ import type {
   IndexObject,
   IndexOptions,
   IndexStats,
+  StatsParams,
   DocumentsQuery,
   DocumentQuery,
   DocumentOptions,
@@ -285,11 +286,14 @@ export class Index<T extends RecordAny = RecordAny> {
   /**
    * Get stats of an index
    *
+   * @param params - Optional parameters to control size formatting and
+   *   internal database size reporting
    * @returns Promise containing object with stats of the index
    */
-  async getStats(): Promise<IndexStats> {
+  async getStats(params?: StatsParams): Promise<IndexStats> {
     return await this.httpRequest.get<IndexStats>({
       path: `indexes/${this.uid}/stats`,
+      params,
     });
   }
 

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -14,6 +14,7 @@ import type {
   Key,
   Health,
   Stats,
+  StatsParams,
   Version,
   KeyUpdate,
   IndexesQuery,
@@ -698,10 +699,12 @@ export class Meilisearch {
   /**
    * Get the stats of all the database
    *
+   * @param params - Optional parameters to control size formatting and
+   *   internal database size reporting
    * @returns Promise returning object of all the stats
    */
-  async getStats(): Promise<Stats> {
-    return await this.httpRequest.get<Stats>({ path: "stats" });
+  async getStats(params?: StatsParams): Promise<Stats> {
+    return await this.httpRequest.get<Stats>({ path: "stats", params });
   }
 
   ///

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -746,19 +746,29 @@ export type Health = {
  *** STATS
  */
 
+/** @see https://www.meilisearch.com/docs/reference/api/stats */
+export type StatsParams = {
+  /** When true, index stat objects include an `internalDatabaseSizes` map of internal DB names to their sizes. */
+  showInternalDatabaseSizes?: boolean;
+  /** When `"human"`, all size fields are returned as human-readable strings (e.g. `"2.3 MiB"`); defaults to `"raw"` (numeric bytes). */
+  sizeFormat?: "raw" | "human";
+};
+
 export type IndexStats = {
   numberOfDocuments: number;
   isIndexing: boolean;
   fieldDistribution: FieldDistribution;
   numberOfEmbeddedDocuments: number;
   numberOfEmbeddings: number;
-  rawDocumentDbSize: number;
-  avgDocumentSize: number;
+  rawDocumentDbSize: number | string;
+  avgDocumentSize: number | string;
+  /** Present only when `showInternalDatabaseSizes` is `true`. Keys are subject to change. */
+  internalDatabaseSizes?: Record<string, number | string>;
 };
 
 export type Stats = {
-  databaseSize: number;
-  usedDatabaseSize: number;
+  databaseSize: number | string;
+  usedDatabaseSize: number | string;
   lastUpdate: string;
   indexes: {
     [index: string]: IndexStats;


### PR DESCRIPTION
Closes #2185.

Adds support for the two new query parameters introduced in [Meilisearch v1.44.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.44.0) for the stats endpoints.

## Changes

**`src/types/types.ts`**
- New `StatsParams` type with `showInternalDatabaseSizes?: boolean` and `sizeFormat?: "raw" | "human"`
- `IndexStats.internalDatabaseSizes?: Record<string, number | string>` — present only when `showInternalDatabaseSizes: true`; typed as `Record<string, number | string>` per the spec note that keys are subject to change
- Size fields (`rawDocumentDbSize`, `avgDocumentSize`, `databaseSize`, `usedDatabaseSize`) widened to `number | string` to accommodate `sizeFormat: "human"` responses

**`src/indexes.ts`** — `getStats(params?: StatsParams)` passes params as query string

**`src/meilisearch.ts`** — `getStats(params?: StatsParams)` passes params as query string

**`.code-samples.meilisearch.yaml`** — updated `get_index_stats_1` and `get_indexes_stats_1` to show both new params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds support for two new query parameters introduced in Meilisearch v1.44.0 for the stats endpoints: showInternalDatabaseSizes and sizeFormat.

## Changes

**Type Definitions (src/types/types.ts)**
- Added `StatsParams`:
  - `showInternalDatabaseSizes?: boolean` — include internal database size breakdown when true
  - `sizeFormat?: "raw" | "human"` — return sizes as bytes or human-readable strings
- Updated `IndexStats`:
  - `rawDocumentDbSize` and `avgDocumentSize` widened from `number` to `number | string`
  - added optional `internalDatabaseSizes?: Record<string, number | string>` (present when `showInternalDatabaseSizes` is true)
- Updated `Stats`:
  - `databaseSize` and `usedDatabaseSize` widened from `number` to `number | string`

**Method Signatures (src/indexes.ts, src/meilisearch.ts)**
- `Index.getStats(params?: StatsParams)` now accepts optional params and forwards them as query string parameters to `GET /indexes/{uid}/stats`.
- `Meilisearch.getStats(params?: StatsParams)` now accepts optional params and forwards them as query string parameters to `GET /stats`.

**Code Samples (.code-samples.meilisearch.yaml)**
- Updated examples `get_index_stats_1` and `get_indexes_stats_1` to call `getStats()` with `{ showInternalDatabaseSizes: true, sizeFormat: 'human' }`.

## References
- Closes `#2185`
- Aligns SDK with Meilisearch v1.44.0 stats API changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->