### PR TITLE
Fix per-request `extraRequestInit` being overridden by client defaults

### DIFF
--- a/src/http-requests.ts
+++ b/src/http-requests.ts
@@ -213,8 +213,8 @@ export class HttpRequests {
         contentType === undefined || typeof body !== "string"
           ? JSON.stringify(body)
           : body,
-      ...extraRequestInit,
       ...this.#requestInit,
+      ...extraRequestInit,
       headers: this.#getHeaders(extraRequestInit?.headers, contentType),
     };
 

--- a/tests/http-requests.test.ts
+++ b/tests/http-requests.test.ts
@@ -1,5 +1,6 @@
 import {
   afterAll,
+  assert,
   beforeEach,
   describe,
   expect,
@@ -106,5 +107,50 @@ describe("HttpRequests", () => {
     ).rejects.toThrow(
       "Response body is null - server did not return a readable stream",
     );
+  });
+
+  test("should let per-request extraRequestInit override client requestInit", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ status: "available" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const config: Config = {
+      host: "http://localhost:7700",
+      requestInit: { credentials: "omit" },
+    };
+    const httpRequests = new HttpRequests(config);
+
+    await httpRequests.get({
+      path: "health",
+      extraRequestInit: { credentials: "include" },
+    });
+
+    assert.isDefined(fetchSpy.mock.lastCall);
+    const [, init] = fetchSpy.mock.lastCall as [URL, RequestInit];
+    expect(init.credentials).toBe("include");
+  });
+
+  test("should apply client requestInit as default without per-request override", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ status: "available" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const config: Config = {
+      host: "http://localhost:7700",
+      requestInit: { credentials: "omit" },
+    };
+    const httpRequests = new HttpRequests(config);
+
+    await httpRequests.get({ path: "health" });
+
+    assert.isDefined(fetchSpy.mock.lastCall);
+    const [, init] = fetchSpy.mock.lastCall as [URL, RequestInit];
+    expect(init.credentials).toBe("omit");
   });
 });


### PR DESCRIPTION
Per-request `extraRequestInit` was spread *before* the client-wide `requestInit`, so client defaults silently overrode every per-request option — e.g. a request passing `credentials: "include"` (or its own abort `signal`) still went out with the client's values.

Per-request options must win over client defaults (headers already worked this way via `#getHeaders`). This swaps the two-line spread order so `extraRequestInit` takes precedence.

## Testing

- 2 new tests (per-request override applies; client default kept when no override): verified red on main code, green after. `tests/http-requests.test.ts` — 7 passed.
- `tsc --noEmit`, `oxlint`, and `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Per-request options now correctly override shared request settings when making HTTP requests.
  - Shared request settings continue to apply when no per-request override is provided.

- **Tests**
  - Added coverage for request option precedence and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->