### PR TITLE
Add index size fields to stats responses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       meilisearch:
-        image: getmeili/meilisearch-enterprise:v1.51
+        image: getmeili/meilisearch-enterprise:v1.53
         env:
           MEILI_MASTER_KEY: "masterKey"
           MEILI_NO_ANALYTICS: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.51
+    image: getmeili/meilisearch-enterprise:v1.53
     ports:
       - "7700:7700"
     environment:

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -763,6 +763,8 @@ export type Health = {
 
 export type IndexStats = {
   numberOfDocuments: number;
+  indexSize: number;
+  usedIndexSize: number;
   isIndexing: boolean;
   fieldDistribution: FieldDistribution;
   numberOfEmbeddedDocuments: number;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -638,11 +638,17 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
 
       test(`${permission} key: get /stats information`, async () => {
         const client = await getClient(permission);
+        await client.createIndex(indexNoPk.uid).waitTask();
+
         const response: Stats = await client.getStats();
+        const indexStats = response.indexes[indexNoPk.uid];
+
         expect(response).toHaveProperty("databaseSize", expect.any(Number));
         expect(response).toHaveProperty("usedDatabaseSize", expect.any(Number));
         expect(response).toHaveProperty("lastUpdate");
         expect(response).toHaveProperty("indexes", expect.any(Object));
+        expect(indexStats).toHaveProperty("indexSize", expect.any(Number));
+        expect(indexStats).toHaveProperty("usedIndexSize", expect.any(Number));
       });
     });
   },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -365,6 +365,8 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       const response = await client.index(indexNoPk.uid).getStats();
 
       expect(response).toHaveProperty("numberOfDocuments", 0);
+      expect(response).toHaveProperty("indexSize", expect.any(Number));
+      expect(response).toHaveProperty("usedIndexSize", expect.any(Number));
       expect(response).toHaveProperty("isIndexing", false);
       expect(response).toHaveProperty("fieldDistribution", {});
       expect(response).toHaveProperty("numberOfEmbeddedDocuments", 0);


### PR DESCRIPTION
## What changed

- add `indexSize` and `usedIndexSize` to the `IndexStats` response type introduced by Meilisearch v1.53.0
- cover both `GET /indexes/{index_uid}/stats` and the per-index entries returned by `GET /stats`
- run local and CI integration tests against Meilisearch v1.53

Closes #2220

## Test plan

- `corepack pnpm exec prettier -c .github/workflows/tests.yml docker-compose.yml src/types/types.ts tests/client.test.ts tests/index.test.ts`
- `corepack pnpm lint` (0 errors; 2 pre-existing warnings)
- `corepack pnpm types`
- `corepack pnpm build`
- `corepack pnpm test tests/index.test.ts tests/client.test.ts` against Meilisearch v1.53.0 (224 tests passed)

## AI assistance

OpenAI Codex was used to inspect the existing stats implementation, edit the types, tests, and Meilisearch test version, and run the validation commands. I reviewed the resulting diff and test results before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Index statistics now include `indexSize` and `usedIndexSize` values.

* **Bug Fixes**
  * Improved stats retrieval so per-index usage details are returned consistently.

* **Tests**
  * Updated test coverage to verify the new statistics fields.
  * Refreshed integration test environments to use a newer service version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->