### PR TITLE
Fix crash on non-JSON error response body

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -73,6 +73,21 @@ function getHeaders(config: Config, headersInit?: HeadersInit): Headers {
 const TIMEOUT_ID = Symbol("<timeout>");
 
 /**
+ * Parses a response body as JSON, returning `undefined` when the body is empty
+ * or is not valid JSON (e.g. an HTML error page from a proxy).
+ */
+function parseResponseBody<T>(responseBody: string): T | undefined {
+  if (responseBody === "") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(responseBody) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Attach a timeout signal to a {@link RequestInit}, while preserving original
  * signal functionality, if there is one.
  *
@@ -258,10 +273,9 @@ export class HttpRequests {
       stopTimeout?.();
     }
 
-    const parsedResponse =
-      responseBody === ""
-        ? undefined
-        : (JSON.parse(responseBody) as T | MeilisearchErrorResponse);
+    const parsedResponse = parseResponseBody<T | MeilisearchErrorResponse>(
+      responseBody,
+    );
 
     if (!response.ok) {
       throw new MeilisearchApiError(
@@ -353,9 +367,7 @@ export class HttpRequests {
       // For error responses, we still need to read the body to get error details
       const responseBody = await response.text();
       const parsedResponse =
-        responseBody === ""
-          ? undefined
-          : (JSON.parse(responseBody) as MeilisearchErrorResponse);
+        parseResponseBody<MeilisearchErrorResponse>(responseBody);
 
       throw new MeilisearchApiError(response, parsedResponse);
     }

--- a/tests/http-requests.test.ts
+++ b/tests/http-requests.test.ts
@@ -87,6 +87,60 @@ describe("HttpRequests", () => {
     ).rejects.toThrow(MeilisearchApiError);
   });
 
+  test("should throw MeilisearchApiError for error response with HTML body", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("<html><body>502 Bad Gateway</body></html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    const config: Config = { host: "http://localhost:7700" };
+    const httpRequests = new HttpRequests(config);
+
+    const error = await httpRequests
+      .get({ path: "indexes" })
+      .catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(MeilisearchApiError);
+    expect((error as MeilisearchApiError).message).toBe("502: Bad Gateway");
+    expect((error as MeilisearchApiError).cause).toBeUndefined();
+  });
+
+  test("should throw MeilisearchApiError for error response with plain text body", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Service Unavailable", {
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    const config: Config = { host: "http://localhost:7700" };
+    const httpRequests = new HttpRequests(config);
+
+    await expect(httpRequests.get({ path: "indexes" })).rejects.toThrow(
+      MeilisearchApiError,
+    );
+  });
+
+  test("should throw MeilisearchApiError for stream error response with HTML body", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("<html><body>502 Bad Gateway</body></html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    const config: Config = { host: "http://localhost:7700" };
+    const httpRequests = new HttpRequests(config);
+
+    await expect(
+      httpRequests.postStream({ path: "chat", body: {} }),
+    ).rejects.toThrow(MeilisearchApiError);
+  });
+
   test("should handle null response body for stream", async () => {
     fetchSpy.mockResolvedValue(
       new Response(null, {


### PR DESCRIPTION
When the server (or a proxy in front of it) returns a non-JSON error body — e.g. an nginx `502 Bad Gateway` HTML page — the client threw a raw `SyntaxError: Unexpected token '<'...` instead of a `MeilisearchApiError`, so callers couldn't handle it as a normal API error.

This parses the body defensively (falling back to `undefined`, like the empty-body case already did) so error responses always surface as `MeilisearchApiError` with the HTTP status. Same symptom as #1892.

## Testing

- 2 new tests (HTML body, plain-text body): `vitest run tests/http-requests.test.ts` — 8 passed.
- `tsc --noEmit`, `oxlint`, and `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Error responses containing HTML, plain text, or other invalid JSON now consistently return an API error.
  - Streaming requests now handle invalid error-response bodies consistently.
  - Successful responses with invalid JSON now surface the JSON parsing error directly.
  - Error details are omitted when an error response cannot be parsed as JSON.

- **Tests**
  - Added coverage for standard and streaming requests receiving non-JSON error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->