### PR TITLE
Add `personalize` search parameter

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -269,8 +269,8 @@ export type SearchParams = Query &
     /**
      * Personalize search results for a given user context.
      *
-     * @experimental Requires Meilisearch >= v1.47 with the personalization
-     *   feature enabled.
+     * Experimental; requires Meilisearch v1.47 or later with the
+     * personalization feature enabled.
      */
     personalize?: Personalize;
   };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -212,6 +212,10 @@ export type HybridSearch = {
   semanticRatio?: number;
 };
 
+export type Personalize = {
+  userContext: string;
+};
+
 /**
  * Search request media binary data with explicit MIME
  *
@@ -262,6 +266,13 @@ export type SearchParams = Query &
     locales?: Locale[];
     media?: MediaPayload;
     showPerformanceDetails?: boolean;
+    /**
+     * Personalize search results for a given user context.
+     *
+     * @experimental Requires Meilisearch >= v1.47 with the personalization
+     *   feature enabled.
+     */
+    personalize?: Personalize;
   };
 
 // Search parameters for searches made with the GET method

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1156,3 +1156,29 @@ describe.each([{ permission: "Master" }])(
     });
   },
 );
+
+describe("search request body", () => {
+  test("forwards personalize in the search request body", async () => {
+    const client = new Meilisearch(config);
+    const postSpy = vi
+      .spyOn(HttpRequests.prototype, "post")
+      .mockResolvedValue({ hits: [], query: "prince" });
+
+    try {
+      await client.index("books").search("prince", {
+        personalize: { userContext: "user-123" },
+      });
+
+      expect(postSpy).toHaveBeenCalledWith({
+        path: "indexes/books/search",
+        body: {
+          q: "prince",
+          personalize: { userContext: "user-123" },
+        },
+        extraRequestInit: undefined,
+      });
+    } finally {
+      postSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Meilisearch v1.47.0 adds experimental personalized search. This adds the typed
`personalize` parameter (`{ userContext: string }`) to `SearchParams`. Closes #2193.

## Changes

- Add a `Personalize` type (`{ userContext: string }`), mirroring `HybridSearch`.
- Add `personalize?: Personalize` to `SearchParams`. Since `search()` forwards
  parameters to the API as-is, this is the only change needed for the POST search
  path, and `MultiSearchQuery` inherits it.

## Notes

- `SearchRequestGET` is intentionally left unchanged: like `hybrid`, object-valued
  parameters aren't represented in the GET query type.
- Verified with `tsc` (type-checks cleanly). Integration tests for the experimental
  personalization feature require a backend with it enabled plus an embedder; happy
  to add coverage if you point me to the preferred fixture setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds support for personalized search from Meilisearch v1.47.0 to the meilisearch-js SDK.

## Changes

**src/types/types.ts:**
- Added a new `Personalize` type with a `userContext: string` property
- Extended `SearchParams` to include an optional `personalize?: Personalize` parameter
- Documented as experimental, requiring Meilisearch v1.47 or later with personalization enabled

**tests/client.test.ts:**
- Added a request-shape test (`describe("search request body")`) that verifies the client forwards `personalize` in the POST search request body

## Notes

- The `search()` method forwards parameters to the API as-is; adding `personalize` to `SearchParams` enables support for both the POST search path and `MultiSearchQuery` (which inherits from it)
- `SearchRequestGET` was intentionally left unchanged since object-valued parameters (like `personalize`) are not represented in the GET query type, consistent with the existing `hybrid` handling
- A tsdoc lint issue was fixed by rephrasing the `personalize` doc comment to avoid an unescaped `>` character
- TypeScript compilation and formatting checks were verified locally (`tsc --noEmit`, `prettier -c`)

## Related issue
Closes `#2193`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->