### PR TITLE
Add filter condition to Dynamic Search Rules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       meilisearch:
-        image: getmeili/meilisearch-enterprise:v1.50
+        image: getmeili/meilisearch-enterprise:v1.51
         env:
           MEILI_MASTER_KEY: "masterKey"
           MEILI_NO_ANALYTICS: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.50
+    image: getmeili/meilisearch-enterprise:v1.51
     ports:
       - "7700:7700"
     environment:

--- a/src/types/search-rules.ts
+++ b/src/types/search-rules.ts
@@ -34,16 +34,24 @@ export type SearchRuleTimeCondition = {
   end?: string | null;
 };
 
+/** Filter condition for a dynamic search rule */
+export type SearchRuleFilterCondition = {
+  /** Expected facet values for filter activation */
+  values: Record<string, string>;
+};
+
 /** Conditions that must match before the dynamic search rule applies. */
 export type SearchRuleConditions = {
   query?: SearchRuleQueryCondition | null;
   time?: SearchRuleTimeCondition | null;
+  filter?: SearchRuleFilterCondition | null;
 };
 
 /** Dynamic search rule object */
 export type SearchRule = {
   uid: string;
   description?: string | null;
+  lastUpdatedAt?: string | null;
   precedence?: number | null;
   active?: boolean;
   conditions?: SearchRuleConditions;

--- a/tests/search-rules.test.ts
+++ b/tests/search-rules.test.ts
@@ -84,7 +84,11 @@ describe("dynamic search rules", () => {
     expect(response).toHaveProperty("actions", SEARCH_RULE_PATCH.actions);
     expect(response.conditions).toMatchObject(SEARCH_RULE_PATCH.conditions!);
     expect(response).toHaveProperty("lastUpdatedAt");
-    expect(Date.parse(response.lastUpdatedAt!)).not.toBeNaN();
+    expect(response.lastUpdatedAt).toBeTypeOf("string");
+    // Meilisearch date-time fields use RFC 3339 / ISO 8601 (OpenAPI format: date-time)
+    expect(response.lastUpdatedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+    );
   });
 
   it("can delete a dynamic search rule", async () => {

--- a/tests/search-rules.test.ts
+++ b/tests/search-rules.test.ts
@@ -12,6 +12,12 @@ const SEARCH_RULE_PATCH: SearchRuleUpdatePayload = {
   active: true,
   conditions: {
     query: { words: "invoice" },
+    filter: {
+      values: {
+        color: "red",
+        category: "shirt",
+      },
+    },
   },
   actions: [
     {
@@ -77,6 +83,8 @@ describe("dynamic search rules", () => {
     expect(response).toHaveProperty("precedence", SEARCH_RULE_PATCH.precedence);
     expect(response).toHaveProperty("actions", SEARCH_RULE_PATCH.actions);
     expect(response.conditions).toMatchObject(SEARCH_RULE_PATCH.conditions!);
+    expect(response).toHaveProperty("lastUpdatedAt");
+    expect(Date.parse(response.lastUpdatedAt!)).not.toBeNaN();
   });
 
   it("can delete a dynamic search rule", async () => {


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes meilisearch/meilisearch-js#2211

## What does this PR do?

* Add the new "filter" type of condition for triggering DSR
* Update target meilisearch version to v1.51

## PR checklist

Please check if your PR fulfills the following requirements:

- [X] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

## Summary by CodeRabbit

* **New Features**
  * Dynamic search rules now support an optional filter condition (e.g., filtering by attributes like color or category).
  * Search rule data can now include `lastUpdatedAt` with RFC 3339/ISO 8601 date-time formatting.
* **Maintenance**
  * Updated the Meilisearch version used by the application and integration testing environment.
* **Tests**
  * Extended search rule coverage to validate the new filter condition and `lastUpdatedAt` field.