### PR TITLE
Test request timeout abort deterministically with a mocked fetch

### DIFF
--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,6 +1,9 @@
 import { test, describe, beforeEach, vi } from "vitest";
 import { Meilisearch, assert } from "./utils/meilisearch-test-utils.js";
-import { MeilisearchRequestError } from "../src/index.js";
+import {
+  MeilisearchRequestError,
+  MeilisearchRequestTimeOutError,
+} from "../src/index.js";
 
 const mockedFetch = vi.fn();
 globalThis.fetch = mockedFetch;
@@ -15,5 +18,44 @@ describe("Test on updates", () => {
 
     const client = new Meilisearch({ host: "http://localhost:9345" });
     await assert.rejects(client.health(), MeilisearchRequestError);
+  });
+
+  test(`Throw MeilisearchRequestTimeOutError when request exceeds the timeout`, async () => {
+    // A `fetch` that never resolves on its own and only settles once its abort
+    // signal fires, mirroring how the real `fetch` reacts to an aborted signal.
+    // This removes the event-loop timing race of testing against a real server,
+    // so the timeout path is exercised deterministically.
+    mockedFetch.mockImplementation(
+      (_input: unknown, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const { signal } = init ?? {};
+          if (signal == null) {
+            return;
+          }
+
+          signal.addEventListener(
+            "abort",
+            // The real `fetch` rejects with the signal's abort reason, which is
+            // the internal timeout marker the SDK checks for; forward it as-is.
+            // oxlint-disable-next-line prefer-promise-reject-errors
+            () => reject(signal.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    const timeout = 1;
+    const client = new Meilisearch({
+      host: "http://localhost:9345",
+      timeout,
+    });
+
+    const error = await assert.rejects(
+      client.health(),
+      MeilisearchRequestError,
+    );
+
+    assert.instanceOf(error.cause, MeilisearchRequestTimeOutError);
+    assert.strictEqual(error.cause.cause.timeout, timeout);
   });
 });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1504,24 +1504,10 @@ describe.each([
     expect(c).toHaveProperty("value.query", searchQuery);
   });
 
-  test(`${permission} key: search should be aborted when reaching timeout`, async () => {
-    const key = await getKey(permission);
-    const client = new Meilisearch({
-      ...config,
-      apiKey: key,
-      timeout: 1,
-    });
-
-    const error = await assert.rejects(
-      client.health(),
-      MeilisearchRequestError,
-    );
-
-    assert.strictEqual(
-      (error.cause as Error)?.message,
-      "request timed out after 1ms",
-    );
-  });
+  // The timeout-based abort is covered deterministically with a mocked `fetch`
+  // in `tests/errors.test.ts`. Asserting it against a real server here raced the
+  // event loop (`fetch` could resolve before the 1ms timeout aborted) and made
+  // the test flaky. See https://github.com/meilisearch/meilisearch-js/issues/1922.
 
   test(`${permission} key: search should be aborted on abort signal`, async () => {
     const key = await getKey(permission);

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1504,7 +1504,6 @@ describe.each([
     expect(c).toHaveProperty("value.query", searchQuery);
   });
 
-
   test(`${permission} key: search should be aborted on abort signal`, async () => {
     const key = await getKey(permission);
     const client = new Meilisearch({

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1504,10 +1504,6 @@ describe.each([
     expect(c).toHaveProperty("value.query", searchQuery);
   });
 
-  // The timeout-based abort is covered deterministically with a mocked `fetch`
-  // in `tests/errors.test.ts`. Asserting it against a real server here raced the
-  // event loop (`fetch` could resolve before the 1ms timeout aborted) and made
-  // the test flaky. See https://github.com/meilisearch/meilisearch-js/issues/1922.
 
   test(`${permission} key: search should be aborted on abort signal`, async () => {
     const key = await getKey(permission);


### PR DESCRIPTION
## Related issue

Closes #1922.

## Problem

The `search should be aborted when reaching timeout` test in `tests/search.test.ts` ran against a real server with `timeout: 1` (ms). `fetch` could resolve before the abort signal fired — `setTimeout` does not guarantee tight timing under a busy event loop — so the request sometimes completed before the timeout, and the test failed intermittently in CI (see the run linked in the issue).

As suggested by @flevi29 in the issue, the reliable way to test this is to mock `fetch` so the abort is guaranteed to win.

## What this does

- Removes the flaky real-server timeout test from `tests/search.test.ts` (it also tested `client.health()`, not search) and leaves a short comment pointing to its replacement.
- Adds a test in `tests/errors.test.ts` that mocks `fetch` with a promise which only settles when its abort signal fires, mirroring the real `fetch` abort behaviour. The 1ms timeout therefore always wins, exercising the timeout path deterministically.
- Asserts the rejection is a `MeilisearchRequestError` caused by a `MeilisearchRequestTimeOutError` carrying the configured timeout.

The new test needs no running Meilisearch instance.

## Testing

- `pnpm test tests/errors.test.ts` — passing.
- `pnpm types`, `pnpm lint`, `pnpm build` — clean.

## AI assistance disclosure

The test and this description were drafted with the assistance of Claude, then reviewed and verified by me before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added deterministic coverage for health-request timeouts, including verification of the returned timeout error and configured timeout value.
  - Removed a server-dependent search timeout test to improve test reliability.
  - Retained coverage for abort-signal behavior and request cancellation.
  - No changes were made to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->