### PR TITLE
Add JavaScript code samples for conversational search

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -670,3 +670,62 @@ post_render_template_1: |-
       inline: { id: 'this document' }
     }
   })
+get_chat_settings_1: |-
+  client.index('INDEX_NAME').getChat()
+update_chat_settings_1: |-
+  client.index('INDEX_NAME').updateChat({
+    description: 'An index of movies.',
+    documentTemplate: "A movie titled '{{doc.title}}' released in {{ doc.release_date }}",
+    documentTemplateMaxBytes: 400
+  })
+list_chat_workspaces_1: |-
+  client.getChatWorkspaces()
+post_chat_completion_1: |-
+  client.chat('WORKSPACE_NAME').streamCompletion({
+    model: 'PROVIDER_MODEL_UID',
+    messages: [
+      {
+        role: 'user',
+        content: 'USER_PROMPT'
+      }
+    ],
+    stream: true,
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: '_meiliSearchProgress',
+          description: 'Reports real-time search progress to the user'
+        }
+      },
+      {
+        type: 'function',
+        function: {
+          name: '_meiliSearchSources',
+          description: 'Provides sources and references for the information'
+        }
+      }
+    ]
+  })
+chat_get_settings_1: |-
+  client.chat('WORKSPACE_NAME').get()
+chat_patch_settings_1: |-
+  client.chat('WORKSPACE_NAME').update({ apiKey: 'your-valid-api-key' })
+chat_patch_settings_prompts_1: |-
+  client.chat('WORKSPACE_NAME').update({
+    prompts: {
+      searchDescription: 'Search the outdoor gear catalog whenever the user asks about products, prices, availability, or specifications. Do not use it for generic small talk.',
+      searchQParam: 'A short natural-language query capturing the user intent. Rewrite long questions into 3 to 8 keywords. Preserve product names and brand names verbatim.',
+      searchIndexUidParam: 'Choose between: "products" for physical gear, accessories, and apparel; "guides" for how-to articles and buying guides; "reviews" for customer reviews and ratings. Use "products" by default.'
+    }
+  })
+reset_chat_workspace_settings_1: |-
+  client.chat('WORKSPACE_NAME').reset()
+chat_create_key_1: |-
+  client.createKey({
+    name: 'Chat API Key',
+    description: 'API key for chat completions',
+    actions: ['search', 'chatCompletions'],
+    indexes: ['*'],
+    expiresAt: null
+  })


### PR DESCRIPTION
## Summary

- Add JS SDK samples to `.code-samples.meilisearch.yaml` for conversational search / chat keys that already exist in the docs CURL samples and map to existing meilisearch-js APIs.
- Keys added: `get_chat_settings_1`, `update_chat_settings_1`, `list_chat_workspaces_1`, `post_chat_completion_1`, `chat_get_settings_1`, `chat_patch_settings_1`, `chat_patch_settings_prompts_1`, `reset_chat_workspace_settings_1`, `chat_create_key_1`.
- Skipped (no SDK method yet): `get_chat_workspace_1`, `delete_chat_workspace_1`, `reset_chat_settings_1`. Skipped (missing from docs YAML): `update_experimental_features_chat_1`.

## Test plan

- [ ] Confirm new key names match `meilisearch/documentation` `.code-samples.meilisearch.yaml` exactly
- [ ] After docs regenerate snippets, verify JS tabs appear for conversational search pages that import these CodeSamples
- [ ] Spot-check payloads against CURL (placeholders and field values)

## Documentation follow-up (for maintainers / agents)

Run these steps in `meilisearch/documentation` (and a follow-up meilisearch-js PR if needed). Treat this as an agent task brief.

### 1. Fix missing `update_experimental_features_chat_1`

`capabilities/conversational_search/getting_started/setup.mdx` imports `CodeSamplesUpdateExperimentalFeaturesChat1` / `code_samples_update_experimental_features_chat_1.mdx`, but that key is **not** in docs `.code-samples.meilisearch.yaml` and the generated snippet is missing.

1. Add to docs `.code-samples.meilisearch.yaml`:

```yaml
update_experimental_features_chat_1: |-
  curl \
    -X PATCH 'MEILISEARCH_URL/experimental-features/' \
    -H 'Content-Type: application/json' \
    --data-binary '{
      "chatCompletions": true
    }'
```

2. Regenerate / ensure the snippet is produced.
3. In meilisearch-js `.code-samples.meilisearch.yaml`, add the matching sample (only after the docs key exists, or CI `unused-sdk-samples` fails):

```yaml
update_experimental_features_chat_1: |-
  client.updateExperimentalFeatures({ chatCompletions: true })
```

### 2. Convert inline CURL-only CodeGroups to CodeSamples

Many conversational search pages still use inline `<CodeGroup>` with only bash. Those do **not** pick up SDK YAML. Convert where payloads match existing keys (or add new docs YAML keys if payloads differ):

- `getting_started/setup.mdx` and `how_to/configure_index_chat_settings.mdx` → prefer `update_chat_settings_1` / `get_chat_settings_1` (and reset key only if/when SDKs expose `resetChat`).
- `how_to/configure_chat_workspace.mdx` create/update examples → prefer `chat_patch_settings_1` / OpenAI-shaped workspace update keys.

**Multi-provider tabs (OpenAI / Azure / Mistral / vLLM):** only wire or author the **OpenAI** example for SDK languages. Leave other providers as CURL-only, or omit SDK tabs for them.

### 3. Do not request SDK samples for missing methods

Until meilisearch-js (and peers) implement them, do **not** expect SDK samples for:

- `get_chat_workspace_1` (`GET /chats/{uid}`)
- `delete_chat_workspace_1` (`DELETE /chats/{uid}`)
- `reset_chat_settings_1` (index chat settings reset)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Meilisearch Chat API examples for retrieving and updating chat settings.
  * Documented workspace listing and management operations.
  * Added examples for streaming chat completions with search tools and prompt configuration.
  * Included an example for creating a Chat API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->