### PR TITLE
Add render template route support (experimental)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -632,3 +632,14 @@ patch_dynamic_search_rule_1: |-
   })
 delete_dynamic_search_rule_1: |-
   client.deleteDynamicSearchRule('RULE_UID')
+post_render_template_1: |-
+  client.renderTemplate({
+    template: {
+      kind: 'inlineDocumentTemplate',
+      inline: 'An inline document template rendered on {{doc.id}}'
+    },
+    input: {
+      kind: 'inlineDocument',
+      inline: { id: 'this document' }
+    }
+  })

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -43,6 +43,8 @@ import type {
   RemoveRemoteOptions,
   UpdateNetworkOptions,
   ShardInitialization,
+  RenderTemplateParams,
+  RenderTemplateResponse,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -744,6 +746,31 @@ export class Meilisearch {
   createSnapshot(): EnqueuedTaskPromise {
     return this.#httpRequestsWithTask.post({
       path: "snapshots",
+    });
+  }
+
+  ///
+  /// RENDER TEMPLATE
+  ///
+
+  /**
+   * Render a template by injecting the given input.
+   *
+   * This is an experimental feature. Enable the `renderRoute` experimental
+   * feature via {@link Meilisearch.updateExperimentalFeatures} before calling
+   * it.
+   *
+   * @param params - Template/fragment to render and the input to inject
+   * @returns Promise returning the unrendered template and the rendered result
+   * @experimental
+   * @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post}
+   */
+  async renderTemplate(
+    params: RenderTemplateParams,
+  ): Promise<RenderTemplateResponse> {
+    return await this.httpRequest.post<RenderTemplateResponse>({
+      path: "render-template",
+      body: params,
     });
   }
 

