### PR TITLE
Bump meilisearch to v1.46.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       meilisearch:
-        image: getmeili/meilisearch-enterprise:v1.42
+        image: getmeili/meilisearch-enterprise:v1.46
         env:
           MEILI_MASTER_KEY: "masterKey"
           MEILI_NO_ANALYTICS: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.42
+    image: getmeili/meilisearch-enterprise:v1.46
     ports:
       - "7700:7700"
     environment:

--- a/tests/__snapshots__/facet_search.test.ts.snap
+++ b/tests/__snapshots__/facet_search.test.ts.snap
@@ -14,6 +14,7 @@ exports[`Test on POST search > Admin key: basic facet value search 1`] = `
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -27,6 +28,7 @@ exports[`Test on POST search > Admin key: facet value search with exhaustive fac
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -40,6 +42,7 @@ exports[`Test on POST search > Admin key: facet value search with filter 1`] = `
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -65,6 +68,7 @@ exports[`Test on POST search > Admin key: facet value search with no facet query
   ],
   "facetQuery": null,
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -78,6 +82,7 @@ exports[`Test on POST search > Admin key: facet value search with search query 1
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -95,6 +100,7 @@ exports[`Test on POST search > Master key: basic facet value search 1`] = `
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -108,6 +114,7 @@ exports[`Test on POST search > Master key: facet value search with exhaustive fa
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -121,6 +128,7 @@ exports[`Test on POST search > Master key: facet value search with filter 1`] = 
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -146,6 +154,7 @@ exports[`Test on POST search > Master key: facet value search with no facet quer
   ],
   "facetQuery": null,
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -159,6 +168,7 @@ exports[`Test on POST search > Master key: facet value search with search query 
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -176,6 +186,7 @@ exports[`Test on POST search > Search key: basic facet value search 1`] = `
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -189,6 +200,7 @@ exports[`Test on POST search > Search key: facet value search with exhaustive fa
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -202,6 +214,7 @@ exports[`Test on POST search > Search key: facet value search with filter 1`] = 
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -227,6 +240,7 @@ exports[`Test on POST search > Search key: facet value search with no facet quer
   ],
   "facetQuery": null,
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;
 
@@ -240,5 +254,6 @@ exports[`Test on POST search > Search key: facet value search with search query 
   ],
   "facetQuery": "a",
   "processingTimeMs": 0,
+  "remoteErrors": {},
 }
 `;


### PR DESCRIPTION
# Pull Request

- update meilisearch to v1.46.0
- update tests snapshots

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the Meilisearch dependency from v1.42 to v1.46 across the project's CI/CD and local development configurations.

## Changes

- **`.github/workflows/tests.yml`**: Updated the integration test service container image from `getmeili/meilisearch-enterprise:v1.42` to `getmeili/meilisearch-enterprise:v1.46`
- **`docker-compose.yml`**: Updated the Meilisearch service Docker image from `getmeili/meilisearch-enterprise:v1.42` to `getmeili/meilisearch-enterprise:v1.46`

Both changes ensure consistent Meilisearch version (v1.46) across testing and local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->