### PR TITLE
Add missing network/sharding error codes to `ErrorStatusCode`

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1297,6 +1297,58 @@ export const ErrorStatusCode = {
   /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_similar_ranking_score_threshold */
   INVALID_SIMILAR_RANKING_SCORE_THRESHOLD:
     "invalid_similar_ranking_score_threshold",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#not_leader */
+  NOT_LEADER: "not_leader",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_leader */
+  INVALID_NETWORK_LEADER: "invalid_network_leader",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_remotes */
+  INVALID_NETWORK_REMOTES: "invalid_network_remotes",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_search_api_key */
+  INVALID_NETWORK_SEARCH_API_KEY: "invalid_network_search_api_key",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_self */
+  INVALID_NETWORK_SELF: "invalid_network_self",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_shards */
+  INVALID_NETWORK_SHARDS: "invalid_network_shards",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_url */
+  INVALID_NETWORK_URL: "invalid_network_url",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#invalid_network_write_api_key */
+  INVALID_NETWORK_WRITE_API_KEY: "invalid_network_write_api_key",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#network_version_mismatch */
+  NETWORK_VERSION_MISMATCH: "network_version_mismatch",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#network_version_too_old */
+  NETWORK_VERSION_TOO_OLD: "network_version_too_old",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#unknown_remote */
+  UNKNOWN_REMOTE: "unknown_remote",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#unprocessed_network_task */
+  UNPROCESSED_NETWORK_TASK: "unprocessed_network_task",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#unexpected_network_previous_remotes */
+  UNEXPECTED_NETWORK_PREVIOUS_REMOTES: "unexpected_network_previous_remotes",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#import_task_already_received */
+  IMPORT_TASK_ALREADY_RECEIVED: "import_task_already_received",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#import_task_unknown_remote */
+  IMPORT_TASK_UNKNOWN_REMOTE: "import_task_unknown_remote",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#import_task_without_network_task */
+  IMPORT_TASK_WITHOUT_NETWORK_TASK: "import_task_without_network_task",
+
+  /** @see https://www.meilisearch.com/docs/reference/errors/error_codes#receive_import_finished_unknown_remote */
+  RECEIVE_IMPORT_FINISHED_UNKNOWN_REMOTE:
+    "receive_import_finished_unknown_remote",
 };
 
 export type ErrorStatusCode =


### PR DESCRIPTION
Closes #2093

## Context

#2093 asks for the SDK to adopt the v1.30 sharding/network changes (leader-based cluster model). Looking at `src/types/network.ts`, the actual data model (`self`/`remotes`/`leader`/`shards` on `Network`, `InitializeNetworkOptions`, `ShardUpdate`, etc.) is already up to date — there's no leftover `sharding: true` flag or anything like that.

What's still missing is the error codes that come with this feature. None of the network/sharding-related codes documented on the [error codes reference page](https://www.meilisearch.com/docs/reference/errors/error_codes) exist in `ErrorStatusCode`, including `not_leader`, which is exactly the error mentioned in the issue for leader-only write operations on a non-leader node.

## Change

Added all 17 network/sharding-related error codes to `ErrorStatusCode` in `src/types/types.ts`, each with a `@see` link to its entry on the reference page, following the file's existing pattern:

- `not_leader`
- `invalid_network_leader`, `invalid_network_remotes`, `invalid_network_search_api_key`, `invalid_network_self`, `invalid_network_shards`, `invalid_network_url`, `invalid_network_write_api_key`
- `network_version_mismatch`, `network_version_too_old`
- `unknown_remote`, `unprocessed_network_task`, `unexpected_network_previous_remotes`
- `import_task_already_received`, `import_task_unknown_remote`, `import_task_without_network_task`
- `receive_import_finished_unknown_remote`

Purely additive (new constants only), no existing behavior touched. There's no dedicated test file for `ErrorStatusCode` completeness (the other ~150 entries aren't individually tested either), so I didn't add one for these specifically — happy to add coverage if you'd rather have it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for additional error status codes covering network configuration, version compatibility, remote validation, and import-task processing.
  - Expanded the available error status type to represent these conditions consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->