--- a/src/types/experimental-features.ts
+++ b/src/types/experimental-features.ts
@@ -14,4 +14,5 @@ export type RuntimeTogglableFeatures = {
   metrics?: boolean | null;
   multimodal?: boolean | null;
   network?: boolean | null;
+  renderRoute?: boolean | null;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -818,6 +818,43 @@ export type ChatSettingsPayload = {
 };
 
 /*
+ ** RENDER TEMPLATE
+ */
+
+/**
+ * Template/fragment or input to render. The `kind` field discriminates the
+ * source; the remaining fields depend on that kind.
+ *
+ * @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post}
+ */
+export type RenderTemplateSource = { kind: string } & RecordAny;
+
+/** @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post} */
+export type RenderTemplateParams = {
+  /** Template/fragment to fetch for rendering. */
+  template: RenderTemplateSource;
+  /**
+   * Input injected into the template to render the final string/JSON object. If
+   * `null` or missing, the template is not rendered.
+   */
+  input?: RenderTemplateSource | null;
+};
+
+/** @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post} */
+export type RenderTemplateResponse = {
+  /**
+   * Unrendered template or fragment, fetched in index or echoed back from the
+   * inline template in the request.
+   */
+  template: unknown;
+  /**
+   * Result of rendering the template by injecting the `input`. `null` if
+   * `input` was `null` or missing in the request.
+   */
+  rendered?: unknown;
+};
+
+/*
  ** Keys
  */
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -823,11 +823,22 @@ export type ChatSettingsPayload = {
 
 /**
  * Template/fragment or input to render. The `kind` field discriminates the
- * source; the remaining fields depend on that kind.
+ * source; the remaining fields depend on that kind (kept open via `RecordAny`
+ * since this route is experimental and its payload shape may change).
  *
  * @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post}
  */
-export type RenderTemplateSource = { kind: string } & RecordAny;
+export type RenderTemplateSource = {
+  kind:
+    | "documentTemplate"
+    | "indexDocument"
+    | "inlineDocumentTemplate"
+    | "inlineDocument"
+    | "inlineFragment"
+    | "searchFragment"
+    | "inlineSearch"
+    | "chatDocumentTemplate";
+} & RecordAny;
 
 /** @see {@link https://www.meilisearch.com/docs/reference/api/template/render-documents-with-post} */
 export type RenderTemplateParams = {

--- a/tests/experimental-features.test.ts
+++ b/tests/experimental-features.test.ts
@@ -16,6 +16,7 @@ afterAll(async () => {
     metrics: false,
     multimodal: false,
     network: false,
+    renderRoute: false,
   } satisfies { [TKey in keyof RuntimeTogglableFeatures]-?: false });
 });
 
@@ -31,6 +32,7 @@ test(`${ms.updateExperimentalFeatures.name} and ${ms.getExperimentalFeatures.nam
     metrics: true,
     multimodal: true,
     network: true,
+    renderRoute: true,
   };
 
   const updateResponse = await ms.updateExperimentalFeatures(features);

--- a/tests/render-template.test.ts
+++ b/tests/render-template.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, expect, test, describe } from "vitest";
+import {
+  ErrorStatusCode,
+  type RenderTemplateParams,
+} from "../src/types/index.js";
+import { getClient } from "./utils/meilisearch-test-utils.js";
+
+const renderTemplateParams = {
+  template: {
+    kind: "inlineDocumentTemplate",
+    inline: "An inline document template rendered on {{doc.id}}",
+  },
+  input: {
+    kind: "inlineDocument",
+    inline: { id: "this document" },
+  },
+} satisfies RenderTemplateParams;
+
+beforeAll(async () => {
+  const client = await getClient("Master");
+  await client.updateExperimentalFeatures({ renderRoute: true });
+});
+
+afterAll(async () => {
+  const client = await getClient("Master");
+  await client.updateExperimentalFeatures({ renderRoute: false });
+});
+
+describe.each([{ permission: "Master" }, { permission: "Admin" }])(
+  "Test on render template",
+  ({ permission }) => {
+    test(`${permission} key: Render an inline document template`, async () => {
+      const client = await getClient(permission);
+
+      const response = await client.renderTemplate(renderTemplateParams);
+
+      expect(response).toHaveProperty("template");
+      expect(response).toHaveProperty("rendered");
+      expect(response.rendered).toStrictEqual(
+        "An inline document template rendered on this document",
+      );
+    });
+  },
+);
+
+describe.each([
+  { permission: "Search", errorCode: ErrorStatusCode.INVALID_API_KEY },
+  { permission: "No", errorCode: ErrorStatusCode.MISSING_AUTHORIZATION_HEADER },
+])("Test on render template", ({ permission, errorCode }) => {
+  test(`${permission} key: try to render a template and be denied`, async () => {
+    const client = await getClient(permission);
+    await expect(
+      client.renderTemplate(renderTemplateParams),
+    ).rejects.toHaveProperty("cause.code", errorCode);
+  });
+});


### PR DESCRIPTION
## What

Adds SDK support for Meilisearch v1.48's experimental **render template** route (`POST /render-template`), as requested in #2195.

- `Meilisearch.renderTemplate(params)` — calls `POST /render-template`, marked `@experimental` (enable the `renderRoute` experimental feature first).
- Request/response types (`RenderTemplateParams`, `RenderTemplateResponse`, `RenderTemplateSource`).
- Adds `renderRoute` to `RuntimeTogglableFeatures` so `updateExperimentalFeatures({ renderRoute: true })` typechecks.
- Test mirroring the existing per-feature key-permission matrix, plus the exhaustive experimental-features map update.
- `.code-samples.meilisearch.yaml` entry under `post_render_template_1`, matching the docs example.

Closes #2195

## Testing

- `pnpm build` (vite + tsc) and `tsc --noEmit` — pass; `prettier -c .` — clean.
- Integration tests run against a real Meilisearch **v1.48.3** (Docker): `vitest run tests/render-template.test.ts tests/experimental-features.test.ts` → **5/5 pass** (happy path incl. the rendered-string assertion + the auth/permission matrix).

## Notes

- Response fields (`template`, `rendered`) are typed `unknown` because the API returns either a string or a JSON object depending on template kind; request `template`/`input` use the repo's existing `RecordAny` pattern (as with `RestEmbedder`) since the body is `kind`-discriminated.

## AI usage disclosure

Per the "Coding with AI" guidelines: implemented with AI assistance (Claude). I reviewed and verified it against the render-template + experimental-features API references and confirmed it against a real Meilisearch v1.48.3 instance (the integration tests above). Scope: the method, types, test, and code sample were AI-drafted and human-reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental `renderTemplate` client API to render inline document templates.
  * Introduced the `renderRoute` experimental feature flag to control access to template rendering.
* **Documentation**
  * Added a new Meilisearch documentation code sample (`post_render_template_1`) demonstrating inline template rendering.
* **Tests**
  * Expanded experimental feature flag tests to include `renderRoute`.
  * Added new coverage validating successful rendering and permission-based request denial (including expected error codes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->