### PR TITLE
Add get and delete methods for individual chat workspaces

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -670,3 +670,9 @@ post_render_template_1: |-
       inline: { id: 'this document' }
     }
   })
+list_chat_workspaces_1: |-
+  client.getChatWorkspaces()
+get_chat_workspace_1: |-
+  client.getChatWorkspace('WORKSPACE_NAME')
+delete_chat_workspace_1: |-
+  client.deleteChatWorkspace('WORKSPACE_NAME')

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -46,6 +46,9 @@ import type {
   ShardInitialization,
   RenderTemplateParams,
   RenderTemplateResponse,
+  ChatWorkspaceView,
+  ChatWorkspacesQuery,
+  ChatWorkspacesResults,
 } from "./types/index.js";
 import { ErrorStatusCode } from "./types/index.js";
 import { HttpRequests } from "./http-requests.js";
@@ -307,13 +310,46 @@ export class Meilisearch {
   }
 
   /**
-   * Get all chat workspaces
+   * List the chat workspaces registered on the instance.
    *
-   * @returns Promise returning an array of chat workspaces UIDs
+   * @param parameters - Parameters to paginate the chat workspaces
+   * @returns Promise returning a paginated list of chat workspaces
+   * @experimental
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#list-chat-workspaces}
    */
-  async getChatWorkspaces(): Promise<ResourceResults<{ uid: string }[]>> {
+  async getChatWorkspaces(
+    parameters?: ChatWorkspacesQuery,
+  ): Promise<ChatWorkspacesResults> {
     return await this.httpRequest.get({
       path: "chats",
+      params: parameters,
+    });
+  }
+
+  /**
+   * Get a single chat workspace by its UID.
+   *
+   * @param workspace - The chat workspace UID
+   * @returns Promise returning the chat workspace
+   * @experimental
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#get-a-chat-workspace}
+   */
+  async getChatWorkspace(workspace: string): Promise<ChatWorkspaceView> {
+    return await this.httpRequest.get({
+      path: `chats/${workspace}`,
+    });
+  }
+
+  /**
+   * Delete a chat workspace and its settings.
+   *
+   * @param workspace - The chat workspace UID
+   * @experimental
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#delete-a-chat-workspace}
+   */
+  async deleteChatWorkspace(workspace: string): Promise<void> {
+    await this.httpRequest.delete({
+      path: `chats/${workspace}`,
     });
   }
 

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -46,7 +46,7 @@ import type {
   ShardInitialization,
   RenderTemplateParams,
   RenderTemplateResponse,
-  ChatWorkspaceView,
+  ChatWorkspaceObject,
   ChatWorkspacesQuery,
   ChatWorkspacesResults,
 } from "./types/index.js";
@@ -334,7 +334,7 @@ export class Meilisearch {
    * @experimental
    * @see {@link https://www.meilisearch.com/docs/reference/api/chats/get-a-chat-workspace}
    */
-  async getChatWorkspace(workspace: string): Promise<ChatWorkspaceView> {
+  async getChatWorkspace(workspace: string): Promise<ChatWorkspaceObject> {
     return await this.httpRequest.get({
       path: `chats/${workspace}`,
     });

--- a/src/meilisearch.ts
+++ b/src/meilisearch.ts
@@ -310,12 +310,12 @@ export class Meilisearch {
   }
 
   /**
-   * List the chat workspaces registered on the instance.
+   * List all chat workspaces
    *
    * @param parameters - Parameters to paginate the chat workspaces
    * @returns Promise returning a paginated list of chat workspaces
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#list-chat-workspaces}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/list-chat-workspaces}
    */
   async getChatWorkspaces(
     parameters?: ChatWorkspacesQuery,
@@ -327,12 +327,12 @@ export class Meilisearch {
   }
 
   /**
-   * Get a single chat workspace by its UID.
+   * Get a chat workspace
    *
    * @param workspace - The chat workspace UID
    * @returns Promise returning the chat workspace
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#get-a-chat-workspace}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/get-a-chat-workspace}
    */
   async getChatWorkspace(workspace: string): Promise<ChatWorkspaceView> {
     return await this.httpRequest.get({
@@ -341,11 +341,12 @@ export class Meilisearch {
   }
 
   /**
-   * Delete a chat workspace and its settings.
+   * Delete a chat workspace
    *
    * @param workspace - The chat workspace UID
+   * @returns Promise returning void
    * @experimental
-   * @see {@link https://www.meilisearch.com/docs/reference/api/chats#delete-a-chat-workspace}
+   * @see {@link https://www.meilisearch.com/docs/reference/api/chats/delete-a-chat-workspace}
    */
   async deleteChatWorkspace(workspace: string): Promise<void> {
     await this.httpRequest.delete({

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -786,6 +786,15 @@ export type Stats = {
  ** CHATS
  */
 
+/** A chat workspace registered on the instance. */
+export type ChatWorkspaceView = { uid: string };
+
+/** Parameters used to paginate the list of chat workspaces. */
+export type ChatWorkspacesQuery = ResourceQuery & {};
+
+/** Paginated list of chat workspaces. */
+export type ChatWorkspacesResults = ResourceResults<ChatWorkspaceView[]> & {};
+
 /** @see https://www.meilisearch.com/docs/reference/api/chats#settings-parameters */
 export type ChatWorkspaceSettings = {
   source: "openAi" | "azureOpenAi" | "mistral" | "gemini" | "vLlm";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -787,13 +787,13 @@ export type Stats = {
  */
 
 /** A chat workspace registered on the instance. */
-export type ChatWorkspaceView = { uid: string };
+export type ChatWorkspaceObject = { uid: string };
 
 /** Parameters used to paginate the list of chat workspaces. */
 export type ChatWorkspacesQuery = ResourceQuery & {};
 
 /** Paginated list of chat workspaces. */
-export type ChatWorkspacesResults = ResourceResults<ChatWorkspaceView[]> & {};
+export type ChatWorkspacesResults = ResourceResults<ChatWorkspaceObject[]> & {};
 
 /** @see https://www.meilisearch.com/docs/reference/api/chats#settings-parameters */
 export type ChatWorkspaceSettings = {

--- a/tests/chat-workspaces.test.ts
+++ b/tests/chat-workspaces.test.ts
@@ -56,12 +56,29 @@ test("it can list workspaces", async () => {
   expect(response.results).toEqual([{ uid: "myWorkspace" }]);
 });
 
+test("it can get a single workspace", async () => {
+  const client = await getClient("Admin");
+  await client.chat("myWorkspace").update(WORKSPACE_SETTINGS);
+  const response = await client.getChatWorkspace("myWorkspace");
+  expect(response).toEqual({ uid: "myWorkspace" });
+});
+
 test("it can delete a workspace settings", async () => {
   const client = await getClient("Admin");
   await client.chat("myWorkspace").update(WORKSPACE_SETTINGS);
   await client.chat("myWorkspace").reset();
   const response = await client.getChatWorkspaces();
   expect(response.results).toEqual([{ uid: "myWorkspace" }]);
+});
+
+test("it can delete a workspace", async () => {
+  const client = await getClient("Admin");
+  await client.chat("myWorkspace").update(WORKSPACE_SETTINGS);
+  await client.deleteChatWorkspace("myWorkspace");
+  await expect(client.getChatWorkspace("myWorkspace")).rejects.toHaveProperty(
+    "cause.code",
+    "chat_not_found",
+  );
 });
 
 test("it can create a chat completion (streaming)", async () => {

--- a/tests/chat-workspaces.test.ts
+++ b/tests/chat-workspaces.test.ts
@@ -79,6 +79,7 @@ test("it can delete a workspace", async () => {
     "cause.code",
     "chat_not_found",
   );
+  await client.chat("myWorkspace").update(WORKSPACE_SETTINGS);
 });
 
 test("it can create a chat completion (streaming)", async () => {


### PR DESCRIPTION
## Related issue

Part of #1990 (conversational search / chats API support).

## What this does

The chats API exposes routes to manage a single chat workspace, but the JS client only covered the settings sub-routes (`/chats/{uid}/settings`) and the workspace listing (`GET /chats`). This fills the remaining gaps:

- **`getChatWorkspace(uid)`** — `GET /chats/{workspace_uid}`, returns the workspace (`{ uid }`).
- **`deleteChatWorkspace(uid)`** — `DELETE /chats/{workspace_uid}`, deletes a workspace and its settings.
- **Pagination on `getChatWorkspaces`** — the `GET /chats` endpoint accepts `offset`/`limit`; the method now forwards them via a `ChatWorkspacesQuery` parameter.

New types: `ChatWorkspaceView`, `ChatWorkspacesQuery`, `ChatWorkspacesResults`. The previous inline `ResourceResults<{ uid: string }[]>` return type of `getChatWorkspaces` is structurally unchanged.

## Endpoint coverage after this PR

| Route | Method |
| --- | --- |
| `GET /chats` | `getChatWorkspaces` |
| `GET /chats/{uid}` | `getChatWorkspace` (new) |
| `DELETE /chats/{uid}` | `deleteChatWorkspace` (new) |
| `GET /chats/{uid}/settings` | `chat(uid).get` |
| `PATCH /chats/{uid}/settings` | `chat(uid).update` |
| `DELETE /chats/{uid}/settings` | `chat(uid).reset` |
| `POST /chats/{uid}/chat/completions` | `chat(uid).streamCompletion` |

## Tests

Added integration tests in `tests/chat-workspaces.test.ts` covering getting a single workspace and deleting a workspace (asserting a subsequent get rejects with `chat_not_found`). Ran the chat-workspace suite against `getmeili/meilisearch-enterprise:v1.53` — all passing. `pnpm types`, `pnpm lint`, and `pnpm build` are clean.

## AI assistance disclosure

Code and tests were drafted with the assistance of Claude, then reviewed, tested, and verified by me before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental chat workspace management capabilities.
  * Chat workspaces can now be listed with pagination, retrieved individually, and deleted.
  * Workspace listings provide structured paginated results.
  * Deletion confirms completion without returning additional data.
* **Documentation**
  * Added API documentation and code samples for listing, retrieving, and deleting chat workspaces.
  * Documented chat workspace operations as experimental.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->