### PR TITLE
feat: add indexSize and usedIndexSize to IndexStats (closes #2220)

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -769,6 +769,13 @@ export type IndexStats = {
   numberOfEmbeddings: number;
   rawDocumentDbSize: number;
   avgDocumentSize: number;
+  /** Size of the index database, in bytes. Added in Meilisearch v1.53.0. */
+  indexSize: number;
+  /**
+   * Size of the used pages of the index database, in bytes. Added in
+   * Meilisearch v1.53.0.
+   */
+  usedIndexSize: number;
 };
 
 export type Stats = {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -371,6 +371,8 @@ describe.each([{ permission: "Master" }, { permission: "Admin" }])(
       expect(response).toHaveProperty("numberOfEmbeddings", 0);
       expect(response).toHaveProperty("rawDocumentDbSize", 0);
       expect(response).toHaveProperty("avgDocumentSize", 0);
+      expect(response).toHaveProperty("indexSize", 0);
+      expect(response).toHaveProperty("usedIndexSize", 0);
     });
 
     test(`${permission} key: Get updatedAt and createdAt through fetch info`, async () => {


### PR DESCRIPTION
## What

Closes #2220.

[Meilisearch v1.53.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.53.0) adds `indexSize` and `usedIndexSize` to per-index stats — returned by [Get stats of an index](https://www.meilisearch.com/docs/reference/api/indexes/get-stats-of-index) and per index in [Get stats of all indexes](https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes). This adds them to the SDK's `IndexStats` response shape.

## Changes

- Add `indexSize` and `usedIndexSize` (both `number`, bytes) to the `IndexStats` type in `src/types/types.ts`.
- Extend the `getStats` test in `tests/index.test.ts` to assert the two new properties.

`Index.getStats()` returns the typed HTTP response directly, so no response-mapping change is needed beyond the type shape.

## Validation

- `pnpm types` (`tsc --noEmit`) → passes
- `pnpm lint` (`oxlint --type-aware`) → 0 errors on changed files
- The integration test assertions mirror the existing `getStats` property checks; the suite itself requires a running Meilisearch instance, so I did not run it locally.

First-time contributor here — happy to adjust naming or scope to match your conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added index statistics for total index size and used index size, reported in bytes.

* **Tests**
  * Added coverage verifying both size values are zero for a newly created empty index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->